### PR TITLE
Cosmetic Command Lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -24,6 +24,27 @@
       - id: BoxEncryptionKeyCargo
 
 - type: entity
+  id: LockerQuarterMasterFilledCosmetic
+  suffix: Cosmetic
+  parent: LockerQuarterMaster
+  components:
+  - type: StorageFill
+    contents:
+      - id: CigPackGreen
+        prob: 0.50
+      - id: ClothingHandsGlovesColorBrown
+      - id: ClothingHeadHatQMsoft
+      - id: ClothingHeadHatQMsoftFlipped
+      - id: ClothingHeadsetAltCargo
+      - id: ClothingNeckCloakQm
+      - id: ClothingNeckMantleQM
+      - id: ClothingOuterWinterQM
+      - id: ClothingUniformJumpskirtQM
+      - id: ClothingUniformJumpskirtQMTurtleneck
+      - id: ClothingUniformJumpsuitQM
+      - id: ClothingUniformJumpsuitQMTurtleneck
+
+- type: entity
   id: LockerCaptainFilledHardsuit
   suffix: Filled, Hardsuit
   parent: LockerCaptain
@@ -92,6 +113,29 @@
       - id: ClothingHeadHatCapcap
 
 - type: entity
+  id: LockerCaptainFilledCosmetic
+  suffix: Cosmetic
+  parent: LockerCaptain
+  components:
+  - type: StorageFill
+    contents:
+      - id: CigarGoldCase
+        prob: 0.25
+      - id: ClothingHeadHatCapcap
+      - id: ClothingHeadHatCaptain
+      - id: ClothingHeadsetAltCommand
+      - id: ClothingNeckCloakCap
+      - id: ClothingNeckCloakCapFormal
+      - id: ClothingNeckMantleCap
+      - id: ClothingOuterWinterCap
+      - id: ClothingUniformJumpskirtCapFormalDress
+      - id: ClothingUniformJumpskirtCaptain
+      - id: ClothingUniformJumpsuitCapFormal
+      - id: ClothingUniformJumpsuitCaptain
+      - id: PlushieNuke
+        prob: 0.1
+
+- type: entity
   id: LockerHeadOfPersonnelFilled
   suffix: Filled
   parent: LockerHeadOfPersonnel
@@ -120,6 +164,25 @@
       - id: ClothingBackpackIan
         prob: 0.5
       - id: AccessConfigurator
+
+- type: entity
+  id: LockerHeadOfPersonnelFilledCosmetic
+  suffix: Cosmetic
+  parent: LockerHeadOfPersonnel
+  components:
+  - type: StorageFill
+    contents:
+      - id: CigarGoldCase
+        prob: 0.25
+      - id: ClothingBackpackIan
+        prob: 0.5
+      - id: ClothingHeadHatHopcap
+      - id: ClothingHeadsetCommand
+      - id: ClothingNeckCloakHop
+      - id: ClothingNeckMantleHOP
+      - id: ClothingOuterWinterHoP
+      - id: ClothingUniformJumpskirtHoP
+      - id: ClothingUniformJumpsuitHoP
 
 - type: entity
   id: LockerChiefEngineerFilledHardsuit
@@ -172,6 +235,27 @@
       - id: AccessConfigurator
 
 - type: entity
+  id: LockerChiefEngineerFilledCosmetic
+  suffix: Cosmetic
+  parent: LockerChiefEngineer
+  components:
+  - type: StorageFill
+    contents:
+      - id: CigarCase
+        prob: 0.15
+      - id: ClothingEyesGlassesMeson
+      - id: ClothingHandsGlovesColorYellow
+      - id: ClothingHeadHatBeretEngineering
+      - id: ClothingHeadsetAltEngineering
+      - id: ClothingNeckCloakCe
+      - id: ClothingNeckMantleCE
+      - id: ClothingOuterWinterCE
+      - id: ClothingUniformJumpskirtChiefEngineer
+      - id: ClothingUniformJumpskirtChiefEngineerTurtle
+      - id: ClothingUniformJumpsuitChiefEngineer
+      - id: ClothingUniformJumpsuitChiefEngineerTurtle
+
+- type: entity
   id: LockerChiefMedicalOfficerFilledHardsuit
   suffix: Filled, Hardsuit
   parent: LockerChiefMedicalOfficer
@@ -219,6 +303,25 @@
       - id: BoxEncryptionKeyMedical
 
 - type: entity
+  id: LockerChiefMedicalOfficerFilledCosmetic
+  suffix: Cosmetic
+  parent: LockerChiefMedicalOfficer
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingCloakCmo
+      - id: ClothingEyesHudMedical
+      - id: ClothingHandsGlovesNitrile
+      - id: ClothingHeadHatBeretCmo
+      - id: ClothingHeadsetAltMedical
+      - id: ClothingMaskSterile
+      - id: ClothingNeckMantleCMO
+      - id: ClothingOuterCoatLabCmo
+      - id: ClothingOuterWinterCMO
+      - id: ClothingUniformJumpskirtCMO
+      - id: ClothingUniformJumpsuitCMO
+
+- type: entity
   id: LockerResearchDirectorFilledHardsuit
   suffix: Filled, Hardsuit
   parent: LockerResearchDirector
@@ -262,6 +365,22 @@
       - id: BoxEncryptionKeyScience
 
 - type: entity
