### PR TITLE
Add Department Head Clothing To Uniform Printer (Part 2 Electric Boogaloo)

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -785,6 +785,14 @@
       - ClothingUniformJumpskirtBrigmedic
       - ClothingUniformJumpsuitWarden
       - ClothingUniformJumpskirtWarden
+      - ClothingUniformJumpskirtHosFormal
+      - ClothingUniformJumpskirtHoSParadeMale
+      - ClothingUniformJumpsuitHoSBlue
+      - ClothingUniformJumpsuitHosFormal
+      - ClothingUniformJumpsuitHoSGrey
+      - ClothingUniformJumpsuitHoSParadeMale
+      - ClothingUniformJumpsuitCapFormal
+      - ClothingUniformJumpskirtCapFormalDress
       - ClothingOuterWinterCap
       - ClothingOuterWinterCE
       - ClothingOuterWinterCMO
@@ -819,6 +827,24 @@
       - ClothingOuterWinterSci
       - ClothingOuterWinterRobo
       - ClothingOuterWinterSec
+      - ClothingNeckCloakHop
+      - ClothingNeckCloakQm
+      - ClothingNeckCloakCe
+      - ClothingCloakCmo
+      - ClothingNeckCloakRd
+      - ClothingNeckCloakHos
+      - ClothingNeckCloakCapFormal
+      - ClothingNeckCloakCap
+      - ClothingHeadHatBeretEngineering
+      - ClothingHeadHatBeretCmo
+      - ClothingHeadHatBeretRND
+      - ClothingHeadHatBeretHoS
+      - ClothingHeadHatHoshat
+      - ClothingHeadHatHopcap
+      - ClothingHeadHatQMsoftFlipped
+      - ClothingHeadHatQMsoft
+      - ClothingHeadHatCaptain
+      - ClothingHeadHatCapcap
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -700,3 +700,201 @@
   completetime: 3.2
   materials:
     Cloth: 500
+
+- type: latheRecipe
+  id: ClothingNeckCloakQm
+  result: ClothingNeckCloakQm
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingHeadHatQMsoftFlipped
+  result: ClothingHeadHatQMsoftFlipped
+  completetime: 2.5
+  materials:
+    Cloth: 150
+
+- type: latheRecipe
+  id: ClothingHeadHatQMsoft
+  result: ClothingHeadHatQMsoft
+  completetime: 2.5
+  materials:
+    Cloth: 150
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitCapFormal
+  result: ClothingUniformJumpsuitCapFormal
+  completetime: 2.5
+  materials:
+    Cloth: 300
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUniformJumpskirtCapFormalDress
+  result: ClothingUniformJumpskirtCapFormalDress
+  completetime: 2.5
+  materials:
+    Cloth: 300
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingNeckCloakCapFormal
+  result: ClothingNeckCloakCapFormal
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 150
+
+- type: latheRecipe
+  id: ClothingNeckCloakCap
+  result: ClothingNeckCloakCap
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 150
+
+- type: latheRecipe
+  id: ClothingHeadHatCaptain
+  result: ClothingHeadHatCaptain
+  completetime: 2.5
+  materials:
+    Cloth: 150
+
+- type: latheRecipe
+  id: ClothingHeadHatCapcap
+  result: ClothingHeadHatCapcap
+  completetime: 2.5
+  materials:
+    Cloth: 150
+
+- type: latheRecipe
+  id: ClothingNeckCloakHop
+  result: ClothingNeckCloakHop
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 150
+
+- type: latheRecipe
+  id: ClothingHeadHatHopcap
+  result: ClothingHeadHatHopcap
+  completetime: 2.5
+  materials:
+    Cloth: 150
+
+- type: latheRecipe
+  id: ClothingNeckCloakCe
+  result: ClothingNeckCloakCe
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 150
+
+- type: latheRecipe
+  id: ClothingCloakCmo
+  result: ClothingCloakCmo
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 150
+
+- type: latheRecipe
+  id: ClothingNeckCloakRd
+  result: ClothingNeckCloakRd
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 150
+
+- type: latheRecipe
+  id: ClothingNeckCloakHos
+  result: ClothingNeckCloakHos
+  completetime: 2.8
+  materials:
+    Cloth: 150
+    Durathread: 150
+
+- type: latheRecipe
+  id: ClothingHeadHatBeretEngineering
+  result: ClothingHeadHatBeretEngineering
+  completetime: 2.5
+  materials:
+    Cloth: 150
+
+- type: latheRecipe
+  id: ClothingHeadHatBeretCmo
+  result: ClothingHeadHatBeretCmo
+  completetime: 2.5
+  materials:
+    Cloth: 150
+
+- type: latheRecipe
+  id: ClothingHeadHatBeretRND
+  result: ClothingHeadHatBeretRND
+  completetime: 2.5
+  materials:
+    Cloth: 150
+
+- type: latheRecipe
+  id: ClothingHeadHatBeretHoS
+  result: ClothingHeadHatBeretHoS
+  completetime: 2.5
+  materials:
+    Cloth: 150
+
+- type: latheRecipe
+  id: ClothingHeadHatHoshat
+  result: ClothingHeadHatHoshat
+  completetime: 2.5
+  materials:
+    Cloth: 150
+
+- type: latheRecipe
+  id: ClothingUniformJumpskirtHosFormal
+  result: ClothingUniformJumpskirtHosFormal
+  completetime: 4
+  materials:
+    Cloth: 300
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUniformJumpskirtHoSParadeMale
+  result: ClothingUniformJumpskirtHoSParadeMale
+  completetime: 4
+  materials:
+    Cloth: 300
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitHoSBlue
+  result: ClothingUniformJumpsuitHoSBlue
+  completetime: 4
+  materials:
+    Cloth: 300
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitHosFormal
+  result: ClothingUniformJumpsuitHosFormal
+  completetime: 4
+  materials:
+    Cloth: 300
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitHoSGrey
+  result: ClothingUniformJumpsuitHoSGrey
+  completetime: 4
+  materials:
+    Cloth: 300
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitHoSParadeMale
+  result: ClothingUniformJumpsuitHoSParadeMale
+  completetime: 4
+  materials:
+    Cloth: 300
+    Durathread: 100


### PR DESCRIPTION
## About the PR
Refer to technical Details Section.

## Why / Balance
Seeing as when department heads leave, they likely aren't taking off their uniforms to go back to central command and enter cryosleep, there should be a way to easily make more, plus it gives HoP more to do. I made the decision to exclude Jackboots, Combat boots, and department head gloves. The gloves are namely to make any detectives have a bit of an easier time.

## Technical details
Adds the following clothing items to the Uniform Printer:
QM Hat, Flipped Hat, Cloak
Captain's Formal Suit, FOrmal Dress, Cloaks, Hard Hat, Cap Cap
HoP's Cap, Cloak
CE, CMO, RD, HoS Cloaks
HoS's Cowboy Hat, Formal Suit, Formal Dress, Parade Uniforms, Blue Suit, Grey Uniform
Engineering, CMO, RD, HoS Berrets

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![Content Client_LpXFm6XID7](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/91865152/82d32a16-3c5c-4228-89f6-3730c5516428)
![Content Client_1i5DKbmnvX](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/91865152/ce7832d0-41dd-4ed6-98dd-53d2ff5b7c32)
