### PR TITLE
Fixes Minor Rules Typos

### DIFF
--- a/Resources/ServerInfo/Rules.txt
+++ b/Resources/ServerInfo/Rules.txt
@@ -4,7 +4,7 @@
 
 [color=#ffe600]Zero Tolerance Policies.[/color]
 
-[color=#7ade00]02.[/color] Do not attempt to evade bans, ahelp questioning or punishments. Do not abuse the ahelp system.
+[color=#7ade00]02.[/color] Do not attempt to evade bans, ahelp questioning, or punishments. Do not abuse the ahelp system.
 - Ban evading using an alternate account or other means will result in an immediate voucher ban.
 - Evading ahelp questioning by disconnecting upon being ahelped, during questioning, or ignoring the admin will usually end in an appeal ban.
 - Attempting to get around role bans by being promoted to that role in-game will lead to a game ban.
@@ -15,7 +15,7 @@
 
 [color=#7ade00]04.[/color] Absolutely no bigotry. This covers ableism, homophobia, racism, sexism, speciesism, and hate speech as a whole. If it's to the point where it makes someone uncomfortable and they ahelp you or an admin finds an issue with it, you will answer for it.
 
-[color=#7ade00]05.[/color] No sexual content, disgusting RP or gross statements. This is not an 18+ server. This means no erotic roleplay, emotes and messages that are sexual in nature, or overtly disgusting things no one wants to hear. Includes "technically not NSFW" jokes.
+[color=#7ade00]05.[/color] No sexual content, disgusting RP, or gross statements. This is not an 18+ server. This means no erotic roleplay, emotes and messages that are sexual in nature, or overtly disgusting things no one wants to hear. Includes "technically not NSFW" jokes.
 
 [color=#7ade00]06.[/color] Do not communicate in-round information about an on-going round through multiple accounts or to other people.
 - Often referred to as metacomms, this is posting screenshots of a live round, talking about in-character events in OOC, sitting in a voice chat talking about the round, etc. It does not matter how minor it is, this is zero tolerance.
@@ -29,12 +29,12 @@
 
 [color=#7ade00]08.[/color] Don't be a huge dick, try not to over escalate. You're playing a roleplaying game with several other people. Don't actively make other people's lives hell for your own enjoyment, or generally grief. Usually referred to as self-antaging.
 - Leeway is obviously granted for antagonist roles. But try to drive the round with roleplay as best as you can.
-- Some leeway is also granted in the case of players wanting to roleplay out minor crimes. But the line here is drawn when it becomes over the top, uninteresting and the issue is repeated even after in-character punishment. It is always safer to ahelp for permission before you do it.
+- Some leeway is also granted in the case of players wanting to roleplay out minor crimes. But the line here is drawn when it becomes over the top, uninteresting, and/or the issue is repeated even after in-character punishment. It is always safer to ahelp for permission before you do it.
 - For both of these it is a good rule of thumb to avoid intentionally permanently removing someone from the round unless in pursuit of an objective.
 - If you're starting a social fight or such, try your best attempt to bring the person to medical if either party enters crit.
 
 
-- Try your best not to negatively affect SSD players. Stealing from them or killing them is not allowed, but things like moving them to a safe spot or security finishing out a search is fine.
+- Try your best not to negatively affect SSD players. Stealing from them or killing them is not allowed, but things like moving them to a safe spot or security performing a search is fine.
 
 [color=#7ade00]09.[/color] You are playing a high roleplay server, speak and act like a human being. You are held up to a high level of roleplay, this does not mean you need to have entirely documented lore for your character or constantly emote out actions, but you're expected to actively engage in roleplay when it comes up.
 - Do not use text speech like "omg", or "XD".
@@ -61,16 +61,16 @@
 
 [color=#7ade00]14.[/color] Full continuity of your character and events that happen to them is expected. All rounds are canonical unless stated otherwise by an admin.
 - You are allowed to recall past shifts in any manner, unless it violates New Life rule.
-- Punishments you receive will be enforced to carry out in-character throughout rounds. If your character gets demoted you're expected to stay out of that job until a reasonable amount of time has passed or you get rehired in-game.
+- Punishments you receive will be enforced and carried out in-character throughout rounds. If your character gets demoted, you're expected to stay out of that job until a reasonable amount of time has passed, or you get rehired in-game.
 - Your characters should generally hold no more than two departmental jobs and a service side job in-character. You may swap departments from time to time so long as it doesn't happen constantly.
 - Permanent death is not required, as there's off-site DNA storages for all crewmembers.
 
-[color=#7ade00]15.[/color] Stay within your job, reasonable knowledge and abilities. Referred to as metagaming.
+[color=#7ade00]15.[/color] Stay within your job, reasonable knowledge, and abilities. Referred to as metagaming.
 - Unless your character has a past in the type of work they shouldn't know how to do jobs outside of theirs.
 - Do not do other people's jobs for them, only play the role you signed up for. If you want to play a different job ask the Head of Personnel for a job change. Exceptions can be made for if no active staff exist for a department, if it is reasonable for your character to know how to.
 - Basic crew should not be knowledgeable on most non-NT technology and items, unless they've experienced it in-character. Security and command may have some leeway within reason.
 
-[color=#7ade00]16.[/color] Command and security are expected to be competent, lawful and follow procedure.
+[color=#7ade00]16.[/color] Command and security are expected to be competent, lawful, and follow procedure.
 - Neither roles should be grossly incompetent at their job or in their judgment. You are held to higher standards and are usually looked up to be good at your work, a role model, and reflection of your department, act like it.
 - You shouldn't be knowingly breaking the law consistently as a command or security member.
-- Command staff should know Standard Operating Procedure and follow it to the best of their abilities. Security should know both Standard Operating Procedure, Space Law, follow it and enforce it to the best of their abilities. Failure to do so is likely to result in role bans.
+- Command staff should know Standard Operating Procedure and follow it to the best of their abilities. Security should know both Standard Operating Procedure, Space Law, follow it, and enforce it to the best of their abilities. Failure to do so is likely to result in role bans.

--- a/Resources/ServerInfo/Rules.txt
+++ b/Resources/ServerInfo/Rules.txt
@@ -23,7 +23,7 @@
 
 [color=#7ade00]07.[/color] Intentionally using, or abusing exploits, bugs, and external programs is not allowed.
 - From the moment you learn it's a bug you're expected to report it and never intentionally use it again.
-- External programs are things such as autoclickers, marcos, and such.
+- External programs are things such as autoclickers, macros, and such.
 
 [color=#ffe600]General Etiquette.[/color]
 


### PR DESCRIPTION
## About the PR

Changes I made which I'm not sure are correct, preferred, etc have a italicized question mark before and after them This looks like _?_
**Rule 2**
"...attempt to evade bans, ahelp questioning or..." has been changed to "...attempt to evade bans, ahelp questioning **,** or...", fixing the missing comma from the list.

**Rule 5**
"No sexual content, disgusting RP or gross statements." has been changed to "No sexual content, disgusting RP**,** or gross statements." fixing the missing comma from the list.

**Rule 7**
"...such as autoclickers, marcos, and such." has been changed to "...such as autoclickers, **macros**, and such." fixing the typo in marco.

**Rule 8**
_?_ "when it becomes over the top, uninteresting and the issue is repeated even after in-character punishment." has been changed to "when it becomes over the top, uninteresting, and/or the issue is repeated even after in-character punishment." now including an "and/or". _?_ This could go either way, again personal preference. I'm not sure if you folks would want this to be changed.

" but things like moving them to a safe spot or security finishing out a search is fine." has been changed to " but things like moving them to a safe spot or security **performing** a search is fine.", this helps with clarity.

**Rule 14**
_?_ "- Punishments you receive **will be enforced to carry out** in-character throughout rounds." has been changed to "- Punishments you receive **will be enforced and carried out** in-character throughout rounds." _?_ This was a weird typo and it seemed like the most straight forward fix. This is also preference, tell me if you want it changed.

"If your character gets demoted you're expected to stay out of..." has been changed to "If your character gets demoted, you're expected to stay out of..." marking "If your character gets demoted" as an introductory statement.

"amount of time has passed or you get rehired" has been changed to "amount of time has passed, or you get rehired in-game.", including a comma giving it slightly better clarity in my opinion.

**Rule 15**
_?_ "Stay within your job, reasonable knowledge and abilities. Referred to as metagaming." has been changed to "Stay within your job, reasonable knowledge, and abilities. Referred to as metagaming." _?_ (This is separating the list slightly further, this is purely preference.)

**Rule 16**
"..are expected to be competent, lawful and follow procedure." has been changed to "are expected to be competent, lawful, and follow procedure." fixing the comma missing in the list.

_?_ "...should know both standard operating procedure, space law, follow it and enforce it..." has been changed to "...should know both standard operating procedure, space law, follow it, and enforce it..." fixing what seemed to me like a missing comma. _?_

## Why?
Rule Clarity.

## Note
If any of these changes admins want reverted, just let me know. I tried to make changes that only made rules clearer to read, or fixing typos. If you want something removed or altered, post a review requesting the relevant changes.
