### PR TITLE
Anti-Psych RP Chem

### DIFF
--- a/Content.Client/Traits/ParacusiaSystem.cs
+++ b/Content.Client/Traits/ParacusiaSystem.cs
@@ -58,6 +58,9 @@ public sealed class ParacusiaSystem : SharedParacusiaSystem
         var timeInterval = _random.NextFloat(paracusia.MinTimeBetweenIncidents, paracusia.MaxTimeBetweenIncidents);
         paracusia.NextIncidentTime += TimeSpan.FromSeconds(timeInterval);
 
+        if (_timing.CurTime <= paracusia.IncidentsDelayedUntil)
+            return;
+
         // Offset position where the sound is played
         var randomOffset =
             new Vector2

--- a/Content.Server/Traits/Assorted/ParacusiaSystem.cs
+++ b/Content.Server/Traits/Assorted/ParacusiaSystem.cs
@@ -1,10 +1,13 @@
 using Content.Shared.Traits.Assorted;
 using Robust.Shared.Audio;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Traits.Assorted;
 
 public sealed class ParacusiaSystem : SharedParacusiaSystem
 {
+    [Dependency] private readonly IGameTiming _timing = default!;
+
     public void SetSounds(EntityUid uid, SoundSpecifier sounds, ParacusiaComponent? component = null)
     {
         if (!Resolve(uid, ref component))
@@ -34,5 +37,16 @@ public sealed class ParacusiaSystem : SharedParacusiaSystem
         }
         component.MaxSoundDistance = maxSoundDistance;
         Dirty(component);
+    }
+
+    public void SetIncidentDelay(EntityUid uid, TimeSpan delayTime, ParacusiaComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+        {
+            return;
+        }
+
+        component.IncidentsDelayedUntil = _timing.CurTime + delayTime;
+        Dirty(uid, component);
     }
 }

--- a/Content.Server/_CD/Chemistry/ReagentEffects/ResetParacusia.cs
+++ b/Content.Server/_CD/Chemistry/ReagentEffects/ResetParacusia.cs
@@ -1,0 +1,26 @@
+using Content.Server.Traits.Assorted;
+using Content.Shared.Chemistry.Reagent;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._CD.Chemistry.ReagentEffects;
+
+
+[UsedImplicitly]
+public sealed partial class ResetParacusia : ReagentEffect
+{
+    [DataField("TimerReset")]
+    public int TimerReset = 600;
+
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => Loc.GetString("reagent-effect-guidebook-reset-paracusia", ("chance", Probability));
+
+    public override void Effect(ReagentEffectArgs args)
+    {
+        if (args.Scale != 1f)
+            return;
+
+        var sys = args.EntityManager.EntitySysManager.GetEntitySystem<ParacusiaSystem>();
+        sys.SetIncidentDelay(args.SolutionEntity, new TimeSpan(0, 0, TimerReset));
+    }
+}

