### PR TITLE
Lost & Found Locker Guidebook "Help"

### DIFF
--- a/Resources/Prototypes/_CD/Entities/Structures/Storage/lockers.yml
+++ b/Resources/Prototypes/_CD/Entities/Structures/Storage/lockers.yml
@@ -13,3 +13,5 @@
     stateDoorClosed: lostandfound_door
   - type: AccessReader
     access: [["HeadOfPersonnel"]]
+  - type: GuideHelp
+    guides: [Cryosleep]

--- a/Resources/ServerInfo/Guidebook/Cryosleep.xml
+++ b/Resources/ServerInfo/Guidebook/Cryosleep.xml
@@ -7,6 +7,7 @@ While some stations come equipped with a Cryosleep Casket your most reliable way
 
 <Box>
 <GuideEntityEmbed Entity="MachineCryoSleepPod" Caption="Cryosleep Casket"/>
+<GuideEntityEmbed Entity="LockerLostAndFound" Caption="Lost And Found Locker"/>
 </Box>
 
 Upon returning to Central Command, the cryosleep chambers can easily be found by following the signs labeled "Cryo". Once there, you can insert yourself into a Cryosleep Casket, safely storing your body until your next shift.


### PR DESCRIPTION
## About the PR
This adds two things, the cryosleep guidebook entry now includes a visualization for the Lost and Found Locker, along with the Lost and Found Locker directing to the cryosleep entry so its use is more clear.

## Why / Balance
Currently, unless you directly read the cryosleep entry or had seen the Lost and Found work during a round, it was unclear that it directly had a mechanic behind it.

## Media
![Content Client_RVLcWaPj84](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/91865152/753629e9-74e0-40f7-be32-314736b89286)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Tweak: The cryosleep guidebook entry has been lightly altered to be more clear of what the Lost and Found Locker looks like.
