### PR TITLE
Extend Round End Time

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -333,10 +333,10 @@ namespace Content.Shared.CCVar
 
         /// <summary>
         /// The time in seconds that the server should wait before restarting the round.
-        /// Defaults to 2 minutes.
+        /// Defaults to 5 minutes. CD change from 2 to 5 because the Cvar doesn't work.
         /// </summary>
         public static readonly CVarDef<float> RoundRestartTime =
-            CVarDef.Create("game.round_restart_time", 120f, CVar.SERVERONLY);
+            CVarDef.Create("game.round_restart_time", 300f, CVar.SERVERONLY);
 
         /// <summary>
         /// Respawn time, how long the player has to wait in seconds after death.


### PR DESCRIPTION
## About the PR
Changes the default round end time from 2 minutes to 5 to give more time to tie up RP ends.

## Why / Balance
Feels like a good number, enough time to settle down but not too long that it's obnoxious. I've done this manually several times here and on Upstream, people seem to like it.

## Technical details
Changes the default of the Cvar instead of using the Cvar because the Cvar was last known to crash servers at round end.

**Changelog**
The delay from when the round ends to when the game is returned to the lobby has been upped from 2 to 5 minutes.