### PR TITLE
Painkiller RP Meds + Addictine

### DIFF
--- a/Resources/Locale/en-US/_CD/reagents/RPmeds.ftl
+++ b/Resources/Locale/en-US/_CD/reagents/RPmeds.ftl
@@ -58,3 +58,32 @@ reagent-effect-anxietymed-strong6 = You feel quite calm.
 reagent-effect-anxietymed-strong7 = You feel like you can take on the world!
 
 reagent-effect-anxietymed-fade = The calming effects start to fade...
+
+reagent-effect-medaddiction-1 = You're yearning for another high.
+reagent-effect-medaddiction-2 = You really need some more drugs.
+reagent-effect-medaddiction-3 = You feel empty. Find another fix.
+reagent-effect-medaddiction-4 = Go get some drugs, you can quit later.
+reagent-effect-medaddiction-5 = You feel desperate for your next high.
+reagent-effect-medaddiction-6 = You can feel your hands shaking.
+reagent-effect-medaddiction-7 = You could use another hit right now
+reagent-effect-medaddiction-8 = One more fix couldn't hurt, right?
+
+reagent-effect-painkiller-mild1 = Your body hurts a bit less.
+reagent-effect-painkiller-mild2 = You feel a little bit dizzy.
+reagent-effect-painkiller-mild3 = You feel a tiny bit numb.
+reagent-effect-painkiller-mild4 = Any pain you had has faded slightly.
+
+
+reagent-effect-painkiller-normal1 = Any pain you had has faded significantly.
+reagent-effect-painkiller-normal2 = You feel dizzy.
+reagent-effect-painkiller-normal3 = Your entire body goes numb briefly.
+reagent-effect-painkiller-normal4 = You feel your pain fade somewhat.
+
+reagent-effect-painkiller-strong1 = You forgot what pain feels like.
+reagent-effect-painkiller-strong2 = You can't see straight.
+reagent-effect-painkiller-strong3 = You feel a sense of deep nostalgia.
+reagent-effect-painkiller-strong4 = Your entire body feels numb.
+reagent-effect-painkiller-strong5 = You hardly feel anything at all.
+reagent-effect-painkiller-strong6 = Any pain you were feeling is gone.
+
+reagent-effect-painkiller-fade = The painkiller's effects start to fade...

--- a/Resources/Locale/en-US/_CD/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_CD/reagents/meta/medicine.ftl
@@ -5,7 +5,7 @@ reagent-name-neurozenium = Neurozenium
 reagent-desc-neurozenium = Once considered child-safe shoe polish, Neurozenium was found to be a fairly effective antidepressant in an impressive zero-to-hero story. Do not take it with alcohol in your system. Consult a doctor before combining with other medications.
 
 reagent-name-blissifylovene = Blissifylovene
-reagent-desc-blissifylovene = A military-grade antidepressant with a very low dosage. Very powerful, though it is often considered a last resort due to its interactions with other medications and psychosis-inducing overdoses.
+reagent-desc-blissifylovene = A military-grade antidepressant with a very low dosage. Very powerful, though it is often considered a last resort due to its interactions with other medications and psychosis-inducing overdoses. Addictive in all but the smallest of doses.
 
 reagent-name-calmafluxine = Calmafluxine
 reagent-desc-calmafluxine = A mild, over-the-counter anxiety medication. Commonly prescribed to children as the body naturally flushes out any excess medication, making overdose functionally impossible.
@@ -15,3 +15,15 @@ reagent-desc-tranquinase = Run-of-the-mill anxiety medication. Derived from an o
 
 reagent-name-equilibrazine = Equilibrazine
 reagent-desc-equilibrazine = A Nanotrasen engineered chemical recipe designed to keep workers working with only small doses. It didn't make the cut, but it functions as a potent treatment for anxiety and panic attacks. Can be taken fine with alcohol, but is wildly incompatible with most antidepressants.
