### PR TITLE
Terminal/Arrivals Hot-Fixes

### DIFF
--- a/Resources/Maps/Misc/terminal.yml
+++ b/Resources/Maps/Misc/terminal.yml
@@ -46379,6 +46379,13 @@ entities:
     - pos: -37.5,4.5
       parent: 2
       type: Transform
+- proto: VendingMachineSyndieDrobe
+  entities:
+  - uid: 8735
+    components:
+    - pos: -2.5,38.5
+      parent: 2
+      type: Transform
 - proto: VendingMachineTheater
   entities:
   - uid: 411


### PR DESCRIPTION
## About the PR
Does some minor bug fixes to the terminal.

## Why / Balance
Was missing some chairs, seemingly by mistake. Just made it so the left and right side are mirrored. The old disposals was leading into the admin only room, which had a full telecomms server and a CC Vend, figured I'd make it so players couldn't get there if they tried to. Also adds a syndiedrobe to the admin-only room, this is to help admins figure out appropriate attire for event characters if need be. (Similar to the current purpose the CC Vend Serves.)

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase.

Left Side Arrivals:
![Content Client_xs0gKAhhrO](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/91865152/86a27535-8962-4b0b-87cf-71fa20a300d7)

New Disposals:
![Content Client_Hi2NJDl7gK](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/91865152/6c5dbc7f-266c-471f-957f-f4656d3b360f)
