### PR TITLE
Adds A Generic Roach Spawner

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/mobs.yml
@@ -30,7 +30,7 @@
     prototypes:
       - MobCockroach
     rarePrototypes:
-      - Mobmothroach
+      - MobMothroach
     rareChance: 0.03
 
 - type: entity


### PR DESCRIPTION
## About the PR
Adds a new spawner for mappers to use.

Requires [this PR](https://github.com/space-wizards/space-station-14/pull/19752) to be merged/pulled from upstream.

## Why / Balance
Before this there was no way to consistently get mothroaches or cockroaches, this makes it so mappers can include them if they want.

## Media
-Its a draft, I'll do media later.

## ToDo

- [ ] Test
- [x] Make a spawner icon (Currently Uses Mouse Icon, could just, not define the icon and have it make one for us.)

**Changelog**
no cl no fun