+
+reagent-name-addictine = addictine
+reagent-desc-addictine = A chemical produced by the body when metabolizing certain medications. Causes symptoms of withdrawl. Neutralizes bloodstream cleansers like charcoal and ipecac. 
+
+reagent-name-stubantazine = Stubantazine
+reagent-desc-stubantazine = A mild painkiller commonly used to treat brief stents of pain, though it lasts a little while for good measure. Overdose or consumption of alcohol may cause vomiting and digestion inefficiency.
+
+reagent-name-soretizone = Soretizone
+reagent-desc-soretizone = A fairly effective painkiller developed to treat chronic pain. It works for cases that Stubantazine won't solve. Overdoses will knock you right out. High doses may cause addiction. Does not conflict with reasonable amounts of alcohol.
+
+reagent-name-agonolexyne = Agonolexyne
+reagent-desc-agonolexyne = An incredibly potent and fast acting opioid invented to speed up the application of painkillers during surgery. Stops you from feeling pain (or really anything at all). Interacts poorly with alcohol. Known to be very addictive. Overdose may relax the lungs to the point of non-function.

--- a/Resources/Prototypes/_CD/Reactions/medicine.yml
+++ b/Resources/Prototypes/_CD/Reactions/medicine.yml
@@ -78,3 +78,47 @@
       amount: 1
   products:
     Equilibrazine: 5
+
+- type: reaction
+  id: Stubantazine
+  reactants:
+    Bicaridine:
+      amount: 1
+    Lithium:
+      amount: 1
+    Oil:
+      amount: 1
+  products:
+    Stubantazine: 3
+
+- type: reaction
+  id: Soretizone
+  minTemp: 340
+  reactants:
+    Bicaridine:
+      amount: 1
+    Phenol:
+      amount: 1
+    Iron:
+      amount: 1
+    TableSalt:
+      amount: 1
+      catalyst: true
+  products:
+    Soretizone: 3
+
+- type: reaction
+  id: Agonolexyne
+  minTemp: 350
+  reactants:
+    Bicaridine:
+      amount: 1
+    SulfuricAcid:
+      amount: 1
+    Sodium:
+      amount: 1
+    Plasma:
+      amount: 1
+      catalyst: true
+  products:
+    Agonolexyne: 3

--- a/Resources/Prototypes/_CD/Reagents/medicine.yml
+++ b/Resources/Prototypes/_CD/Reagents/medicine.yml
@@ -335,6 +335,13 @@
         emote: Yawn
         showInChat: true
         probability: 0.02
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Ethanol # Alcohol makes it really easy to overdose by increasing your body's absorption of the medicine.
+          min: 1
+        reagent: Tranquinase
+        amount: 0.1
       - !type:MovespeedModifier
         walkSpeedModifier: 0.8
         sprintSpeedModifier: 0.8

--- a/Resources/Prototypes/_CD/Reagents/medicine.yml
+++ b/Resources/Prototypes/_CD/Reagents/medicine.yml
@@ -191,6 +191,17 @@
           min: 10
         reagent: Neurozenium
         amount: -7.5
+      - !type:AdjustReagent
+        probablity: 0.5 # Chance of Addiction rising per tick
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Addictine
+          max: 10 # maximum addiction severity for this reagent
+        - !type:ReagentThreshold
+          reagent: Blissifylovene
+          min: 1.5
+        reagent: Addictine
+        amount: 0.1
       - !type:HealthChange
         conditions:
           - !type:ReagentThreshold
@@ -204,6 +215,26 @@
         - !type:ReagentThreshold
           reagent: Tranquinase # conflicts with many other meds
           min: 2.0
+        key: ForcedSleep
+        component: ForcedSleeping
+        refresh: false
+        type: Add
+        probability: 0.4
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Soretizone # conflicts with many other meds
+          min: 3.0
+        key: ForcedSleep
+        component: ForcedSleeping
+        refresh: false
+        type: Add
+        probability: 0.3
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Agonolexyne # conflicts with many other meds
+          min: 0.25
         key: ForcedSleep
         component: ForcedSleeping
         refresh: false
