### PR TITLE
Remove Senior Officers Roundstart Secglasses

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
@@ -26,7 +26,7 @@
     jumpsuit: ClothingUniformJumpsuitSeniorOfficer
     back: ClothingBackpackSecurityFilled
     shoes: ClothingShoesBootsCombatFilled
-    eyes: ClothingEyesGlassesSecurity
+    eyes: ClothingEyesGlassesSunglasses
     head: ClothingHeadHatBeretSecurity
     outerClothing: ClothingOuterArmorBasic
     id: SeniorOfficerPDA


### PR DESCRIPTION
## About the PR
The senior officer role now spawns with sunglasses instead of security sunglasses.

## Why / Balance
Secglasses are meant to be a T2 research and have been removed from the roundstart kits of the rest of security. SO's got overlooked due to the nature of how we have been reverting their removal.

**Changelog**
tweak: Senior Officers now spawn with sunglasses instead of security sunglasses, this brings them in line with the rest of roundstart security.
