### PR TITLE
Increase Time To Rot (The Rot No Longer Consumes)

### DIFF
--- a/Content.Shared/Atmos/Miasma/PerishableComponent.cs
+++ b/Content.Shared/Atmos/Miasma/PerishableComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class PerishableComponent : Component
     /// How long it takes after death to start rotting.
     /// </summary>
     [DataField("rotAfter"), ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan RotAfter = TimeSpan.FromMinutes(10);
+    public TimeSpan RotAfter = TimeSpan.FromMinutes(15);
 
     /// <summary>
     /// How much rotting has occured


### PR DESCRIPTION
## About the PR
Oh boy, don't you love untested changes? I love untested changes.
closes #3 
This increases the rot timer to take longer overall, I'm looking for input as to how much longer it should be increased, as I'm going with five extra minuets for now. We could possibly bring it to twenty over all, but I don't know if that is quite justified.
**The rot consumes slower than before.**

## Why / Balance
Due to the increased round duration, I believe the time to rot should reflect that, with standard round times (1H 20M) it takes you about 12% of the round to rot, but with out extended round times (5 hours), that drops to 0.03. It should take more time for people to rot. I doubt there will be many times people actually rot due to antags, but I still think this should be increased not only because of antags, but the chances of accidents that can occur during the shift.

## Technical details
Changes line 16 of PerishableComponent.cs this should hypothetically add five minuets to the rot timer, bringing it to fifteen total.

I will include media upon request (assuming I can actually figure out how to test....)

If for whatever reason this doesn't work, I'll actually take a closer look.

:cl: 
 tweak:  The time for bodies to rot has been increased from 10 -> 15 minuets. 