@@ -326,13 +357,6 @@
         damage:
           types:
             Poison: 1
-      - !type:AdjustReagent
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Ethanol # Alcohol makes it really easy to overdose by increasing your body's absorption of the medicine.
-          min: 1
-        reagent: Tranquinase
-        amount: 0.1
       - !type:PopupMessage
         type: Local
         visualType: Small
@@ -419,3 +443,261 @@
           - !type:ReagentThreshold
             max: 0.1
 
+- type: reagent
+  id: Addictine
+  name: reagent-name-addictine
+  group: Toxins
+  desc: reagent-desc-addictine
+  flavor: savory
+  color: "#d9d9d9"
+  physicalDesc: reagent-physical-desc-refreshing
+  metabolisms:
+    Poison:
+      metabolismRate : 0.01
+      effects:
+      - !type:PopupMessage
+        type: Local
+        visualType: LargeCaution
+        messages:
+          - "reagent-effect-medaddiction-1"
+          - "reagent-effect-medaddiction-2"
+          - "reagent-effect-medaddiction-3"
+          - "reagent-effect-medaddiction-4"
+          - "reagent-effect-medaddiction-5"
+          - "reagent-effect-medaddiction-6"
+          - "reagent-effect-medaddiction-7"
+          - "reagent-effect-medaddiction-8"
+        probability: 0.08
+        conditions:
+        - !type:ReagentThreshold # the following three chemicals are addictive, and thus will counteract cravings.
+          reagent: Blissifylovene
+          max: 0.01
+        - !type:ReagentThreshold
+          reagent: Soretizone
+          max: 0.01
+        - !type:ReagentThreshold
+          reagent: Agonolexyne
+          max: 0.01
+      - !type:AdjustReagent
+        reagent: Charcoal # purges bloodstream cleaners
+        amount: -10.0
+      - !type:AdjustReagent
+        reagent: Ipecac # purges bloodstream cleaners
+        amount: -10.0
+      - !type:MovespeedModifier
+        walkSpeedModifier: 0.95
+        sprintSpeedModifier: 0.7
+        conditions:
+        - !type:ReagentThreshold
+          max: 1.0 # it gets worse before the addiction ends.
+        - !type:ReagentThreshold # the following three chemicals are addictive, and thus will counteract cravings.
+          reagent: Blissifylovene
+          max: 0.01
+        - !type:ReagentThreshold
+          reagent: Soretizone
+          max: 0.01
+        - !type:ReagentThreshold
+          reagent: Agonolexyne
+          max: 0.01
+
+- type: reagent
+  id: Stubantazine
+  name: reagent-name-stubantazine
+  group: Medicine
+  desc: reagent-desc-stubantazine
+  physicalDesc: reagent-physical-desc-sour
+  flavor: sour
+  color: "#6bb3b5"
+  metabolisms:
+    Medicine:
+      metabolismRate : 0.02
+      effects:
+      - !type:PopupMessage
+        type: Local
+        visualType: Medium
+        messages:
+          - "reagent-effect-painkiller-mild1"
+          - "reagent-effect-painkiller-mild2"
+          - "reagent-effect-painkiller-mild3"
+          - "reagent-effect-painkiller-mild4"
+        probability: 0.08
+      - !type:ChemVomit
+        probability: 0.4
+        conditions:
+          - !type:ReagentThreshold # makes you vomit if you OD
+            min: 14
+      - !type:SatiateHunger # causes digestion inefficiency during overdose
+        factor: -1.2
+        conditions:
+          - !type:ReagentThreshold 
+            min: 14
+      - !type:ChemVomit
+        probability: 0.8
+        conditions:
+          - !type:ReagentThreshold # alcohol causes vomiting
+            reagent: Ethanol
+            min: 2
+      - !type:SatiateHunger # causes digestion inefficiency if you drink alcohol
+        factor: -2.0
+        conditions:
+          - !type:ReagentThreshold 
+            reagent: Ethanol
+            min: 2
+      - !type:PopupMessage
+        type: Local
+        visualType: Small
+        messages:
+          - "reagent-effect-painkiller-fade" # A decent chance to notify the player when their meds run out
+        probability: 0.35
+        conditions:
+          - !type:ReagentThreshold
+            max: 0.2
+
+- type: reagent
+  id: Soretizone
+  name: reagent-name-soretizone
+  group: Medicine
+  desc: reagent-desc-soretizone
+  physicalDesc: reagent-physical-desc-thick
+  flavor: tingly
+  color: "#2e2c2c"
+  metabolisms:
+    Medicine:
+      metabolismRate : 0.01
+      effects:
+      - !type:PopupMessage
+        type: Local
+        visualType: Large
+        messages:
+          - "reagent-effect-painkiller-normal1"
+          - "reagent-effect-painkiller-normal2"
+          - "reagent-effect-painkiller-normal3"
+          - "reagent-effect-painkiller-normal4"
+        probability: 0.085
+      - !type:GenericStatusEffect
+        probability: 0.1
+        conditions:
+        - !type:ReagentThreshold
+          min: 14.5 # overdose knocks you out
+        key: ForcedSleep
+        component: ForcedSleeping
+        refresh: false
+        type: Add
+      - !type:GenericStatusEffect
+        probability: 0.08
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Stubantazine
+          min: 5 # taking with other painkillers will knock you out
+        key: ForcedSleep
+        component: ForcedSleeping
+        refresh: false
+        type: Add
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Ethanol # lots of alcohol makes it really easy to overdose by increasing your body's absorption of the medicine.
+          min: 20
+        reagent: Soretizone
+        amount: 0.03
+      - !type:AdjustReagent
+        probablity: 0.55 # Chance of Addiction rising per tick
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Addictine
+          max: 5 # maximum addiction severity for this reagent
+        - !type:ReagentThreshold
+          min: 9
+        reagent: Addictine
+        amount: 0.1
+      - !type:PopupMessage
+        type: Local
+        visualType: Medium # stronger painkiller = more noticable fading
+        messages:
+          - "reagent-effect-painkiller-fade" # A decent chance to notify the player when their meds run out
+        probability: 0.4
+        conditions:
+          - !type:ReagentThreshold
+            max: 0.1
+
+- type: reagent
+  id: Agonolexyne
+  name: reagent-name-agonolexyne
+  group: Medicine
+  desc: reagent-desc-agonolexyne
+  physicalDesc: reagent-physical-desc-overpowering
+  flavor: nothing
+  color: "#ffc7c7"
+  metabolisms:
+    Medicine:
+      metabolismRate : 0.01
+      effects:
+      - !type:PopupMessage
+        type: Local
+        visualType: Large
+        messages:
+          - "reagent-effect-painkiller-strong1"
+          - "reagent-effect-painkiller-strong2"
+          - "reagent-effect-painkiller-strong3"
+          - "reagent-effect-painkiller-strong4"
+          - "reagent-effect-painkiller-strong5"
+          - "reagent-effect-painkiller-strong6"
+        probability: 0.1
+      - !type:GenericStatusEffect
+        probability: 0.1
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Stubantazine
+          min: 4 # taking with other painkillers will knock you out
+        key: ForcedSleep
+        component: ForcedSleeping
+        refresh: false
+        type: Add
+      - !type:GenericStatusEffect
+        probability: 0.15
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Soretizone
+          min: 2 # taking with other painkillers will knock you out
+        key: ForcedSleep
+        component: ForcedSleeping
+        refresh: false
+        type: Add
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Ethanol # Alcohol makes it really easy to overdose by increasing your body's absorption of the medicine.
+          min: 1
+        reagent: Agonolexyne
+        amount: 0.04
+      - !type:AdjustReagent
+        probablity: 0.8 # Chance of Addiction rising per tick
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Addictine
+          max: 25 # maximum addiction severity for this reagent
+        - !type:ReagentThreshold
+          min: 0.25
+        reagent: Addictine
+        amount: 0.2
+      - !type:Drunk # OD causes drunkeness
+        conditions:
+          - !type:ReagentThreshold
+            min: 5
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 5.5
+        damage:
+          types:
+            Asphyxiation: 1 # your lungs relax so much you can't breathe, suffocating you on OD
+      - !type:PopupMessage
+        type: Local
+        visualType: Large # stronger painkiller = more noticable fading
+        messages:
+          - "reagent-effect-painkiller-fade" # A decent chance to notify the player when their meds run out
+        probability: 0.5
+        conditions:
+          - !type:ReagentThreshold
+            max: 0.1
+          