--- a/Content.Shared/Traits/Assorted/ParacusiaComponent.cs
+++ b/Content.Shared/Traits/Assorted/ParacusiaComponent.cs
@@ -43,5 +43,9 @@ public sealed partial class ParacusiaComponent : Component
     [DataField("timeBetweenIncidents", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan NextIncidentTime;
 
+    [ViewVariables(VVAccess.ReadWrite)]
+    [AutoNetworkedField]
+    public TimeSpan IncidentsDelayedUntil = new(0, 0 ,0);
+
     public EntityUid? Stream;
 }

--- a/Resources/Locale/en-US/_CD/reagents/RPmeds.ftl
+++ b/Resources/Locale/en-US/_CD/reagents/RPmeds.ftl
@@ -90,7 +90,7 @@ reagent-effect-painkiller-fade = The painkiller's effects start to fade...
 
 reagent-effect-antipsych-normal1 = You gain a sense of clarity.
 reagent-effect-antipsych-normal2 = You feel your mind has somewhat calmed.
-reagent-effect-antipsych-normal3 = Your sanitiy seems to improve.
+reagent-effect-antipsych-normal3 = Your sanity seems to improve.
 reagent-effect-antipsych-normal4 = You space out for a moment.
 reagent-effect-antipsych-normal5 = You feel a bit drowsy.
 

--- a/Resources/Locale/en-US/_CD/reagents/RPmeds.ftl
+++ b/Resources/Locale/en-US/_CD/reagents/RPmeds.ftl
@@ -1,28 +1,28 @@
 ### Messages to be used with RP-based medication.
 
-reagent-effect-antidepressant-mild1 = You feel like things aren't so bad. 
-reagent-effect-antidepressant-mild2 = The world seems a bit brighter. 
+reagent-effect-antidepressant-mild1 = You feel like things aren't so bad.
+reagent-effect-antidepressant-mild2 = The world seems a bit brighter.
 reagent-effect-antidepressant-mild3 = You feel a bit better about yourself.
 reagent-effect-antidepressant-mild4 = You feel slightly motivated.
 
-reagent-effect-antidepressant-normal1 = You feel pretty alright. 
-reagent-effect-antidepressant-normal2 = You find it hard to focus. 
+reagent-effect-antidepressant-normal1 = You feel pretty alright.
+reagent-effect-antidepressant-normal2 = You find it hard to focus.
 reagent-effect-antidepressant-normal3 = You feel purposeful.
 reagent-effect-antidepressant-normal4 = You feel motivated.
 
-reagent-effect-antidepressant-normaloverdose1 = You feel irrationally angry. 
+reagent-effect-antidepressant-normaloverdose1 = You feel irrationally angry.
 reagent-effect-antidepressant-normaloverdose2 = Everyone is out to get you!
 
-reagent-effect-antidepressant-strong1 = You feel a sense of great joy deep down. 
+reagent-effect-antidepressant-strong1 = You feel a sense of great joy deep down.
 reagent-effect-antidepressant-strong2 = You space out for a moment.
 reagent-effect-antidepressant-strong3 = You feel good about yourself.
 reagent-effect-antidepressant-strong4 = You feel a sense of great purpose.
 
-reagent-effect-antidepressant-strongoverdose1 = You're gonna die! YOU'RE GONNA DIE! 
-reagent-effect-antidepressant-strongoverdose2 = Run! RUN! HIDE! 
+reagent-effect-antidepressant-strongoverdose1 = You're gonna die! YOU'RE GONNA DIE!
+reagent-effect-antidepressant-strongoverdose2 = Run! RUN! HIDE!
 reagent-effect-antidepressant-strongoverdose3 = They're after you. THEY'LL KILL YOU.
 reagent-effect-antidepressant-strongoverdose4 = They're all plotting against you.
-reagent-effect-antidepressant-strongoverdose5 = Watch your back, BEHIND YOU! 
+reagent-effect-antidepressant-strongoverdose5 = Watch your back, BEHIND YOU!
 reagent-effect-antidepressant-strongoverdose6 = You won't last the shift.
 reagent-effect-antidepressant-strongoverdose7 = Shut up. SHUT UP. SHUT UP!
 reagent-effect-antidepressant-strongoverdose8 = Get away. GET AWAY! IT'S GONNA EXPLODE!
@@ -87,3 +87,11 @@ reagent-effect-painkiller-strong5 = You hardly feel anything at all.
 reagent-effect-painkiller-strong6 = Any pain you were feeling is gone.
 
 reagent-effect-painkiller-fade = The painkiller's effects start to fade...
+
+reagent-effect-antipsych-normal1 = You gain a sense of clarity.
+reagent-effect-antipsych-normal2 = You feel your mind has somewhat calmed.
+reagent-effect-antipsych-normal3 = Your sanitiy seems to improve.
+reagent-effect-antipsych-normal4 = You space out for a moment.
+reagent-effect-antipsych-normal5 = You feel a bit drowsy.
+
+reagent-effect-antipsych-fade = The anti-psychotic's effects start to fade...

--- a/Resources/Locale/en-US/_CD/reagents/guidebook.ftl
+++ b/Resources/Locale/en-US/_CD/reagents/guidebook.ftl
@@ -1,0 +1,5 @@
+reagent-effect-guidebook-reset-paracusia =
+    { $chance ->
+        [1] Temporarily staves
+        *[other] temporarily stave
+    } off paracusia

--- a/Resources/Locale/en-US/_CD/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_CD/reagents/meta/medicine.ftl
@@ -28,5 +28,5 @@ reagent-desc-soretizone = A fairly effective painkiller developed to treat chron
 reagent-name-agonolexyne = Agonolexyne
 reagent-desc-agonolexyne = An incredibly potent and fast acting opioid invented to speed up the application of painkillers during surgery. Stops you from feeling pain (or really anything at all). Interacts poorly with alcohol. Known to be very addictive. Overdose may relax the lungs to the point of non-function.
 
-reagent-name-saphrodipine = Saprodipine
-reagent-desc-saphrodipine = A commonly used anti-psychotic with minimal side-effects. Typically used to treat hallucinations. Side effects include fatigue.
+reagent-name-saprodipine = Saprodipine
+reagent-desc-saprodipine = A commonly used anti-psychotic with minimal side-effects. Typically used to treat hallucinations. Side effects include fatigue.

--- a/Resources/Locale/en-US/_CD/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_CD/reagents/meta/medicine.ftl
@@ -17,7 +17,7 @@ reagent-name-equilibrazine = Equilibrazine
 reagent-desc-equilibrazine = A Nanotrasen engineered chemical recipe designed to keep workers working with only small doses. It didn't make the cut, but it functions as a potent treatment for anxiety and panic attacks. Can be taken fine with alcohol, but is wildly incompatible with most antidepressants.
 
 reagent-name-addictine = addictine
-reagent-desc-addictine = A chemical produced by the body when metabolizing certain medications. Causes symptoms of withdrawl. Neutralizes bloodstream cleansers like charcoal and ipecac. 
+reagent-desc-addictine = A chemical produced by the body when metabolizing certain medications. Causes symptoms of withdrawl. Neutralizes bloodstream cleansers like charcoal and ipecac.
 
 reagent-name-stubantazine = Stubantazine
 reagent-desc-stubantazine = A mild painkiller commonly used to treat brief stents of pain, though it lasts a little while for good measure. Overdose or consumption of alcohol may cause vomiting and digestion inefficiency.
@@ -27,3 +27,6 @@ reagent-desc-soretizone = A fairly effective painkiller developed to treat chron
 
 reagent-name-agonolexyne = Agonolexyne
 reagent-desc-agonolexyne = An incredibly potent and fast acting opioid invented to speed up the application of painkillers during surgery. Stops you from feeling pain (or really anything at all). Interacts poorly with alcohol. Known to be very addictive. Overdose may relax the lungs to the point of non-function.
+
+reagent-name-saphrodipine = Saprodipine
+reagent-desc-saphrodipine = A commonly used anti-psychotic with minimal side-effects. Typically used to treat hallucinations. Side effects include fatigue.

--- a/Resources/Prototypes/_CD/Reactions/medicine.yml
+++ b/Resources/Prototypes/_CD/Reactions/medicine.yml
@@ -122,3 +122,14 @@
       catalyst: true
   products:
     Agonolexyne: 3
+
+- type: reaction
+  id: Saprodipine
+  minTemp: 350
+  reactants:
+    Stellibinin:
+      amount: 1
+    Synaptizine:
+      amount: 1
+  products:
+    Saprodipine: 2

--- a/Resources/Prototypes/_CD/Reagents/medicine.yml
+++ b/Resources/Prototypes/_CD/Reagents/medicine.yml
@@ -730,6 +730,10 @@
           - "reagent-effect-antipsych-normal4"
           - "reagent-effect-antipsych-normal5"
         probability: 0.085
+      - !type:ResetParacusia
+        conditions:
+        - !type:ReagentThreshold
+          min: 10
       - !type:MovespeedModifier
         probability: 0.3
         conditions:

--- a/Resources/Prototypes/_CD/Reagents/medicine.yml
+++ b/Resources/Prototypes/_CD/Reagents/medicine.yml
@@ -87,7 +87,7 @@
         - !type:ReagentThreshold
           reagent: Ethanol # Alcohol makes it really easy to overdose by increasing your body's absorption of the medicine.
           min: 1
-        reagent: Neurozenium 
+        reagent: Neurozenium
         amount: 0.15
       - !type:AdjustReagent
         conditions:
@@ -163,10 +163,10 @@
           min: 5.1
       - !type:GenericStatusEffect
         conditions:
-        - !type:ReagentThreshold 
+        - !type:ReagentThreshold
           min: 5.1
         key: SeeingRainbows # hallucinations set in after 40 seconds, meaning ~0.40u overdose untreated.
-        component: SeeingRainbows 
+        component: SeeingRainbows
         type: Add
         time: 1.1
         refresh: false
@@ -175,7 +175,7 @@
         - !type:ReagentThreshold
           reagent: Ethanol # Alcohol makes it really easy to overdose by increasing your body's absorption of the medicine.
           min: 1
-        reagent: Blissifylovene 
+        reagent: Blissifylovene
         amount: 0.15
       - !type:AdjustReagent
         conditions:
@@ -536,7 +536,7 @@
       - !type:SatiateHunger # causes digestion inefficiency during overdose
         factor: -1.2
         conditions:
-          - !type:ReagentThreshold 
+          - !type:ReagentThreshold
             min: 14
       - !type:ChemVomit
         probability: 0.8
@@ -547,7 +547,7 @@
       - !type:SatiateHunger # causes digestion inefficiency if you drink alcohol
         factor: -2.0
         conditions:
-          - !type:ReagentThreshold 
+          - !type:ReagentThreshold
             reagent: Ethanol
             min: 2
       - !type:PopupMessage
@@ -707,4 +707,51 @@
         conditions:
           - !type:ReagentThreshold
             max: 0.1
-          
+
+- type: reagent
+  id: Saprodipine
+  name: reagent-name-saphrodipine
+  group: Medicine
+  desc: reagent-desc-saphrodipine
+  physicalDesc: reagent-physical-desc-foamy
+  flavor: medicine
+  color: "#45B1A7"
+  metabolisms:
+    Medicine:
+      metabolismRate : 0.01
+      effects:
+      - !type:PopupMessage
+        type: Local
+        visualType: Large
+        messages:
+          - "reagent-effect-antipsych-normal1"
+          - "reagent-effect-antipsych-normal2"
+          - "reagent-effect-antipsych-normal3"
+          - "reagent-effect-antipsych-normal4"
+          - "reagent-effect-antipsych-normal5"
+        probability: 0.085
+      - !type:MovespeedModifier
+        probability: 0.3
+        conditions:
+        - !type:ReagentThreshold
+          min: 10.1 # Slight overdose slows you down a bit
+        walkSpeedModifier: 0.85
+        sprintSpeedModifier: 0.75
+      - !type:GenericStatusEffect
+        probability: 0.1
+        conditions:
+        - !type:ReagentThreshold
+          min: 20 # taking far too much has a chance to knock you out
+        key: ForcedSleep
+        component: ForcedSleeping
+        refresh: false
+        type: Add
+      - !type:PopupMessage
+        type: Local
+        visualType: Medium
+        messages:
+          - "reagent-effect-antipsych-fade" # A decent chance to notify the player when their meds run out
+        probability: 0.5
+        conditions:
+          - !type:ReagentThreshold
+            max: 0.1

--- a/Resources/Prototypes/_CD/Reagents/medicine.yml
+++ b/Resources/Prototypes/_CD/Reagents/medicine.yml
@@ -710,9 +710,9 @@
 
 - type: reagent
   id: Saprodipine
-  name: reagent-name-saphrodipine
+  name: reagent-name-saprodipine
   group: Medicine
-  desc: reagent-desc-saphrodipine
+  desc: reagent-desc-saprodipine
   physicalDesc: reagent-physical-desc-foamy
   flavor: medicine
   color: "#45B1A7"
@@ -730,6 +730,23 @@
           - "reagent-effect-antipsych-normal4"
           - "reagent-effect-antipsych-normal5"
         probability: 0.085
+        conditions:
+        - !type:ReagentThreshold
+          max: 10.1
+      - !type:PopupMessage
+        type: Local
+        visualType: LargeCaution
+        messages:
+          - "reagent-effect-anxietymed-normaloverdose1" # overdose makes you tired and forgetful
+          - "reagent-effect-anxietymed-normaloverdose2"
+          - "reagent-effect-anxietymed-normaloverdose3"
+          - "reagent-effect-anxietymed-normaloverdose4"
+          - "reagent-effect-anxietymed-normaloverdose5"
+          - "reagent-effect-anxietymed-normaloverdose6"
+        probability: 0.06
+        conditions:
+        - !type:ReagentThreshold
+          min: 10.1
       - !type:ResetParacusia
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
 We have been using various mixes of chemicals for an RP anti-psychotic for quite some time. This turns the most common mix we use into an actual chemical.  It also suppresses paracusia in almost the same way Diphenylmethylamine suppresses narcolepsy as I figured it was appropriate.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Should not really affect game balance in any way as it is an RP chem. Technically it is possible to put someone to sleep with it's overdose but chloral hydrate is a far more effective solution.

The name Saphrodipine was chosen mostly at random. I wanted to avoid using the name Haloperidol (what we have been using for this mixture IC) because it is apparently a real medication and I figure it is best to avoid such things.

## Technical details
The chem functions basically the same the other RP chems. To be able to suppress paracusia I added the ResetParacusia reagent effect which required modifications to ParacusiaComponent to sync the delay to the client because paracusia is mostly handled client side.  

## Media
![guidebook](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/57052305/a5e1f8e7-d57e-4372-b645-d2786c04f0d0)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog** 
(please credit to aquif)

:cl:
- add: Saphrodipine an anti-psychotic RP chem. Also suppresses paracusia. 
