### PR TITLE
Disable Clerical and Terminator Events

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -55,17 +55,17 @@
     # duration: 1
   # - type: BureaucraticErrorRule
 
-- type: entity
-  id: ClericalError
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-clerical-error-announcement
-    minimumPlayers: 15
-    weight: 5
-    duration: 1
-  - type: ClericalErrorRule
+# - type: entity
+  # id: ClericalError
+  # parent: BaseGameRule
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # startAnnouncement: station-event-clerical-error-announcement
+    # minimumPlayers: 15
+    # weight: 5
+    # duration: 1
+  # - type: ClericalErrorRule
 
 - type: entity
   parent: BaseGameRule
@@ -283,18 +283,18 @@
     lightBreakChancePerSecond: 0.0003
     doorToggleChancePerSecond: 0.001
 
-- type: entity
-  parent: BaseGameRule
-  id: TerminatorSpawn
-  noSpawn: true
-  components:
-  - type: StationEvent
-    weight: 8
-    duration: 1
-    earliestStart: 30
-    minimumPlayers: 20
-  - type: RandomSpawnRule
-    prototype: SpawnPointGhostTerminator
+# - type: entity
+  # parent: BaseGameRule
+  # id: TerminatorSpawn
+  # noSpawn: true
+  # components:
+  # - type: StationEvent
+    # weight: 8
+    # duration: 1
+    # earliestStart: 30
+    # minimumPlayers: 20
+  # - type: RandomSpawnRule
+    # prototype: SpawnPointGhostTerminator
 
 - type: entity
   id: VentClog


### PR DESCRIPTION
## About the PR
Disables the terminator and clerical error events. (And probably doesn't fail tests.)

## Why / Balance
Terminator is a obvious since it's whole goal is to perma kill someone.
Clerical Error could be a up for a bit more debate, given it's nothing major but if I recall correctly we were leaning towards wanting to disable this one.