--- a/Resources/Prototypes/_CD/Reagents/medicine.yml
+++ b/Resources/Prototypes/_CD/Reagents/medicine.yml
@@ -615,7 +615,7 @@
           max: 5 # maximum addiction severity for this reagent
         - !type:ReagentThreshold
           min: 9
-        reagent: Addictine
+        reagent: Addictine # add
         amount: 0.1
       - !type:PopupMessage
         type: Local


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
I decided to atomize RP meds because they ended up being more complicated than I thought.
## About the PR
<!-- What did you change in this PR? -->
This PR adds 3 painkillerss and a reagent that manages addictions. These reagents are primarily RP-based. Their main purpose is to act as meds that characters may need to take to deal with pain. They give RP prompts that you may or may not follow and have dangerous overdose effects. They all are detailed automatically in the Chemicals section of the guidebook, and can be found by searching for "Addict" or "Painkiller" when looking for chemicals that are addictive and chemicals that are painkillers, respectively. Their guidebook descriptions detail on how they work fairly well.

These chemicals are primarily for RP value and do not really provide any mechanical advantage whatsoever.
The rate at which you receive prompts isn't really intrusive. However, due to the nature of painkillers, the prompts will appear slightly more often compared to other RP medications.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Pretty much the same as the previous PR. I think it aids RP and makes sense that doctors would administer painkillers to patients in pain. If someone's backstory left them with chronic pain, there is now a medication to be prescribed for that too.

