### PR TITLE
Pride Pins in Quickthread

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/quickthreads.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/quickthreads.yml
@@ -56,3 +56,4 @@
     ClothingNeckTieDet: 2
     ClothingNeckTieRed: 2
     ClothingEyesGlassesAviator: 4
+    BoxPridePins: 2

--- a/Resources/Prototypes/_CD/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_CD/Catalog/Fills/Boxes/general.yml
@@ -1,0 +1,30 @@
+# Pride Pins Box
+- type: entity
+  name: pride pin box
+  parent: BoxCardboard
+  id: BoxPridePins
+  description: This box is filled pride pins.
+  components:
+    - type: StorageFill
+      contents:
+        - id: ClothingNeckLGBTPin
+          amount: 1
+        - id: ClothingNeckAromanticPin
+          amount: 1
+        - id: ClothingNeckAsexualPin
+          amount: 1
+        - id: ClothingNeckBisexualPin
+          amount: 1
+        - id: ClothingNeckIntersexPin
+          amount: 1
+        - id: ClothingNeckLesbianPin
+          amount: 1
+        - id: ClothingNeckNonBinaryPin
+          amount: 1
+        - id: ClothingNeckPansexualPin
+          amount: 1
+        - id: ClothingNeckTransPin
+          amount: 1 
+    - type: Sprite
+      layers:
+        - state: box


### PR DESCRIPTION
## About the PR
This adds all (current) versions of the pride pins into the quickthreads. These are in the form of two boxes, just to prevent adding nine new items to the vending machine.

## Why / Balance
Closes: [This Discord Thread](https://discord.com/channels/1163352113162768436/1181400509224063046/1181400509224063046) 

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Add: Pride Pins are now sold at the QuickThreads vendor in the terminal. There are two boxes containing one of each pride pin.
