### PR TITLE
Increase The Effect of Eye Damage

### DIFF
--- a/Content.Client/Eye/Blinding/BlurryVisionOverlay.cs
+++ b/Content.Client/Eye/Blinding/BlurryVisionOverlay.cs
@@ -54,7 +54,7 @@ namespace Content.Client.Eye.Blinding
             // Maybe gradually shrink the view-size?
             // Make the effect only apply to the edge of the viewport?
             // Actually make it blurry??
-            var opacity =  0.75f * _magnitude / BlurryVisionComponent.MaxMagnitude;
+            var opacity =  1f * _magnitude / BlurryVisionComponent.MaxMagnitude;
             var worldHandle = args.WorldHandle;
             var viewport = args.WorldBounds;
             worldHandle.SetTransform(Matrix3.Identity);

--- a/Content.Shared/Eye/Blinding/Components/BlindableComponent.cs
+++ b/Content.Shared/Eye/Blinding/Components/BlindableComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class BlindableComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField("EyeDamage"), AutoNetworkedField]
     public int EyeDamage = 0;
 
-    public const int MaxDamage = 8;
+    public const int MaxDamage = 3;
 
     /// <description>
     /// Used to ensure that this doesn't break with sandbox or admin tools.

--- a/Content.Shared/Eye/Blinding/Components/BlurryVisionComponent.cs
+++ b/Content.Shared/Eye/Blinding/Components/BlurryVisionComponent.cs
@@ -17,5 +17,5 @@ public sealed partial class BlurryVisionComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField("magnitude"), AutoNetworkedField]
     public float Magnitude;
 
-    public const float MaxMagnitude = 10;
+    public const float MaxMagnitude = 3;
 }


### PR DESCRIPTION
## About the PR
- Decreases the amount of damage needed to go perma blind, from 8 to 3.
- Makes the "blur" effect _way_ more present.

## Why / Balance
Stop fucking hurting you eyes.
- I can't remember the last time oculine was ever even used.
- Prevents people from doing engi's job a bit more.
- More punishing for being stupid.

## Media
https://github.com/cosmatic-drift-14/cosmatic-drift/assets/110078045/1b743441-77df-4bdb-9753-aa842b1b451d