### PR TITLE
Larger Character Descriptions

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -25,7 +25,7 @@ namespace Content.Shared.Preferences
     public sealed partial class HumanoidCharacterProfile : ICharacterProfile
     {
         public const int MaxNameLength = 32;
-        public const int MaxDescLength = 2048; // CosmaticDrift-LargerCharacterDescriptions // Was 512
+        public const int MaxDescLength = 1024; // CosmaticDrift-LargerCharacterDescriptions // Was 512
 
         private readonly Dictionary<string, JobPriority> _jobPriorities;
         private readonly List<string> _antagPreferences;

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -25,7 +25,7 @@ namespace Content.Shared.Preferences
     public sealed partial class HumanoidCharacterProfile : ICharacterProfile
     {
         public const int MaxNameLength = 32;
-        public const int MaxDescLength = 512;
+        public const int MaxDescLength = 2048; // CosmaticDrift-LargerCharacterDescriptions // Was 512
 
         private readonly Dictionary<string, JobPriority> _jobPriorities;
         private readonly List<string> _antagPreferences;


### PR DESCRIPTION
# About the PR

Changed the limit on character descriptions from 512 to 1024 characters.

# Why / Balance

512 characters is not a very large amount, especially for an HRP server.

# Changelog

:cl:
- tweak: Character descriptions can now be up to 1024 chars in length