+  id: LockerResearchDirectorFilledCosmetic
+  suffix: Cosmetic
+  parent: LockerResearchDirector
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingHandsGlovesColorPurple
+      - id: ClothingHeadHatBeretRND
+      - id: ClothingHeadsetAltScience
+      - id: ClothingNeckCloakRd
+      - id: ClothingNeckMantleRD
+      - id: ClothingOuterWinterRD
+      - id: ClothingUniformJumpskirtResearchDirector
+      - id: ClothingUniformJumpsuitResearchDirector
+
+- type: entity
   id: LockerHeadOfSecurityFilledHardsuit
   suffix: Filled, Hardsuit
   parent: LockerHeadOfSecurity
@@ -295,31 +414,30 @@
       - id: BookSecretDocuments
 
 - type: entity
-  id: LockerHeadOfSecurityFilled
-  suffix: Filled
+  id: LockerHeadOfSecurityFilledCosmetic
+  suffix: Cosmetic
   parent: LockerHeadOfSecurity
   components:
   - type: StorageFill
     contents:
-      - id: ClothingEyesHudSecurity
-      - id: WeaponDisabler
-      - id: ClothingHeadHatBeretHoS
-      - id: ClothingHeadHatHoshat
-      - id: ClothingNeckCloakHos
-      - id: ClothingOuterCoatHoSTrench
-      - id: ClothingUniformJumpskirtHoSAlt
-      - id: ClothingUniformJumpsuitHoSAlt
-      - id: ClothingBeltSecurityFilled
-      - id: ClothingHeadsetAltSecurity
-      - id: ClothingEyesGlassesSecurity
-      - id: ClothingShoesBootsJack
       - id: CigarGoldCase
         prob: 0.50
-      - id: DoorRemoteSecurity
+      - id: ClothingBeltSecurityWebbing
+      - id: ClothingEyesGlassesSecurity
+      - id: ClothingEyesHudSecurity
+      - id: ClothingHeadHatBeretHoS
+      - id: ClothingHeadHatHoshat
+      - id: ClothingHeadsetAltSecurity
+      - id: ClothingNeckCloakHos
+      - id: ClothingNeckMantleHOS
+      - id: ClothingOuterCoatHoSTrench
+      - id: ClothingOuterWinterHoS
+      - id: ClothingShoesBootsJack
+      - id: ClothingUniformJumpskirtHoSAlt
       - id: ClothingUniformJumpskirtHosFormal
+      - id: ClothingUniformJumpskirtHoSParadeMale
+      - id: ClothingUniformJumpsuitHoSAlt
+      - id: ClothingUniformJumpsuitHoSBlue
       - id: ClothingUniformJumpsuitHosFormal
-      - id: RubberStampHos
-      - id: SecurityTechFabCircuitboard
-      - id: BoxEncryptionKeySecurity
-      - id: HoloprojectorSecurity
-      - id: BookSecretDocuments
+      - id: ClothingUniformJumpsuitHoSGrey
+      - id: ClothingUniformJumpsuitHoSParadeMale

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -414,6 +414,36 @@
       - id: BookSecretDocuments
 
 - type: entity
+  id: LockerHeadOfSecurityFilled
+  suffix: Filled
+  parent: LockerHeadOfSecurity
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingEyesHudSecurity
+      - id: WeaponDisabler
+      - id: ClothingHeadHatBeretHoS
+      - id: ClothingHeadHatHoshat
+      - id: ClothingNeckCloakHos
+      - id: ClothingOuterCoatHoSTrench
+      - id: ClothingUniformJumpskirtHoSAlt
+      - id: ClothingUniformJumpsuitHoSAlt
+      - id: ClothingBeltSecurityFilled
+      - id: ClothingHeadsetAltSecurity
+      - id: ClothingEyesGlassesSecurity
+      - id: ClothingShoesBootsJack
+      - id: CigarGoldCase
+        prob: 0.50
+      - id: DoorRemoteSecurity
+      - id: ClothingUniformJumpskirtHosFormal
+      - id: ClothingUniformJumpsuitHosFormal
+      - id: RubberStampHos
+      - id: SecurityTechFabCircuitboard
+      - id: BoxEncryptionKeySecurity
+      - id: HoloprojectorSecurity
+      - id: BookSecretDocuments
+
+- type: entity
   id: LockerHeadOfSecurityFilledCosmetic
   suffix: Cosmetic
   parent: LockerHeadOfSecurity
@@ -433,9 +463,11 @@
       - id: ClothingOuterCoatHoSTrench
       - id: ClothingOuterWinterHoS
       - id: ClothingShoesBootsJack
+      - id: ClothingUniformJumpskirtHoS
       - id: ClothingUniformJumpskirtHoSAlt
       - id: ClothingUniformJumpskirtHosFormal
       - id: ClothingUniformJumpskirtHoSParadeMale
+      - id: ClothingUniformJumpsuitHoS
       - id: ClothingUniformJumpsuitHoSAlt
       - id: ClothingUniformJumpsuitHoSBlue
       - id: ClothingUniformJumpsuitHosFormal


### PR DESCRIPTION
## About the PR
Adds a fill for all head's of staff lockers to be cosmetic items without actual gear.

## Why / Balance
I intend to use it for the CentCom Arrivals map.

## Media
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/110078045/58a7fdec-a68f-440a-810c-2adc4877648b)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame.

**Changelog**
No need.