### PR TITLE
Adds Flippo's to the ShadySmokes

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
@@ -13,7 +13,6 @@
     PackPaperRollingFilters: 3
     CheapLighter: 4
     Lighter: 3
-    FlippoLighter: 2
-    FlippoEngravedLighter: 1
+    FlippoLighter: 3
   emaggedInventory:
     CigPackSyndicate: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
@@ -13,6 +13,6 @@
     PackPaperRollingFilters: 3
     CheapLighter: 4
     Lighter: 3
-    FlippoLighter: 3
+    FlippoLighter: 2
   emaggedInventory:
     CigPackSyndicate: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
@@ -12,6 +12,8 @@
     Matchbox: 5
     PackPaperRollingFilters: 3
     CheapLighter: 4
-    Lighter: 1
+    Lighter: 3
+    FlippoLighter: 2
+    FlippoEngravedLighter: 1
   emaggedInventory:
     CigPackSyndicate: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Number of basic lighters has been increased to three, Flippo has been added in every shadysmokes. This adds up to 3 basic lighters and 2 Flippo's (Engraved Flippo was removed due to it being a thief objective)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I don't see any issues with letting people have more ease of access with wanting to smoke cigerettes, It's not like it's going to crash the server (Unless it fucking does)

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Two Flippo lighters have been added to ShadySmokes along with three basic lighters!