Addictine allows reagents to have varying levels of addiction, but overall addiction is primarily RP-focused with few mechanical downsides. It neutralizes bloodstream cleansers to prevent vomiting away your addiction.

## Reagents added
From least impactful to most:
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/137215465/0cfae513-1b9a-47d0-9457-83fa028ec208)
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/137215465/dfde41d9-66c3-4974-8169-f50b66c03f1f)
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/137215465/eb3e9dc8-585d-48a6-a394-1046b53a6a16)
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/137215465/26581d6d-9ec0-4757-bbe3-f7e79e65f62d)
Table salt is a catalyst in the above reaction, meaning it will not be consumed.
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/137215465/3d6a14c9-16b0-41f4-bcb0-d05ba832fa4d)
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/137215465/5586e775-3af1-48ae-a4af-980825c6730b)
Plasma is a catalyst in the above reaction, meaning it will not be consumed.
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/137215465/b4707c71-2087-4d2d-ba6e-59680f2586b7)
The following reagents are addictive:
Soretizone: Somewhat addictive (low addiction cap)
Blissifylovene: Addictive (medium addiction cap)
Agonolexyne: Incredibly addictive (high addiction cap)
Addiction cap affects how long it takes characters to get over their addiction.
Adding additional addictions is fairly simple. To do so:
1. Reference your new reagent in the Addictine prototype.
2. Have your reagent add increments of Addictine as it metabolizes, with a cap depending on how severe you wish for the addiction to become.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
:cl:
- add: Added three types of painkillers for RP purposes.
- add: Some reagents are now addictive.
-->
