### PR TITLE
Ferrous Update

### DIFF
--- a/Resources/Maps/_CD/ferrous.yml
+++ b/Resources/Maps/_CD/ferrous.yml
@@ -11850,13 +11850,9 @@ entities:
   entities:
   - uid: 12866
     components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 12865
+    - pos: 20.451284,14.26887
+      parent: 2
       type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: BedsheetCMO
   entities:
   - uid: 11261
@@ -11930,13 +11926,9 @@ entities:
   entities:
   - uid: 12860
     components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 12859
+    - pos: 20.63184,14.824426
+      parent: 2
       type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: BedsheetQM
   entities:
   - uid: 7455
@@ -40265,9 +40257,13 @@ entities:
   entities:
   - uid: 12858
     components:
-    - pos: 20.470167,14.672701
-      parent: 2
+    - flags: InContainer
+      type: MetaData
+    - parent: 12865
       type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: FoodPieBananaCream
   entities:
   - uid: 12790
@@ -60435,7 +60431,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 12866
+          - 12858
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -60612,17 +60608,6 @@ entities:
         - 0
         - 0
       type: EntityStorage
-    - containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 12860
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-      type: ContainerContainer
 - proto: LockerParamedicFilled
   entities:
   - uid: 7747

--- a/Resources/Maps/_CD/ferrous.yml
+++ b/Resources/Maps/_CD/ferrous.yml
@@ -7590,6 +7590,18 @@ entities:
       type: DeviceList
     - joinedGrid: 2
       type: AtmosDevice
+  - uid: 3524
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -21.5,-8.5
+      parent: 2
+      type: Transform
+    - devices:
+      - 5440
+      - 11025
+      type: DeviceList
+    - joinedGrid: 2
+      type: AtmosDevice
   - uid: 6801
     components:
     - rot: 1.5707963267948966 rad
@@ -8633,19 +8645,6 @@ entities:
       - 9850
       - 9844
       - 9851
-      type: DeviceList
-    - joinedGrid: 2
-      type: AtmosDevice
-  - uid: 11025
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -21.5,-8.5
-      parent: 2
-      type: Transform
-    - devices:
-      - 12852
-      - 11000
-      - 6793
       type: DeviceList
     - joinedGrid: 2
       type: AtmosDevice
@@ -10161,11 +10160,12 @@ entities:
       type: Transform
 - proto: AirlockResearchDirectorLocked
   entities:
-  - uid: 3524
+  - uid: 11000
     components:
     - flags: PvsPriority
       type: MetaData
-    - pos: -21.5,-9.5
+    - rot: -1.5707963267948966 rad
+      pos: -21.5,-9.5
       parent: 2
       type: Transform
 - proto: AirlockSalvageGlassLocked
@@ -11850,9 +11850,13 @@ entities:
   entities:
   - uid: 12866
     components:
-    - pos: 20.451284,14.26887
-      parent: 2
+    - flags: InContainer
+      type: MetaData
+    - parent: 12865
       type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: BedsheetCMO
   entities:
   - uid: 11261
@@ -11926,9 +11930,13 @@ entities:
   entities:
   - uid: 12860
     components:
-    - pos: 20.63184,14.824426
-      parent: 2
+    - flags: InContainer
+      type: MetaData
+    - parent: 12859
       type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: BedsheetQM
   entities:
   - uid: 7455
@@ -27968,11 +27976,6 @@ entities:
     - pos: -18.5,-5.5
       parent: 2
       type: Transform
-  - uid: 5440
-    components:
-    - pos: -21.5,-9.5
-      parent: 2
-      type: Transform
   - uid: 5441
     components:
     - pos: -24.5,-9.5
@@ -38984,16 +38987,6 @@ entities:
     - pos: -26.5,11.5
       parent: 2
       type: Transform
-  - uid: 12852
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -21.5,-9.5
-      parent: 2
-      type: Transform
-    - configurators:
-      deviceLists:
-      - 11025
-      type: DeviceNetwork
 - proto: FirelockEdge
   entities:
   - uid: 3261
@@ -41241,6 +41234,14 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: -19.5,-10.5
+      parent: 2
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 6793
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -22.5,-8.5
       parent: 2
       type: Transform
     - color: '#990000FF'
@@ -55786,19 +55787,6 @@ entities:
       type: AtmosDevice
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 6793
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -23.5,-9.5
-      parent: 2
-      type: Transform
-    - deviceLists:
-      - 11025
-      type: DeviceNetwork
-    - joinedGrid: 2
-      type: AtmosDevice
-    - color: '#0055CCFF'
-      type: AtmosPipeColor
   - uid: 6811
     components:
     - rot: -1.5707963267948966 rad
@@ -56596,6 +56584,19 @@ entities:
       type: AtmosDevice
     - color: '#0055CCFF'
       type: AtmosPipeColor
+  - uid: 11025
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -23.5,-9.5
+      parent: 2
+      type: Transform
+    - deviceLists:
+      - 3524
+      type: DeviceNetwork
+    - joinedGrid: 2
+      type: AtmosDevice
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
   - uid: 12682
     components:
     - pos: -37.5,29.5
@@ -56732,6 +56733,19 @@ entities:
       pos: 9.5,28.5
       parent: 2
       type: Transform
+    - joinedGrid: 2
+      type: AtmosDevice
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 5440
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -23.5,-8.5
+      parent: 2
+      type: Transform
+    - deviceLists:
+      - 3524
+      type: DeviceNetwork
     - joinedGrid: 2
       type: AtmosDevice
     - color: '#990000FF'
@@ -57700,19 +57714,6 @@ entities:
       type: Transform
     - deviceLists:
       - 2648
-      type: DeviceNetwork
-    - joinedGrid: 2
-      type: AtmosDevice
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 11000
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -22.5,-8.5
-      parent: 2
-      type: Transform
-    - deviceLists:
-      - 11025
       type: DeviceNetwork
     - joinedGrid: 2
       type: AtmosDevice
@@ -60431,6 +60432,7 @@ entities:
           occludes: True
           ents:
           - 12858
+          - 12866
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -60607,6 +60609,17 @@ entities:
         - 0
         - 0
       type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 12860
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
 - proto: LockerParamedicFilled
   entities:
   - uid: 7747

--- a/Resources/Maps/_CD/ferrous.yml
+++ b/Resources/Maps/_CD/ferrous.yml
@@ -38990,6 +38990,7 @@ entities:
       pos: -21.5,-9.5
       parent: 2
       type: Transform
+    - configurators:
       deviceLists:
       - 11025
       type: DeviceNetwork

--- a/Resources/Maps/_CD/ferrous.yml
+++ b/Resources/Maps/_CD/ferrous.yml
@@ -38990,8 +38990,6 @@ entities:
       pos: -21.5,-9.5
       parent: 2
       type: Transform
-    - configurators:
-      - invalid
       deviceLists:
       - 11025
       type: DeviceNetwork

--- a/Resources/Maps/_CD/ferrous.yml
+++ b/Resources/Maps/_CD/ferrous.yml
@@ -6853,9 +6853,11 @@ entities:
           -7,-7:
             0: 65535
           -6,-8:
-            0: 65535
+            0: 49151
+            2: 16384
           -6,-7:
-            0: 65535
+            0: 63487
+            3: 2048
           -5,-8:
             0: 65535
           -5,-7:
@@ -6950,7 +6952,7 @@ entities:
             0: 60608
           -14,-5:
             0: 65532
-            2: 3
+            4: 3
           -13,-5:
             0: 65523
           -15,-4:
@@ -7087,10 +7089,10 @@ entities:
             0: 3276
           0,-10:
             0: 4369
-            2: 25088
+            4: 25088
           0,-9:
             0: 29457
-            2: 36078
+            4: 36078
           7,6:
             0: 65535
           13,-6:
@@ -7379,11 +7381,11 @@ entities:
             0: 273
           -14,-6:
             0: 52224
-            2: 13056
+            4: 13056
           -13,-6:
             0: 13056
           1,-9:
-            2: 12288
+            4: 12288
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -7402,6 +7404,36 @@ entities:
           - 0
         - volume: 2500
           temperature: 235
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.6852
+          - 81.57766
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14975
           moles:
           - 21.824879
           - 82.10312
@@ -8622,6 +8654,8 @@ entities:
   entities:
   - uid: 8821
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-30.5
       parent: 2
       type: Transform
@@ -8629,12 +8663,16 @@ entities:
   entities:
   - uid: 17
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 22.5,-3.5
       parent: 2
       type: Transform
   - uid: 72
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 22.5,-8.5
       parent: 2
@@ -8751,6 +8789,8 @@ entities:
   entities:
   - uid: 2363
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,-21.5
       parent: 2
       type: Transform
@@ -8758,6 +8798,8 @@ entities:
   entities:
   - uid: 9607
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,10.5
       parent: 2
       type: Transform
@@ -8773,6 +8815,8 @@ entities:
   entities:
   - uid: 3917
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -17.5,-20.5
       parent: 2
@@ -8797,6 +8841,16 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: 18.5,19.5
+      parent: 2
+      type: Transform
+  - uid: 139
+    components:
+    - pos: 19.5,26.5
+      parent: 2
+      type: Transform
+  - uid: 698
+    components:
+    - pos: 18.5,26.5
       parent: 2
       type: Transform
   - uid: 2636
@@ -8829,31 +8883,25 @@ entities:
       type: Transform
 - proto: AirlockCommandLocked
   entities:
-  - uid: 139
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 18.5,26.5
-      parent: 2
-      type: Transform
-  - uid: 2694
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 19.5,26.5
-      parent: 2
-      type: Transform
   - uid: 3045
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 7.5,30.5
       parent: 2
       type: Transform
   - uid: 8801
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,9.5
       parent: 2
       type: Transform
   - uid: 9872
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 10.5,30.5
       parent: 2
@@ -8937,45 +8985,61 @@ entities:
   entities:
   - uid: 421
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 27.5,-6.5
       parent: 2
       type: Transform
   - uid: 588
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-6.5
       parent: 2
       type: Transform
   - uid: 2087
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -20.5,29.5
       parent: 2
       type: Transform
   - uid: 7532
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -50.5,18.5
       parent: 2
       type: Transform
   - uid: 8796
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,7.5
       parent: 2
       type: Transform
   - uid: 9098
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -53.5,6.5
       parent: 2
       type: Transform
   - uid: 9896
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -44.5,-19.5
       parent: 2
       type: Transform
   - uid: 11204
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-4.5
       parent: 2
       type: Transform
@@ -9128,27 +9192,37 @@ entities:
   entities:
   - uid: 2571
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,6.5
       parent: 2
       type: Transform
   - uid: 2574
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,35.5
       parent: 2
       type: Transform
   - uid: 8973
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,31.5
       parent: 2
       type: Transform
   - uid: 9096
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -54.5,20.5
       parent: 2
       type: Transform
   - uid: 9097
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -54.5,17.5
       parent: 2
@@ -9157,6 +9231,8 @@ entities:
   entities:
   - uid: 160
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-18.5
       parent: 2
       type: Transform
@@ -9501,11 +9577,15 @@ entities:
   entities:
   - uid: 2173
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,21.5
       parent: 2
       type: Transform
   - uid: 2696
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,25.5
       parent: 2
       type: Transform
@@ -9534,6 +9614,8 @@ entities:
   entities:
   - uid: 794
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,5.5
       parent: 2
       type: Transform
@@ -9541,12 +9623,16 @@ entities:
   entities:
   - uid: 2302
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 27.5,-19.5
       parent: 2
       type: Transform
   - uid: 2346
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-21.5
       parent: 2
       type: Transform
@@ -9554,12 +9640,16 @@ entities:
   entities:
   - uid: 3752
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -36.5,-21.5
       parent: 2
       type: Transform
   - uid: 3758
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-26.5
       parent: 2
       type: Transform
@@ -9567,6 +9657,8 @@ entities:
   entities:
   - uid: 795
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,10.5
       parent: 2
       type: Transform
@@ -9574,12 +9666,16 @@ entities:
   entities:
   - uid: 201
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 15.5,-21.5
       parent: 2
       type: Transform
   - uid: 241
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-19.5
       parent: 2
       type: Transform
@@ -9587,175 +9683,239 @@ entities:
   entities:
   - uid: 762
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-8.5
       parent: 2
       type: Transform
   - uid: 773
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,1.5
       parent: 2
       type: Transform
   - uid: 1264
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -10.5,34.5
       parent: 2
       type: Transform
   - uid: 1265
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -10.5,35.5
       parent: 2
       type: Transform
   - uid: 1266
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,34.5
       parent: 2
       type: Transform
   - uid: 1267
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,35.5
       parent: 2
       type: Transform
   - uid: 2167
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -23.5,14.5
       parent: 2
       type: Transform
   - uid: 2529
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-24.5
       parent: 2
       type: Transform
   - uid: 2615
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 14.5,-2.5
       parent: 2
       type: Transform
   - uid: 2775
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-15.5
       parent: 2
       type: Transform
   - uid: 3312
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-2.5
       parent: 2
       type: Transform
   - uid: 3722
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -4.5,-14.5
       parent: 2
       type: Transform
   - uid: 3731
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -41.5,-16.5
       parent: 2
       type: Transform
   - uid: 4758
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,-25.5
       parent: 2
       type: Transform
   - uid: 4759
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-26.5
       parent: 2
       type: Transform
   - uid: 8887
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -39.5,-12.5
       parent: 2
       type: Transform
   - uid: 8989
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,29.5
       parent: 2
       type: Transform
   - uid: 9021
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -50.5,5.5
       parent: 2
       type: Transform
   - uid: 9355
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -12.5,-5.5
       parent: 2
       type: Transform
   - uid: 9455
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 25.5,13.5
       parent: 2
       type: Transform
   - uid: 9456
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 36.5,5.5
       parent: 2
       type: Transform
   - uid: 9549
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,1.5
       parent: 2
       type: Transform
   - uid: 9577
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,6.5
       parent: 2
       type: Transform
   - uid: 9578
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,1.5
       parent: 2
       type: Transform
   - uid: 9579
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-6.5
       parent: 2
       type: Transform
   - uid: 10672
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-7.5
       parent: 2
       type: Transform
   - uid: 10812
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -24.5,19.5
       parent: 2
       type: Transform
   - uid: 10854
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,-5.5
       parent: 2
       type: Transform
   - uid: 11147
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,-23.5
       parent: 2
       type: Transform
   - uid: 11193
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-11.5
       parent: 2
       type: Transform
   - uid: 11555
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-1.5
       parent: 2
       type: Transform
   - uid: 12518
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 6.5,13.5
       parent: 2
@@ -9764,18 +9924,24 @@ entities:
   entities:
   - uid: 9089
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -48.5,11.5
       parent: 2
       type: Transform
   - uid: 9090
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -49.5,17.5
       parent: 2
       type: Transform
   - uid: 10784
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,11.5
       parent: 2
       type: Transform
@@ -9783,6 +9949,8 @@ entities:
   entities:
   - uid: 9252
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,-3.5
       parent: 2
       type: Transform
@@ -9790,18 +9958,24 @@ entities:
   entities:
   - uid: 556
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 33.5,-3.5
       parent: 2
       type: Transform
   - uid: 9815
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -20.5,11.5
       parent: 2
       type: Transform
   - uid: 9816
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -20.5,12.5
       parent: 2
@@ -9810,6 +9984,8 @@ entities:
   entities:
   - uid: 2682
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 20.5,10.5
       parent: 2
@@ -9895,18 +10071,24 @@ entities:
   entities:
   - uid: 9025
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -46.5,9.5
       parent: 2
       type: Transform
   - uid: 9176
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -41.5,12.5
       parent: 2
       type: Transform
   - uid: 9214
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -43.5,16.5
       parent: 2
       type: Transform
@@ -9921,6 +10103,8 @@ entities:
   entities:
   - uid: 7453
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -49.5,-12.5
       parent: 2
       type: Transform
@@ -9935,6 +10119,8 @@ entities:
   entities:
   - uid: 3524
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-9.5
       parent: 2
       type: Transform
@@ -9983,11 +10169,15 @@ entities:
   entities:
   - uid: 3481
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-6.5
       parent: 2
       type: Transform
   - uid: 3503
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,-3.5
       parent: 2
@@ -10080,11 +10270,15 @@ entities:
   entities:
   - uid: 12215
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -54.5,-21.5
       parent: 2
       type: Transform
   - uid: 12220
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -53.5,-21.5
       parent: 2
       type: Transform
@@ -10629,54 +10823,9 @@ entities:
     - pos: -21.5,-26.5
       parent: 2
       type: Transform
-- proto: AmePart
+- proto: AmeJar
   entities:
-  - uid: 698
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 3812
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
   - uid: 699
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 3812
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-  - uid: 700
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 3812
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-  - uid: 701
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 3812
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-  - uid: 702
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 3812
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
-  - uid: 703
     components:
     - flags: InContainer
       type: MetaData
@@ -11850,56 +11999,78 @@ entities:
   entities:
   - uid: 388
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-3.5
       parent: 2
       type: Transform
   - uid: 409
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-3.5
       parent: 2
       type: Transform
   - uid: 413
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-5.5
       parent: 2
       type: Transform
   - uid: 2218
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,27.5
       parent: 2
       type: Transform
   - uid: 2718
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,25.5
       parent: 2
       type: Transform
   - uid: 2857
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,29.5
       parent: 2
       type: Transform
   - uid: 3109
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-5.5
       parent: 2
       type: Transform
   - uid: 3441
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-8.5
       parent: 2
       type: Transform
   - uid: 3442
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 4.5,-8.5
       parent: 2
       type: Transform
   - uid: 3443
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-8.5
       parent: 2
       type: Transform
   - uid: 8500
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,28.5
       parent: 2
       type: Transform
@@ -28987,9 +29158,9 @@ entities:
       type: Transform
 - proto: CaptainIDCard
   entities:
-  - uid: 2638
+  - uid: 2694
     components:
-    - pos: 25.490566,24.606686
+    - pos: 25.49681,25.401386
       parent: 2
       type: Transform
 - proto: CarbonDioxideCanister
@@ -31288,6 +31459,13 @@ entities:
     - pos: -24.5,-2.5
       parent: 2
       type: Transform
+- proto: CleanerDispenser
+  entities:
+  - uid: 701
+    components:
+    - pos: 8.5,10.5
+      parent: 2
+      type: Transform
 - proto: ClosetBase
   entities:
   - uid: 212
@@ -32492,6 +32670,33 @@ entities:
     - links:
       - 7535
       type: DeviceLinkSink
+  - uid: 1152
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 21.5,-27.5
+      parent: 2
+      type: Transform
+    - links:
+      - 4767
+      type: DeviceLinkSink
+  - uid: 1200
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 22.5,-27.5
+      parent: 2
+      type: Transform
+    - links:
+      - 4767
+      type: DeviceLinkSink
+  - uid: 2325
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 23.5,-27.5
+      parent: 2
+      type: Transform
+    - links:
+      - 4767
+      type: DeviceLinkSink
   - uid: 2730
     components:
     - rot: 3.141592653589793 rad
@@ -32570,7 +32775,7 @@ entities:
       parent: 2
       type: Transform
     - links:
-      - 4757
+      - 4767
       type: DeviceLinkSink
   - uid: 4741
     components:
@@ -32578,7 +32783,7 @@ entities:
       parent: 2
       type: Transform
     - links:
-      - 4757
+      - 4767
       type: DeviceLinkSink
   - uid: 4742
     components:
@@ -32586,7 +32791,7 @@ entities:
       parent: 2
       type: Transform
     - links:
-      - 4757
+      - 4767
       type: DeviceLinkSink
   - uid: 4743
     components:
@@ -32595,7 +32800,7 @@ entities:
       parent: 2
       type: Transform
     - links:
-      - 4757
+      - 4767
       type: DeviceLinkSink
   - uid: 4744
     components:
@@ -32604,7 +32809,7 @@ entities:
       parent: 2
       type: Transform
     - links:
-      - 4757
+      - 4767
       type: DeviceLinkSink
   - uid: 4745
     components:
@@ -32612,7 +32817,7 @@ entities:
       parent: 2
       type: Transform
     - links:
-      - 4757
+      - 4767
       type: DeviceLinkSink
   - uid: 4746
     components:
@@ -32621,16 +32826,7 @@ entities:
       parent: 2
       type: Transform
     - links:
-      - 4757
-      type: DeviceLinkSink
-  - uid: 4747
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 21.5,-27.5
-      parent: 2
-      type: Transform
-    - links:
-      - 4757
+      - 4767
       type: DeviceLinkSink
   - uid: 5109
     components:
@@ -32760,17 +32956,13 @@ entities:
     - pos: 6.5,-23.5
       parent: 2
       type: Transform
-- proto: CrateEngineeringAMEJar
-  entities:
-  - uid: 2325
-    components:
-    - pos: -20.5,-25.5
-      parent: 2
-      type: Transform
 - proto: CrateEngineeringAMEShielding
   entities:
   - uid: 3812
     components:
+    - desc: Enough Supplies To Set Up A Basic AME Core
+      name: Antimator Reactor Supplies
+      type: MetaData
     - pos: -21.5,-28.5
       parent: 2
       type: Transform
@@ -32779,8 +32971,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
+        - 1.8856695
+        - 7.0937095
         - 0
         - 0
         - 0
@@ -32797,12 +32989,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 698
           - 699
-          - 700
-          - 701
-          - 702
-          - 703
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -32810,9 +32997,9 @@ entities:
       type: ContainerContainer
 - proto: CrateEngineeringCableBulk
   entities:
-  - uid: 3926
+  - uid: 4701
     components:
-    - pos: -24.5,-17.5
+    - pos: -27.5,-20.5
       parent: 2
       type: Transform
   - uid: 10104
@@ -32903,9 +33090,9 @@ entities:
     - pos: 25.5,27.5
       parent: 2
       type: Transform
-- proto: CrateSecurityRiot
+- proto: CrateSecuritySupplies
   entities:
-  - uid: 1152
+  - uid: 930
     components:
     - pos: -3.5,19.5
       parent: 2
@@ -33085,6 +33272,255 @@ entities:
     - pos: 13.3097925,-1.573564
       parent: 2
       type: Transform
+- proto: DefaultStationBeacon
+  entities:
+  - uid: 12814
+    components:
+    - pos: -66.5,4.5
+      parent: 2
+      type: Transform
+    - text: Evacuation
+      type: NavMapBeacon
+    - location: Evac
+      type: WarpPoint
+- proto: DefaultStationBeaconAISatellite
+  entities:
+  - uid: 12838
+    components:
+    - pos: 52.5,29.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconAME
+  entities:
+  - uid: 12837
+    components:
+    - pos: -21.5,-27.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconArmory
+  entities:
+  - uid: 12836
+    components:
+    - pos: -8.5,27.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconArrivals
+  entities:
+  - uid: 12055
+    components:
+    - pos: 46.5,-5.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconArtifactLab
+  entities:
+  - uid: 12046
+    components:
+    - pos: -33.5,-9.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconBar
+  entities:
+  - uid: 12829
+    components:
+    - pos: 13.5,-9.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconBridge
+  entities:
+  - uid: 12834
+    components:
+    - pos: 20.5,31.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconBrig
+  entities:
+  - uid: 12833
+    components:
+    - pos: -3.5,11.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconCaptainsQuarters
+  entities:
+  - uid: 12830
+    components:
+    - pos: 22.5,21.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconCERoom
+  entities:
+  - uid: 3880
+    components:
+    - pos: -19.5,-18.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconCMORoom
+  entities:
+  - uid: 12831
+    components:
+    - pos: -46.5,28.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconDisposals
+  entities:
+  - uid: 12828
+    components:
+    - pos: 17.5,-27.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconEngineering
+  entities:
+  - uid: 12826
+    components:
+    - pos: -9.5,-19.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconEVAStorage
+  entities:
+  - uid: 12827
+    components:
+    - pos: 6.5,27.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconGravGen
+  entities:
+  - uid: 12050
+    components:
+    - pos: -33.5,-25.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconHOPOffice
+  entities:
+  - uid: 12825
+    components:
+    - pos: 11.5,23.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconHOSRoom
+  entities:
+  - uid: 12823
+    components:
+    - pos: -16.5,21.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconJanitorsCloset
+  entities:
+  - uid: 12824
+    components:
+    - pos: 9.5,8.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconLawOffice
+  entities:
+  - uid: 12822
+    components:
+    - pos: -19.5,7.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconLibrary
+  entities:
+  - uid: 12821
+    components:
+    - pos: 2.5,-2.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconMedbay
+  entities:
+  - uid: 12820
+    components:
+    - pos: -35.5,19.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconMedical
+  entities:
+  - uid: 12819
+    components:
+    - pos: -31.5,7.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconMorgue
+  entities:
+  - uid: 4768
+    components:
+    - pos: -44.5,12.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconPermaBrig
+  entities:
+  - uid: 12818
+    components:
+    - pos: -12.5,41.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconQMRoom
+  entities:
+  - uid: 12816
+    components:
+    - pos: -52.5,-12.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconRDRoom
+  entities:
+  - uid: 12815
+    components:
+    - pos: -18.5,-9.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconSalvage
+  entities:
+  - uid: 12813
+    components:
+    - pos: -54.5,-16.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconScience
+  entities:
+  - uid: 12812
+    components:
+    - pos: -17.5,-1.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconSecurity
+  entities:
+  - uid: 12056
+    components:
+    - pos: -9.5,7.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconService
+  entities:
+  - uid: 12835
+    components:
+    - pos: 10.5,-13.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconSupply
+  entities:
+  - uid: 12054
+    components:
+    - pos: -50.5,-5.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconTechVault
+  entities:
+  - uid: 8508
+    components:
+    - pos: 28.5,7.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconTelecoms
+  entities:
+  - uid: 12051
+    components:
+    - pos: -29.5,-32.5
+      parent: 2
+      type: Transform
+- proto: DefaultStationBeaconVault
+  entities:
+  - uid: 12052
+    components:
+    - pos: 29.5,17.5
+      parent: 2
+      type: Transform
 - proto: DefibrillatorCabinetFilled
   entities:
   - uid: 1090
@@ -33201,12 +33637,6 @@ entities:
   - uid: 4403
     components:
     - pos: 25.5,-24.5
-      parent: 2
-      type: Transform
-  - uid: 4768
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 23.5,-27.5
       parent: 2
       type: Transform
   - uid: 4769
@@ -33907,12 +34337,6 @@ entities:
   - uid: 4442
     components:
     - pos: -9.5,-16.5
-      parent: 2
-      type: Transform
-  - uid: 4767
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 22.5,-27.5
       parent: 2
       type: Transform
   - uid: 4770
@@ -36558,16 +36982,16 @@ entities:
       pos: -8.5,-25.5
       parent: 2
       type: Transform
+  - uid: 3921
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 23.5,-27.5
+      parent: 2
+      type: Transform
   - uid: 3967
     components:
     - rot: -1.5707963267948966 rad
       pos: -23.5,-30.5
-      parent: 2
-      type: Transform
-  - uid: 4765
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 21.5,-27.5
       parent: 2
       type: Transform
   - uid: 4798
@@ -36898,11 +37322,60 @@ entities:
     - pos: 23.5,22.5
       parent: 2
       type: Transform
+- proto: DresserCaptainFilled
+  entities:
+  - uid: 4747
+    components:
+    - pos: 25.5,24.5
+      parent: 2
+      type: Transform
+- proto: DresserChiefEngineerFilled
+  entities:
+  - uid: 4757
+    components:
+    - pos: -19.5,-17.5
+      parent: 2
+      type: Transform
+- proto: DresserChiefMedicalOfficerFilled
+  entities:
+  - uid: 2638
+    components:
+    - pos: -46.5,26.5
+      parent: 2
+      type: Transform
 - proto: DresserFilled
   entities:
   - uid: 11547
     components:
     - pos: 27.5,-0.5
+      parent: 2
+      type: Transform
+- proto: DresserHeadOfPersonnelFilled
+  entities:
+  - uid: 4765
+    components:
+    - pos: 7.5,22.5
+      parent: 2
+      type: Transform
+- proto: DresserHeadOfSecurityFilled
+  entities:
+  - uid: 11270
+    components:
+    - pos: -17.5,23.5
+      parent: 2
+      type: Transform
+- proto: DresserQuarterMasterFilled
+  entities:
+  - uid: 12047
+    components:
+    - pos: -51.5,-13.5
+      parent: 2
+      type: Transform
+- proto: DresserWardenFilled
+  entities:
+  - uid: 4049
+    components:
+    - pos: -15.5,17.5
       parent: 2
       type: Transform
 - proto: DrinkBloodyMaryGlass
@@ -59074,6 +59547,8 @@ entities:
   entities:
   - uid: 1199
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,28.5
       parent: 2
       type: Transform
@@ -59081,16 +59556,22 @@ entities:
   entities:
   - uid: 2791
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,17.5
       parent: 2
       type: Transform
   - uid: 2792
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,16.5
       parent: 2
       type: Transform
   - uid: 10869
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 55.5,29.5
       parent: 2
@@ -59111,6 +59592,8 @@ entities:
   entities:
   - uid: 1055
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -19.5,23.5
       parent: 2
@@ -59624,40 +60107,11 @@ entities:
       type: Transform
 - proto: LockerChiefMedicalOfficerFilledHardsuit
   entities:
-  - uid: 11263
+  - uid: 3927
     components:
-    - pos: -46.5,26.5
+    - pos: -47.5,27.5
       parent: 2
       type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 75.31249
-        moles:
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
-    - containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 11264
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-      type: ContainerContainer
 - proto: LockerDetectiveFilled
   entities:
   - uid: 1163
@@ -60527,17 +60981,6 @@ entities:
     - pos: -43.4246,30.6963
       parent: 2
       type: Transform
-- proto: MedkitCombatFilled
-  entities:
-  - uid: 11264
-    components:
-    - flags: InContainer
-      type: MetaData
-    - parent: 11263
-      type: Transform
-    - canCollide: False
-      type: Physics
-    - type: InsideEntityStorage
 - proto: MedkitFilled
   entities:
   - uid: 1019
@@ -60984,11 +61427,6 @@ entities:
       type: Transform
 - proto: PhoneInstrument
   entities:
-  - uid: 3927
-    components:
-    - pos: -19.481844,-17.436829
-      parent: 2
-      type: Transform
   - uid: 8832
     components:
     - pos: 24.489698,21.994608
@@ -61004,11 +61442,6 @@ entities:
     - pos: -18.561308,21.37533
       parent: 2
       type: Transform
-  - uid: 9861
-    components:
-    - pos: 7.5522485,22.635082
-      parent: 2
-      type: Transform
   - uid: 9863
     components:
     - pos: -18.724312,-11.28549
@@ -61017,6 +61450,16 @@ entities:
   - uid: 9864
     components:
     - pos: -52.497658,-11.334412
+      parent: 2
+      type: Transform
+  - uid: 11132
+    components:
+    - pos: 7.4550486,22.84055
+      parent: 2
+      type: Transform
+  - uid: 11263
+    components:
+    - pos: -17.016287,-16.443111
       parent: 2
       type: Transform
   - uid: 11266
@@ -61038,6 +61481,11 @@ entities:
       type: Transform
 - proto: PinpointerNuclear
   entities:
+  - uid: 700
+    components:
+    - pos: 30.64466,15.580786
+      parent: 2
+      type: Transform
   - uid: 2650
     components:
     - pos: 24.469732,22.544186
@@ -61108,6 +61556,11 @@ entities:
     - pos: -37.5,-22.5
       parent: 2
       type: Transform
+  - uid: 9861
+    components:
+    - pos: -19.5,-21.5
+      parent: 2
+      type: Transform
   - uid: 11611
     components:
     - pos: 28.5,-3.5
@@ -61130,6 +61583,11 @@ entities:
       type: Transform
 - proto: PortableGeneratorPacman
   entities:
+  - uid: 3926
+    components:
+    - pos: -42.5,20.5
+      parent: 2
+      type: Transform
   - uid: 3930
     components:
     - pos: -9.5,-21.5
@@ -61323,1380 +61781,1870 @@ entities:
   entities:
   - uid: 463
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,-41.5
       parent: 2
       type: Transform
   - uid: 471
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-29.5
       parent: 2
       type: Transform
   - uid: 472
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -3.5,-41.5
       parent: 2
       type: Transform
   - uid: 473
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-29.5
       parent: 2
       type: Transform
   - uid: 647
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 39.5,0.5
       parent: 2
       type: Transform
   - uid: 651
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 39.5,-2.5
       parent: 2
       type: Transform
   - uid: 687
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 46.5,0.5
       parent: 2
       type: Transform
   - uid: 721
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -11.5,-41.5
       parent: 2
       type: Transform
   - uid: 771
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -28.5,-20.5
       parent: 2
       type: Transform
   - uid: 2430
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-14.5
       parent: 2
       type: Transform
   - uid: 2431
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-14.5
       parent: 2
       type: Transform
   - uid: 2432
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 34.5,-18.5
       parent: 2
       type: Transform
   - uid: 2433
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 29.5,-18.5
       parent: 2
       type: Transform
   - uid: 2940
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 21.5,29.5
       parent: 2
       type: Transform
   - uid: 2941
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 17.5,29.5
       parent: 2
       type: Transform
   - uid: 3240
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 42.5,-24.5
       parent: 2
       type: Transform
   - uid: 3243
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 46.5,-24.5
       parent: 2
       type: Transform
   - uid: 3244
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 42.5,-19.5
       parent: 2
       type: Transform
   - uid: 3245
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,-19.5
       parent: 2
       type: Transform
   - uid: 3561
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-4.5
       parent: 2
       type: Transform
   - uid: 4224
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,8.5
       parent: 2
       type: Transform
   - uid: 4424
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,8.5
       parent: 2
       type: Transform
   - uid: 4727
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 29.5,-0.5
       parent: 2
       type: Transform
   - uid: 4947
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -9.5,-41.5
       parent: 2
       type: Transform
   - uid: 5079
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -47.5,4.5
       parent: 2
       type: Transform
   - uid: 5095
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -54.5,4.5
       parent: 2
       type: Transform
   - uid: 5108
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -58.5,0.5
       parent: 2
       type: Transform
   - uid: 5785
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -0.5,-34.5
       parent: 2
       type: Transform
   - uid: 6274
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -37.5,-8.5
       parent: 2
       type: Transform
   - uid: 6850
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 27.5,30.5
       parent: 2
       type: Transform
   - uid: 7100
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 10.5,-21.5
       parent: 2
       type: Transform
   - uid: 7495
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -55.5,-17.5
       parent: 2
       type: Transform
   - uid: 7948
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -38.5,18.5
       parent: 2
       type: Transform
   - uid: 7949
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -37.5,15.5
       parent: 2
       type: Transform
   - uid: 8461
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -60.5,8.5
       parent: 2
       type: Transform
   - uid: 8743
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 11.5,29.5
       parent: 2
       type: Transform
   - uid: 8744
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 15.5,29.5
       parent: 2
       type: Transform
   - uid: 9658
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -21.5,-6.5
       parent: 2
       type: Transform
   - uid: 9693
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-16.5
       parent: 2
       type: Transform
   - uid: 9865
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -40.5,13.5
       parent: 2
       type: Transform
   - uid: 9880
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 17.5,21.5
       parent: 2
       type: Transform
   - uid: 9881
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 17.5,24.5
       parent: 2
       type: Transform
   - uid: 9883
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,28.5
       parent: 2
       type: Transform
   - uid: 9884
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 6.5,26.5
       parent: 2
       type: Transform
   - uid: 9887
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,24.5
       parent: 2
       type: Transform
   - uid: 9931
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -54.5,-0.5
       parent: 2
       type: Transform
   - uid: 9932
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -47.5,-0.5
       parent: 2
       type: Transform
   - uid: 9934
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -49.5,-3.5
       parent: 2
       type: Transform
   - uid: 9935
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -55.5,-11.5
       parent: 2
       type: Transform
   - uid: 9936
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -56.5,-3.5
       parent: 2
       type: Transform
   - uid: 9937
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -49.5,-8.5
       parent: 2
       type: Transform
   - uid: 9938
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -54.5,-8.5
       parent: 2
       type: Transform
   - uid: 9939
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -47.5,-16.5
       parent: 2
       type: Transform
   - uid: 9941
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -53.5,-15.5
       parent: 2
       type: Transform
   - uid: 9972
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 35.5,-2.5
       parent: 2
       type: Transform
   - uid: 9973
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,0.5
       parent: 2
       type: Transform
   - uid: 10016
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-2.5
       parent: 2
       type: Transform
   - uid: 10017
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -37.5,-5.5
       parent: 2
       type: Transform
   - uid: 10018
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -31.5,-10.5
       parent: 2
       type: Transform
   - uid: 10019
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -31.5,-7.5
       parent: 2
       type: Transform
   - uid: 10020
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,-5.5
       parent: 2
       type: Transform
   - uid: 10021
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -25.5,-10.5
       parent: 2
       type: Transform
   - uid: 10022
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -29.5,-9.5
       parent: 2
       type: Transform
   - uid: 10023
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -30.5,-1.5
       parent: 2
       type: Transform
   - uid: 10024
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,-1.5
       parent: 2
       type: Transform
   - uid: 10025
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,0.5
       parent: 2
       type: Transform
   - uid: 10026
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -21.5,-2.5
       parent: 2
       type: Transform
   - uid: 10027
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -17.5,-3.5
       parent: 2
       type: Transform
   - uid: 10028
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,0.5
       parent: 2
       type: Transform
   - uid: 10236
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -34.5,-31.5
       parent: 2
       type: Transform
   - uid: 10237
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -34.5,-33.5
       parent: 2
       type: Transform
   - uid: 10238
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-30.5
       parent: 2
       type: Transform
   - uid: 10239
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -29.5,-34.5
       parent: 2
       type: Transform
   - uid: 10242
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -33.5,-28.5
       parent: 2
       type: Transform
   - uid: 10244
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -30.5,-26.5
       parent: 2
       type: Transform
   - uid: 10248
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,-18.5
       parent: 2
       type: Transform
   - uid: 10249
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -25.5,-19.5
       parent: 2
       type: Transform
   - uid: 10252
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -20.5,-18.5
       parent: 2
       type: Transform
   - uid: 10253
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-16.5
       parent: 2
       type: Transform
   - uid: 10254
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -15.5,-19.5
       parent: 2
       type: Transform
   - uid: 10258
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,-21.5
       parent: 2
       type: Transform
   - uid: 10259
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -16.5,-23.5
       parent: 2
       type: Transform
   - uid: 10263
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,-17.5
       parent: 2
       type: Transform
   - uid: 10264
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-17.5
       parent: 2
       type: Transform
   - uid: 10266
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -13.5,-26.5
       parent: 2
       type: Transform
   - uid: 10268
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-21.5
       parent: 2
       type: Transform
   - uid: 10269
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -8.5,-27.5
       parent: 2
       type: Transform
   - uid: 10272
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -7.5,-22.5
       parent: 2
       type: Transform
   - uid: 10275
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -15.5,-27.5
       parent: 2
       type: Transform
   - uid: 10276
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -21.5,-27.5
       parent: 2
       type: Transform
   - uid: 10280
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-22.5
       parent: 2
       type: Transform
   - uid: 10281
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-22.5
       parent: 2
       type: Transform
   - uid: 10282
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -23.5,-24.5
       parent: 2
       type: Transform
   - uid: 10288
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-26.5
       parent: 2
       type: Transform
   - uid: 10289
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -26.5,-28.5
       parent: 2
       type: Transform
   - uid: 10292
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -23.5,-34.5
       parent: 2
       type: Transform
   - uid: 10293
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -23.5,-30.5
       parent: 2
       type: Transform
   - uid: 10303
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -21.5,-32.5
       parent: 2
       type: Transform
   - uid: 10352
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -12.5,40.5
       parent: 2
       type: Transform
   - uid: 10353
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -10.5,42.5
       parent: 2
       type: Transform
   - uid: 10354
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,45.5
       parent: 2
       type: Transform
   - uid: 10355
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,45.5
       parent: 2
       type: Transform
   - uid: 10356
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -16.5,40.5
       parent: 2
       type: Transform
   - uid: 10358
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,32.5
       parent: 2
       type: Transform
   - uid: 10363
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,31.5
       parent: 2
       type: Transform
   - uid: 10364
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -16.5,30.5
       parent: 2
       type: Transform
   - uid: 10367
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -17.5,25.5
       parent: 2
       type: Transform
   - uid: 10368
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,28.5
       parent: 2
       type: Transform
   - uid: 10370
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -6.5,28.5
       parent: 2
       type: Transform
   - uid: 10371
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -6.5,26.5
       parent: 2
       type: Transform
   - uid: 10372
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -9.5,27.5
       parent: 2
       type: Transform
   - uid: 10376
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,23.5
       parent: 2
       type: Transform
   - uid: 10378
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -18.5,19.5
       parent: 2
       type: Transform
   - uid: 10379
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -16.5,19.5
       parent: 2
       type: Transform
   - uid: 10382
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,23.5
       parent: 2
       type: Transform
   - uid: 10383
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,23.5
       parent: 2
       type: Transform
   - uid: 10384
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -7.5,19.5
       parent: 2
       type: Transform
   - uid: 10385
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -5.5,19.5
       parent: 2
       type: Transform
   - uid: 10392
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -19.5,16.5
       parent: 2
       type: Transform
   - uid: 10393
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -16.5,15.5
       parent: 2
       type: Transform
   - uid: 10394
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,17.5
       parent: 2
       type: Transform
   - uid: 10398
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,17.5
       parent: 2
       type: Transform
   - uid: 10404
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -16.5,7.5
       parent: 2
       type: Transform
   - uid: 10405
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -21.5,7.5
       parent: 2
       type: Transform
   - uid: 10406
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -18.5,6.5
       parent: 2
       type: Transform
   - uid: 10407
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,7.5
       parent: 2
       type: Transform
   - uid: 10409
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,8.5
       parent: 2
       type: Transform
   - uid: 10410
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -9.5,6.5
       parent: 2
       type: Transform
   - uid: 10449
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -11.5,30.5
       parent: 2
       type: Transform
   - uid: 10450
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -11.5,27.5
       parent: 2
       type: Transform
   - uid: 10451
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -11.5,19.5
       parent: 2
       type: Transform
   - uid: 10452
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -15.5,10.5
       parent: 2
       type: Transform
   - uid: 10453
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,13.5
       parent: 2
       type: Transform
   - uid: 10454
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -9.5,10.5
       parent: 2
       type: Transform
   - uid: 10455
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -3.5,8.5
       parent: 2
       type: Transform
   - uid: 10456
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -3.5,11.5
       parent: 2
       type: Transform
   - uid: 10457
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -3.5,14.5
       parent: 2
       type: Transform
   - uid: 10458
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -11.5,15.5
       parent: 2
       type: Transform
   - uid: 10459
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -5.5,15.5
       parent: 2
       type: Transform
   - uid: 10501
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -27.5,7.5
       parent: 2
       type: Transform
   - uid: 10527
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 6.5,-17.5
       parent: 2
       type: Transform
   - uid: 10528
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 12.5,-17.5
       parent: 2
       type: Transform
   - uid: 10532
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-17.5
       parent: 2
       type: Transform
   - uid: 10533
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 20.5,-20.5
       parent: 2
       type: Transform
   - uid: 10534
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 5.5,-14.5
       parent: 2
       type: Transform
   - uid: 10537
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-10.5
       parent: 2
       type: Transform
   - uid: 10538
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 1.5,-12.5
       parent: 2
       type: Transform
   - uid: 10551
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 13.5,-3.5
       parent: 2
       type: Transform
   - uid: 10552
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 7.5,-3.5
       parent: 2
       type: Transform
   - uid: 10556
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-9.5
       parent: 2
       type: Transform
   - uid: 10557
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 23.5,-14.5
       parent: 2
       type: Transform
   - uid: 10558
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 13.5,-14.5
       parent: 2
       type: Transform
   - uid: 10597
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-9.5
       parent: 2
       type: Transform
   - uid: 10613
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -39.5,6.5
       parent: 2
       type: Transform
   - uid: 10619
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -36.5,9.5
       parent: 2
       type: Transform
   - uid: 10620
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -40.5,9.5
       parent: 2
       type: Transform
   - uid: 10639
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -45.5,10.5
       parent: 2
       type: Transform
   - uid: 10641
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -43.5,10.5
       parent: 2
       type: Transform
   - uid: 10642
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -44.5,14.5
       parent: 2
       type: Transform
   - uid: 10643
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -46.5,16.5
       parent: 2
       type: Transform
   - uid: 10648
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,19.5
       parent: 2
       type: Transform
   - uid: 10650
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,16.5
       parent: 2
       type: Transform
   - uid: 10651
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -33.5,18.5
       parent: 2
       type: Transform
   - uid: 10653
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,12.5
       parent: 2
       type: Transform
   - uid: 10654
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,21.5
       parent: 2
       type: Transform
   - uid: 10655
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -29.5,10.5
       parent: 2
       type: Transform
   - uid: 10660
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -42.5,20.5
       parent: 2
       type: Transform
   - uid: 10785
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,11.5
       parent: 2
       type: Transform
   - uid: 10794
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,8.5
       parent: 2
       type: Transform
   - uid: 10844
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-30.5
       parent: 2
       type: Transform
   - uid: 10880
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 58.5,28.5
       parent: 2
       type: Transform
   - uid: 10881
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 58.5,30.5
       parent: 2
       type: Transform
   - uid: 10961
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 28.5,6.5
       parent: 2
       type: Transform
   - uid: 11230
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -33.5,30.5
       parent: 2
       type: Transform
   - uid: 11231
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -32.5,25.5
       parent: 2
       type: Transform
   - uid: 11232
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,28.5
       parent: 2
       type: Transform
   - uid: 11233
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,32.5
       parent: 2
       type: Transform
   - uid: 11234
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,32.5
       parent: 2
       type: Transform
   - uid: 11235
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -39.5,31.5
       parent: 2
       type: Transform
   - uid: 11236
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -44.5,31.5
       parent: 2
       type: Transform
   - uid: 11237
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,31.5
       parent: 2
       type: Transform
   - uid: 11238
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -46.5,26.5
       parent: 2
       type: Transform
   - uid: 11311
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -41.5,-13.5
       parent: 2
       type: Transform
   - uid: 11312
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,-13.5
       parent: 2
       type: Transform
   - uid: 11313
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-13.5
       parent: 2
       type: Transform
   - uid: 11314
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-13.5
       parent: 2
       type: Transform
   - uid: 11315
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-13.5
       parent: 2
       type: Transform
   - uid: 11316
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-13.5
       parent: 2
       type: Transform
   - uid: 11317
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -36.5,-15.5
       parent: 2
       type: Transform
   - uid: 11333
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -13.5,-8.5
       parent: 2
       type: Transform
   - uid: 11334
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -13.5,-2.5
       parent: 2
       type: Transform
   - uid: 11354
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -43.5,-10.5
       parent: 2
       type: Transform
   - uid: 11356
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -43.5,-0.5
       parent: 2
       type: Transform
   - uid: 11357
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -43.5,-5.5
       parent: 2
       type: Transform
   - uid: 11404
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-10.5
       parent: 2
       type: Transform
   - uid: 11405
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,18.5
       parent: 2
       type: Transform
   - uid: 11406
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,18.5
       parent: 2
       type: Transform
   - uid: 11407
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,18.5
       parent: 2
       type: Transform
   - uid: 11408
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 4.5,23.5
       parent: 2
       type: Transform
   - uid: 11409
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,18.5
       parent: 2
       type: Transform
   - uid: 11410
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,18.5
       parent: 2
       type: Transform
   - uid: 11411
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 26.5,15.5
       parent: 2
       type: Transform
   - uid: 11412
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,18.5
       parent: 2
       type: Transform
   - uid: 11413
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 30.5,15.5
       parent: 2
       type: Transform
   - uid: 11434
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 22.5,7.5
       parent: 2
       type: Transform
   - uid: 11435
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 22.5,11.5
       parent: 2
       type: Transform
   - uid: 11437
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 2
       type: Transform
   - uid: 11438
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 2.5,8.5
       parent: 2
       type: Transform
   - uid: 11442
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,4.5
       parent: 2
       type: Transform
   - uid: 11443
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,4.5
       parent: 2
       type: Transform
   - uid: 11444
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-10.5
       parent: 2
       type: Transform
   - uid: 11449
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,4.5
       parent: 2
       type: Transform
   - uid: 11450
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,4.5
       parent: 2
       type: Transform
   - uid: 11451
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,4.5
       parent: 2
       type: Transform
   - uid: 11453
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -62.5,5.5
       parent: 2
       type: Transform
   - uid: 11454
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -62.5,1.5
       parent: 2
       type: Transform
   - uid: 11455
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -67.5,3.5
       parent: 2
       type: Transform
   - uid: 11456
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -67.5,7.5
       parent: 2
       type: Transform
   - uid: 11457
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -63.5,11.5
       parent: 2
       type: Transform
   - uid: 11458
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -66.5,-0.5
       parent: 2
       type: Transform
   - uid: 11463
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -58.5,2.5
       parent: 2
       type: Transform
   - uid: 11489
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,4.5
       parent: 2
       type: Transform
   - uid: 11491
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,4.5
       parent: 2
       type: Transform
   - uid: 11492
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,4.5
       parent: 2
       type: Transform
   - uid: 11498
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,4.5
       parent: 2
       type: Transform
   - uid: 11499
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,4.5
       parent: 2
       type: Transform
   - uid: 11500
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,4.5
       parent: 2
       type: Transform
   - uid: 11517
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 12.5,0.5
       parent: 2
       type: Transform
   - uid: 11518
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,4.5
       parent: 2
       type: Transform
   - uid: 11647
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 21.5,1.5
       parent: 2
       type: Transform
   - uid: 11648
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,4.5
       parent: 2
       type: Transform
   - uid: 11649
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 39.5,-9.5
       parent: 2
       type: Transform
   - uid: 11650
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 39.5,-15.5
       parent: 2
       type: Transform
   - uid: 11651
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 46.5,-12.5
       parent: 2
       type: Transform
   - uid: 11653
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,5.5
       parent: 2
       type: Transform
   - uid: 11688
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -17.5,-41.5
       parent: 2
       type: Transform
   - uid: 11689
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,-31.5
       parent: 2
       type: Transform
   - uid: 11690
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -5.5,-41.5
       parent: 2
       type: Transform
   - uid: 11750
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -12.5,-38.5
       parent: 2
       type: Transform
   - uid: 11766
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -6.5,-38.5
       parent: 2
       type: Transform
   - uid: 11959
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -13.5,-41.5
       parent: 2
       type: Transform
   - uid: 12151
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-35.5
       parent: 2
       type: Transform
   - uid: 12219
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -53.5,-19.5
       parent: 2
       type: Transform
   - uid: 12222
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -54.5,-19.5
       parent: 2
       type: Transform
   - uid: 12793
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -18.5,-32.5
       parent: 2
@@ -62774,6 +63722,12 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: 46.5,-8.5
+      parent: 2
+      type: Transform
+  - uid: 702
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 17.5,-27.5
       parent: 2
       type: Transform
   - uid: 808
@@ -62888,12 +63842,6 @@ entities:
   - uid: 4700
     components:
     - pos: 18.5,-25.5
-      parent: 2
-      type: Transform
-  - uid: 4701
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 18.5,-27.5
       parent: 2
       type: Transform
   - uid: 4702
@@ -64219,11 +65167,6 @@ entities:
       pos: -35.5,-0.5
       parent: 2
       type: Transform
-  - uid: 11132
-    components:
-    - pos: 21.5,-27.5
-      parent: 2
-      type: Transform
   - uid: 11133
     components:
     - pos: 19.5,-26.5
@@ -64430,7 +65373,6 @@ entities:
       parent: 2
       type: Transform
     - links:
-      - 4757
       - 11142
       type: DeviceLinkSink
 - proto: ReinforcedPlasmaWindow
@@ -65855,6 +66797,8 @@ entities:
   entities:
   - uid: 796
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 6.5,7.5
       parent: 2
@@ -65865,6 +66809,8 @@ entities:
       type: DeviceLinkSink
   - uid: 797
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 6.5,8.5
       parent: 2
@@ -65875,21 +66821,29 @@ entities:
       type: DeviceLinkSink
   - uid: 3504
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,1.5
       parent: 2
       type: Transform
   - uid: 3505
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,1.5
       parent: 2
       type: Transform
   - uid: 3506
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,1.5
       parent: 2
       type: Transform
   - uid: 3611
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-10.5
       parent: 2
       type: Transform
@@ -65898,6 +66852,8 @@ entities:
       type: DeviceLinkSink
   - uid: 3617
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-10.5
       parent: 2
       type: Transform
@@ -65906,6 +66862,8 @@ entities:
       type: DeviceLinkSink
   - uid: 3618
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,-10.5
       parent: 2
       type: Transform
@@ -66716,6 +67674,12 @@ entities:
     - pos: -44.5,19.5
       parent: 2
       type: Transform
+  - uid: 12049
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 11.5,8.5
+      parent: 2
+      type: Transform
 - proto: SMESBasic
   entities:
   - uid: 2284
@@ -67110,10 +68074,9 @@ entities:
       type: Transform
 - proto: SpawnMobCat
   entities:
-  - uid: 11270
+  - uid: 12045
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -47.5,27.5
+    - pos: -46.5,28.5
       parent: 2
       type: Transform
 - proto: SpawnMobCorgi
@@ -67711,9 +68674,9 @@ entities:
       type: Transform
 - proto: SuitStorageWarden
   entities:
-  - uid: 930
+  - uid: 11264
     components:
-    - pos: -15.5,17.5
+    - pos: -15.5,15.5
       parent: 2
       type: Transform
 - proto: SurveillanceCameraCommand
@@ -69115,11 +70078,6 @@ entities:
     - pos: -26.5,-20.5
       parent: 2
       type: Transform
-  - uid: 4049
-    components:
-    - pos: -27.5,-20.5
-      parent: 2
-      type: Transform
   - uid: 4200
     components:
     - rot: 1.5707963267948966 rad
@@ -70125,11 +71083,6 @@ entities:
     - pos: 13.5,31.5
       parent: 2
       type: Transform
-  - uid: 2656
-    components:
-    - pos: 25.5,24.5
-      parent: 2
-      type: Transform
   - uid: 2662
     components:
     - rot: 3.141592653589793 rad
@@ -70275,12 +71228,6 @@ entities:
       pos: -15.5,-18.5
       parent: 2
       type: Transform
-  - uid: 3880
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -15.5,-19.5
-      parent: 2
-      type: Transform
   - uid: 3901
     components:
     - rot: -1.5707963267948966 rad
@@ -70297,12 +71244,6 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: -17.5,-16.5
-      parent: 2
-      type: Transform
-  - uid: 3921
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -19.5,-17.5
       parent: 2
       type: Transform
   - uid: 4615
@@ -70349,12 +71290,6 @@ entities:
   - uid: 7693
     components:
     - pos: -9.5,-7.5
-      parent: 2
-      type: Transform
-  - uid: 8508
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 7.5,22.5
       parent: 2
       type: Transform
   - uid: 8905
@@ -70457,6 +71392,11 @@ entities:
   - uid: 11561
     components:
     - pos: 17.5,-3.5
+      parent: 2
+      type: Transform
+  - uid: 12817
+    components:
+    - pos: -15.5,-19.5
       parent: 2
       type: Transform
 - proto: TargetDarts
@@ -70686,22 +71626,30 @@ entities:
   entities:
   - uid: 1072
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,18.5
       parent: 2
       type: Transform
   - uid: 1073
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,18.5
       parent: 2
       type: Transform
   - uid: 1078
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 0.5,18.5
       parent: 2
       type: Transform
   - uid: 2377
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 39.5,-19.5
       parent: 2
@@ -70956,16 +71904,12 @@ entities:
       type: Transform
 - proto: TwoWayLever
   entities:
-  - uid: 4757
+  - uid: 4767
     components:
-    - pos: 22.5,-28.5
+    - pos: 18.5,-27.5
       parent: 2
       type: Transform
     - linkedPorts:
-        4748:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
         4741:
         - Left: Forward
         - Right: Reverse
@@ -70994,7 +71938,15 @@ entities:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        4747:
+        1152:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        1200:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        2325:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
@@ -71232,6 +72184,13 @@ entities:
     - pos: 10.5,-21.5
       parent: 2
       type: Transform
+- proto: VendingMachineEngiDrobe
+  entities:
+  - uid: 703
+    components:
+    - pos: -24.5,-17.5
+      parent: 2
+      type: Transform
 - proto: VendingMachineEngivend
   entities:
   - uid: 12189
@@ -71436,4965 +72395,6805 @@ entities:
   entities:
   - uid: 14
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,8.5
       parent: 2
       type: Transform
   - uid: 18
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 0.5,11.5
       parent: 2
       type: Transform
   - uid: 26
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,15.5
       parent: 2
       type: Transform
   - uid: 41
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,14.5
       parent: 2
       type: Transform
   - uid: 42
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 1.5,11.5
       parent: 2
       type: Transform
   - uid: 65
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,8.5
       parent: 2
       type: Transform
   - uid: 67
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,8.5
       parent: 2
       type: Transform
   - uid: 69
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,8.5
       parent: 2
       type: Transform
   - uid: 71
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,8.5
       parent: 2
       type: Transform
   - uid: 77
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,34.5
       parent: 2
       type: Transform
   - uid: 225
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,24.5
       parent: 2
       type: Transform
   - uid: 226
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,5.5
       parent: 2
       type: Transform
   - uid: 242
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,14.5
       parent: 2
       type: Transform
   - uid: 246
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,5.5
       parent: 2
       type: Transform
   - uid: 247
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,9.5
       parent: 2
       type: Transform
   - uid: 271
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 47.5,0.5
       parent: 2
       type: Transform
   - uid: 275
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -10.5,36.5
       parent: 2
       type: Transform
   - uid: 276
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,5.5
       parent: 2
       type: Transform
   - uid: 280
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,9.5
       parent: 2
       type: Transform
   - uid: 281
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -1.5,11.5
       parent: 2
       type: Transform
   - uid: 282
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,14.5
       parent: 2
       type: Transform
   - uid: 283
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -2.5,11.5
       parent: 2
       type: Transform
   - uid: 284
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,10.5
       parent: 2
       type: Transform
   - uid: 285
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,14.5
       parent: 2
       type: Transform
   - uid: 286
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -0.5,11.5
       parent: 2
       type: Transform
   - uid: 287
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -2.5,5.5
       parent: 2
       type: Transform
   - uid: 288
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -1.5,5.5
       parent: 2
       type: Transform
   - uid: 289
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -0.5,5.5
       parent: 2
       type: Transform
   - uid: 290
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 0.5,5.5
       parent: 2
       type: Transform
   - uid: 344
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,46.5
       parent: 2
       type: Transform
   - uid: 376
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 30.5,-2.5
       parent: 2
       type: Transform
   - uid: 418
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,26.5
       parent: 2
       type: Transform
   - uid: 429
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,7.5
       parent: 2
       type: Transform
   - uid: 433
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,36.5
       parent: 2
       type: Transform
   - uid: 434
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,8.5
       parent: 2
       type: Transform
   - uid: 435
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,6.5
       parent: 2
       type: Transform
   - uid: 436
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,37.5
       parent: 2
       type: Transform
   - uid: 437
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 42.5,6.5
       parent: 2
       type: Transform
   - uid: 438
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 43.5,9.5
       parent: 2
       type: Transform
   - uid: 439
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 44.5,6.5
       parent: 2
       type: Transform
   - uid: 461
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,0.5
       parent: 2
       type: Transform
   - uid: 462
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,14.5
       parent: 2
       type: Transform
   - uid: 476
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 48.5,-10.5
       parent: 2
       type: Transform
   - uid: 481
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 49.5,-10.5
       parent: 2
       type: Transform
   - uid: 482
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 47.5,-1.5
       parent: 2
       type: Transform
   - uid: 483
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 47.5,-13.5
       parent: 2
       type: Transform
   - uid: 487
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 49.5,-8.5
       parent: 2
       type: Transform
   - uid: 489
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 47.5,-12.5
       parent: 2
       type: Transform
   - uid: 490
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 49.5,-3.5
       parent: 2
       type: Transform
   - uid: 491
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,9.5
       parent: 2
       type: Transform
   - uid: 492
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 49.5,-1.5
       parent: 2
       type: Transform
   - uid: 503
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-2.5
       parent: 2
       type: Transform
   - uid: 504
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 29.5,-2.5
       parent: 2
       type: Transform
   - uid: 506
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,1.5
       parent: 2
       type: Transform
   - uid: 508
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 28.5,-0.5
       parent: 2
       type: Transform
   - uid: 509
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,1.5
       parent: 2
       type: Transform
   - uid: 511
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,1.5
       parent: 2
       type: Transform
   - uid: 514
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,1.5
       parent: 2
       type: Transform
   - uid: 515
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,1.5
       parent: 2
       type: Transform
   - uid: 522
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-2.5
       parent: 2
       type: Transform
   - uid: 535
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 42.5,9.5
       parent: 2
       type: Transform
   - uid: 536
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,9.5
       parent: 2
       type: Transform
   - uid: 539
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,9.5
       parent: 2
       type: Transform
   - uid: 548
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-3.5
       parent: 2
       type: Transform
   - uid: 549
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-3.5
       parent: 2
       type: Transform
   - uid: 550
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-3.5
       parent: 2
       type: Transform
   - uid: 552
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-3.5
       parent: 2
       type: Transform
   - uid: 553
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-3.5
       parent: 2
       type: Transform
   - uid: 554
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,-3.5
       parent: 2
       type: Transform
   - uid: 555
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-3.5
       parent: 2
       type: Transform
   - uid: 642
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 28.5,-2.5
       parent: 2
       type: Transform
   - uid: 645
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 28.5,-1.5
       parent: 2
       type: Transform
   - uid: 646
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 28.5,0.5
       parent: 2
       type: Transform
   - uid: 667
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,26.5
       parent: 2
       type: Transform
   - uid: 677
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 48.5,-1.5
       parent: 2
       type: Transform
   - uid: 716
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 47.5,-10.5
       parent: 2
       type: Transform
   - uid: 727
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 47.5,4.5
       parent: 2
       type: Transform
   - uid: 728
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-43.5
       parent: 2
       type: Transform
   - uid: 729
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,-43.5
       parent: 2
       type: Transform
   - uid: 730
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-43.5
       parent: 2
       type: Transform
   - uid: 838
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,34.5
       parent: 2
       type: Transform
   - uid: 861
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,5.5
       parent: 2
       type: Transform
   - uid: 862
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,5.5
       parent: 2
       type: Transform
   - uid: 863
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,5.5
       parent: 2
       type: Transform
   - uid: 865
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,5.5
       parent: 2
       type: Transform
   - uid: 866
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,5.5
       parent: 2
       type: Transform
   - uid: 867
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,6.5
       parent: 2
       type: Transform
   - uid: 868
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,7.5
       parent: 2
       type: Transform
   - uid: 869
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,8.5
       parent: 2
       type: Transform
   - uid: 870
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,9.5
       parent: 2
       type: Transform
   - uid: 871
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,9.5
       parent: 2
       type: Transform
   - uid: 886
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,9.5
       parent: 2
       type: Transform
   - uid: 887
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,9.5
       parent: 2
       type: Transform
   - uid: 892
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,5.5
       parent: 2
       type: Transform
   - uid: 893
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,9.5
       parent: 2
       type: Transform
   - uid: 894
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,5.5
       parent: 2
       type: Transform
   - uid: 895
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,5.5
       parent: 2
       type: Transform
   - uid: 896
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,9.5
       parent: 2
       type: Transform
   - uid: 898
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,47.5
       parent: 2
       type: Transform
   - uid: 902
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,9.5
       parent: 2
       type: Transform
   - uid: 903
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,8.5
       parent: 2
       type: Transform
   - uid: 904
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,7.5
       parent: 2
       type: Transform
   - uid: 905
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,6.5
       parent: 2
       type: Transform
   - uid: 906
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,5.5
       parent: 2
       type: Transform
   - uid: 912
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -19.5,9.5
       parent: 2
       type: Transform
   - uid: 914
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,47.5
       parent: 2
       type: Transform
   - uid: 931
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,14.5
       parent: 2
       type: Transform
   - uid: 935
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,30.5
       parent: 2
       type: Transform
   - uid: 945
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,25.5
       parent: 2
       type: Transform
   - uid: 949
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -17.5,18.5
       parent: 2
       type: Transform
   - uid: 950
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -15.5,18.5
       parent: 2
       type: Transform
   - uid: 952
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,31.5
       parent: 2
       type: Transform
   - uid: 953
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,14.5
       parent: 2
       type: Transform
   - uid: 954
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,13.5
       parent: 2
       type: Transform
   - uid: 959
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,18.5
       parent: 2
       type: Transform
   - uid: 960
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,24.5
       parent: 2
       type: Transform
   - uid: 961
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,20.5
       parent: 2
       type: Transform
   - uid: 962
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,19.5
       parent: 2
       type: Transform
   - uid: 963
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,22.5
       parent: 2
       type: Transform
   - uid: 964
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,21.5
       parent: 2
       type: Transform
   - uid: 965
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,24.5
       parent: 2
       type: Transform
   - uid: 966
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,23.5
       parent: 2
       type: Transform
   - uid: 967
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,24.5
       parent: 2
       type: Transform
   - uid: 968
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,17.5
       parent: 2
       type: Transform
   - uid: 973
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,15.5
       parent: 2
       type: Transform
   - uid: 974
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,16.5
       parent: 2
       type: Transform
   - uid: 976
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,31.5
       parent: 2
       type: Transform
   - uid: 979
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,27.5
       parent: 2
       type: Transform
   - uid: 981
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,30.5
       parent: 2
       type: Transform
   - uid: 982
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,24.5
       parent: 2
       type: Transform
   - uid: 983
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,17.5
       parent: 2
       type: Transform
   - uid: 984
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -16.5,18.5
       parent: 2
       type: Transform
   - uid: 993
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -10.5,18.5
       parent: 2
       type: Transform
   - uid: 995
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -6.5,18.5
       parent: 2
       type: Transform
   - uid: 996
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,31.5
       parent: 2
       type: Transform
   - uid: 998
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -7.5,18.5
       parent: 2
       type: Transform
   - uid: 1000
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -8.5,18.5
       parent: 2
       type: Transform
   - uid: 1010
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -10.5,17.5
       parent: 2
       type: Transform
   - uid: 1011
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -9.5,18.5
       parent: 2
       type: Transform
   - uid: 1012
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -10.5,15.5
       parent: 2
       type: Transform
   - uid: 1013
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -6.5,15.5
       parent: 2
       type: Transform
   - uid: 1014
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -6.5,17.5
       parent: 2
       type: Transform
   - uid: 1017
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,24.5
       parent: 2
       type: Transform
   - uid: 1024
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,24.5
       parent: 2
       type: Transform
   - uid: 1026
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,24.5
       parent: 2
       type: Transform
   - uid: 1027
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,24.5
       parent: 2
       type: Transform
   - uid: 1028
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,23.5
       parent: 2
       type: Transform
   - uid: 1029
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,24.5
       parent: 2
       type: Transform
   - uid: 1031
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,24.5
       parent: 2
       type: Transform
   - uid: 1032
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,24.5
       parent: 2
       type: Transform
   - uid: 1033
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,24.5
       parent: 2
       type: Transform
   - uid: 1034
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,24.5
       parent: 2
       type: Transform
   - uid: 1035
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,24.5
       parent: 2
       type: Transform
   - uid: 1036
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,24.5
       parent: 2
       type: Transform
   - uid: 1037
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,36.5
       parent: 2
       type: Transform
   - uid: 1041
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,6.5
       parent: 2
       type: Transform
   - uid: 1043
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,24.5
       parent: 2
       type: Transform
   - uid: 1044
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,15.5
       parent: 2
       type: Transform
   - uid: 1045
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,16.5
       parent: 2
       type: Transform
   - uid: 1046
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,17.5
       parent: 2
       type: Transform
   - uid: 1047
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,18.5
       parent: 2
       type: Transform
   - uid: 1048
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,19.5
       parent: 2
       type: Transform
   - uid: 1049
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,20.5
       parent: 2
       type: Transform
   - uid: 1050
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,21.5
       parent: 2
       type: Transform
   - uid: 1051
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,22.5
       parent: 2
       type: Transform
   - uid: 1052
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,23.5
       parent: 2
       type: Transform
   - uid: 1053
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -18.5,18.5
       parent: 2
       type: Transform
   - uid: 1054
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -19.5,18.5
       parent: 2
       type: Transform
   - uid: 1056
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,18.5
       parent: 2
       type: Transform
   - uid: 1057
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -18.5,23.5
       parent: 2
       type: Transform
   - uid: 1061
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,23.5
       parent: 2
       type: Transform
   - uid: 1063
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,19.5
       parent: 2
       type: Transform
   - uid: 1065
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,18.5
       parent: 2
       type: Transform
   - uid: 1066
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,21.5
       parent: 2
       type: Transform
   - uid: 1068
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,21.5
       parent: 2
       type: Transform
   - uid: 1071
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,21.5
       parent: 2
       type: Transform
   - uid: 1100
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,30.5
       parent: 2
       type: Transform
   - uid: 1102
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,23.5
       parent: 2
       type: Transform
   - uid: 1106
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,19.5
       parent: 2
       type: Transform
   - uid: 1109
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,21.5
       parent: 2
       type: Transform
   - uid: 1131
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,31.5
       parent: 2
       type: Transform
   - uid: 1134
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,31.5
       parent: 2
       type: Transform
   - uid: 1135
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,25.5
       parent: 2
       type: Transform
   - uid: 1138
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,25.5
       parent: 2
       type: Transform
   - uid: 1143
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,31.5
       parent: 2
       type: Transform
   - uid: 1145
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,6.5
       parent: 2
       type: Transform
   - uid: 1149
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,25.5
       parent: 2
       type: Transform
   - uid: 1157
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,30.5
       parent: 2
       type: Transform
   - uid: 1158
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,30.5
       parent: 2
       type: Transform
   - uid: 1159
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,25.5
       parent: 2
       type: Transform
   - uid: 1160
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,25.5
       parent: 2
       type: Transform
   - uid: 1165
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -10.5,33.5
       parent: 2
       type: Transform
   - uid: 1166
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,29.5
       parent: 2
       type: Transform
   - uid: 1167
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -16.5,14.5
       parent: 2
       type: Transform
   - uid: 1168
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -15.5,14.5
       parent: 2
       type: Transform
   - uid: 1173
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,32.5
       parent: 2
       type: Transform
   - uid: 1174
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -15.5,32.5
       parent: 2
       type: Transform
   - uid: 1175
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,32.5
       parent: 2
       type: Transform
   - uid: 1176
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,29.5
       parent: 2
       type: Transform
   - uid: 1177
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,29.5
       parent: 2
       type: Transform
   - uid: 1178
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,29.5
       parent: 2
       type: Transform
   - uid: 1195
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -19.5,14.5
       parent: 2
       type: Transform
   - uid: 1198
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,29.5
       parent: 2
       type: Transform
   - uid: 1203
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -5.5,25.5
       parent: 2
       type: Transform
   - uid: 1204
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -5.5,26.5
       parent: 2
       type: Transform
   - uid: 1205
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -5.5,27.5
       parent: 2
       type: Transform
   - uid: 1206
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -5.5,28.5
       parent: 2
       type: Transform
   - uid: 1207
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -5.5,29.5
       parent: 2
       type: Transform
   - uid: 1208
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,30.5
       parent: 2
       type: Transform
   - uid: 1211
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,26.5
       parent: 2
       type: Transform
   - uid: 1213
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,27.5
       parent: 2
       type: Transform
   - uid: 1214
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,28.5
       parent: 2
       type: Transform
   - uid: 1215
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,29.5
       parent: 2
       type: Transform
   - uid: 1216
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,30.5
       parent: 2
       type: Transform
   - uid: 1217
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,31.5
       parent: 2
       type: Transform
   - uid: 1218
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,32.5
       parent: 2
       type: Transform
   - uid: 1219
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,26.5
       parent: 2
       type: Transform
   - uid: 1225
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,32.5
       parent: 2
       type: Transform
   - uid: 1226
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,32.5
       parent: 2
       type: Transform
   - uid: 1227
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,32.5
       parent: 2
       type: Transform
   - uid: 1228
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,31.5
       parent: 2
       type: Transform
   - uid: 1229
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,30.5
       parent: 2
       type: Transform
   - uid: 1230
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,29.5
       parent: 2
       type: Transform
   - uid: 1246
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,28.5
       parent: 2
       type: Transform
   - uid: 1247
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,27.5
       parent: 2
       type: Transform
   - uid: 1250
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,25.5
       parent: 2
       type: Transform
   - uid: 1258
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,25.5
       parent: 2
       type: Transform
   - uid: 1260
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,33.5
       parent: 2
       type: Transform
   - uid: 1261
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -15.5,37.5
       parent: 2
       type: Transform
   - uid: 1262
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -12.5,36.5
       parent: 2
       type: Transform
   - uid: 1273
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -15.5,36.5
       parent: 2
       type: Transform
   - uid: 1275
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -9.5,38.5
       parent: 2
       type: Transform
   - uid: 1277
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -10.5,39.5
       parent: 2
       type: Transform
   - uid: 1278
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -9.5,36.5
       parent: 2
       type: Transform
   - uid: 1279
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -9.5,37.5
       parent: 2
       type: Transform
   - uid: 1285
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -15.5,39.5
       parent: 2
       type: Transform
   - uid: 1286
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,39.5
       parent: 2
       type: Transform
   - uid: 1287
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -9.5,39.5
       parent: 2
       type: Transform
   - uid: 1288
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -15.5,38.5
       parent: 2
       type: Transform
   - uid: 1324
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -68.5,9.5
       parent: 2
       type: Transform
   - uid: 1401
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,10.5
       parent: 2
       type: Transform
   - uid: 1453
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,10.5
       parent: 2
       type: Transform
   - uid: 1462
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,10.5
       parent: 2
       type: Transform
   - uid: 1496
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -8.5,39.5
       parent: 2
       type: Transform
   - uid: 1497
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,39.5
       parent: 2
       type: Transform
   - uid: 1498
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -6.5,39.5
       parent: 2
       type: Transform
   - uid: 1499
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -5.5,39.5
       parent: 2
       type: Transform
   - uid: 1500
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -5.5,42.5
       parent: 2
       type: Transform
   - uid: 1501
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -6.5,42.5
       parent: 2
       type: Transform
   - uid: 1502
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -8.5,42.5
       parent: 2
       type: Transform
   - uid: 1503
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,42.5
       parent: 2
       type: Transform
   - uid: 1504
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -9.5,44.5
       parent: 2
       type: Transform
   - uid: 1505
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -9.5,45.5
       parent: 2
       type: Transform
   - uid: 1506
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -8.5,45.5
       parent: 2
       type: Transform
   - uid: 1507
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,45.5
       parent: 2
       type: Transform
   - uid: 1508
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -6.5,45.5
       parent: 2
       type: Transform
   - uid: 1509
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -5.5,45.5
       parent: 2
       type: Transform
   - uid: 1512
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -9.5,42.5
       parent: 2
       type: Transform
   - uid: 1513
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -9.5,41.5
       parent: 2
       type: Transform
   - uid: 1560
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,39.5
       parent: 2
       type: Transform
   - uid: 1561
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,39.5
       parent: 2
       type: Transform
   - uid: 1562
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,39.5
       parent: 2
       type: Transform
   - uid: 1563
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,40.5
       parent: 2
       type: Transform
   - uid: 1565
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,45.5
       parent: 2
       type: Transform
   - uid: 1573
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,46.5
       parent: 2
       type: Transform
   - uid: 1574
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,46.5
       parent: 2
       type: Transform
   - uid: 1578
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,46.5
       parent: 2
       type: Transform
   - uid: 1579
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,46.5
       parent: 2
       type: Transform
   - uid: 1580
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,46.5
       parent: 2
       type: Transform
   - uid: 1581
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,46.5
       parent: 2
       type: Transform
   - uid: 1587
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,46.5
       parent: 2
       type: Transform
   - uid: 1712
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,33.5
       parent: 2
       type: Transform
   - uid: 1783
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -14.5,29.5
       parent: 2
       type: Transform
   - uid: 2049
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,19.5
       parent: 2
       type: Transform
   - uid: 2090
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -68.5,1.5
       parent: 2
       type: Transform
   - uid: 2091
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -70.5,9.5
       parent: 2
       type: Transform
   - uid: 2093
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -69.5,9.5
       parent: 2
       type: Transform
   - uid: 2169
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,21.5
       parent: 2
       type: Transform
   - uid: 2170
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,21.5
       parent: 2
       type: Transform
   - uid: 2172
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,21.5
       parent: 2
       type: Transform
   - uid: 2176
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,23.5
       parent: 2
       type: Transform
   - uid: 2177
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 16.5,22.5
       parent: 2
       type: Transform
   - uid: 2179
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,21.5
       parent: 2
       type: Transform
   - uid: 2181
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,25.5
       parent: 2
       type: Transform
   - uid: 2185
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 16.5,24.5
       parent: 2
       type: Transform
   - uid: 2188
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 15.5,21.5
       parent: 2
       type: Transform
   - uid: 2190
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,19.5
       parent: 2
       type: Transform
   - uid: 2191
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,20.5
       parent: 2
       type: Transform
   - uid: 2195
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,25.5
       parent: 2
       type: Transform
   - uid: 2198
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,25.5
       parent: 2
       type: Transform
   - uid: 2201
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,25.5
       parent: 2
       type: Transform
   - uid: 2203
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,25.5
       parent: 2
       type: Transform
   - uid: 2204
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,25.5
       parent: 2
       type: Transform
   - uid: 2211
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,25.5
       parent: 2
       type: Transform
   - uid: 2212
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,24.5
       parent: 2
       type: Transform
   - uid: 2213
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,23.5
       parent: 2
       type: Transform
   - uid: 2214
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,22.5
       parent: 2
       type: Transform
   - uid: 2215
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,21.5
       parent: 2
       type: Transform
   - uid: 2217
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,21.5
       parent: 2
       type: Transform
   - uid: 2220
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,21.5
       parent: 2
       type: Transform
   - uid: 2224
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,26.5
       parent: 2
       type: Transform
   - uid: 2252
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,29.5
       parent: 2
       type: Transform
   - uid: 2253
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,29.5
       parent: 2
       type: Transform
   - uid: 2254
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,29.5
       parent: 2
       type: Transform
   - uid: 2255
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,29.5
       parent: 2
       type: Transform
   - uid: 2256
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,29.5
       parent: 2
       type: Transform
   - uid: 2257
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,29.5
       parent: 2
       type: Transform
   - uid: 2258
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,28.5
       parent: 2
       type: Transform
   - uid: 2259
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,27.5
       parent: 2
       type: Transform
   - uid: 2260
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,26.5
       parent: 2
       type: Transform
   - uid: 2434
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 47.5,-17.5
       parent: 2
       type: Transform
   - uid: 2435
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 47.5,-18.5
       parent: 2
       type: Transform
   - uid: 2436
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,-25.5
       parent: 2
       type: Transform
   - uid: 2438
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,-25.5
       parent: 2
       type: Transform
   - uid: 2441
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,-24.5
       parent: 2
       type: Transform
   - uid: 2453
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 47.5,-20.5
       parent: 2
       type: Transform
   - uid: 2454
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 47.5,-19.5
       parent: 2
       type: Transform
   - uid: 2457
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 42.5,-25.5
       parent: 2
       type: Transform
   - uid: 2458
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,-25.5
       parent: 2
       type: Transform
   - uid: 2460
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-26.5
       parent: 2
       type: Transform
   - uid: 2467
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,-25.5
       parent: 2
       type: Transform
   - uid: 2468
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,-26.5
       parent: 2
       type: Transform
   - uid: 2476
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-26.5
       parent: 2
       type: Transform
   - uid: 2545
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,9.5
       parent: 2
       type: Transform
   - uid: 2547
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,36.5
       parent: 2
       type: Transform
   - uid: 2548
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,35.5
       parent: 2
       type: Transform
   - uid: 2549
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,35.5
       parent: 2
       type: Transform
   - uid: 2551
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,34.5
       parent: 2
       type: Transform
   - uid: 2552
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,34.5
       parent: 2
       type: Transform
   - uid: 2554
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 7.5,34.5
       parent: 2
       type: Transform
   - uid: 2557
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,5.5
       parent: 2
       type: Transform
   - uid: 2558
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,9.5
       parent: 2
       type: Transform
   - uid: 2559
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,9.5
       parent: 2
       type: Transform
   - uid: 2560
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,8.5
       parent: 2
       type: Transform
   - uid: 2561
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,7.5
       parent: 2
       type: Transform
   - uid: 2562
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,6.5
       parent: 2
       type: Transform
   - uid: 2563
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 16.5,26.5
       parent: 2
       type: Transform
   - uid: 2564
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 16.5,33.5
       parent: 2
       type: Transform
   - uid: 2568
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,5.5
       parent: 2
       type: Transform
   - uid: 2573
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,6.5
       parent: 2
       type: Transform
   - uid: 2575
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,34.5
       parent: 2
       type: Transform
   - uid: 2576
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,38.5
       parent: 2
       type: Transform
   - uid: 2577
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,34.5
       parent: 2
       type: Transform
   - uid: 2578
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 10.5,31.5
       parent: 2
       type: Transform
   - uid: 2579
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,34.5
       parent: 2
       type: Transform
   - uid: 2580
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,34.5
       parent: 2
       type: Transform
   - uid: 2581
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,34.5
       parent: 2
       type: Transform
   - uid: 2582
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,26.5
       parent: 2
       type: Transform
   - uid: 2583
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 8.5,33.5
       parent: 2
       type: Transform
   - uid: 2585
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,25.5
       parent: 2
       type: Transform
   - uid: 2597
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 26.5,20.5
       parent: 2
       type: Transform
   - uid: 2601
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,26.5
       parent: 2
       type: Transform
   - uid: 2603
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 26.5,23.5
       parent: 2
       type: Transform
   - uid: 2604
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,26.5
       parent: 2
       type: Transform
   - uid: 2606
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 24.5,19.5
       parent: 2
       type: Transform
   - uid: 2607
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 27.5,23.5
       parent: 2
       type: Transform
   - uid: 2610
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 21.5,19.5
       parent: 2
       type: Transform
   - uid: 2618
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 26.5,24.5
       parent: 2
       type: Transform
   - uid: 2620
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 10.5,32.5
       parent: 2
       type: Transform
   - uid: 2626
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 20.5,19.5
       parent: 2
       type: Transform
   - uid: 2629
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,26.5
       parent: 2
       type: Transform
   - uid: 2635
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 27.5,20.5
       parent: 2
       type: Transform
   - uid: 2639
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 26.5,19.5
       parent: 2
       type: Transform
   - uid: 2640
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 27.5,25.5
       parent: 2
       type: Transform
   - uid: 2642
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 27.5,26.5
       parent: 2
       type: Transform
   - uid: 2645
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 4.5,34.5
       parent: 2
       type: Transform
   - uid: 2647
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 3.5,34.5
       parent: 2
       type: Transform
   - uid: 2649
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 26.5,21.5
       parent: 2
       type: Transform
   - uid: 2651
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 17.5,19.5
       parent: 2
       type: Transform
   - uid: 2653
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,26.5
       parent: 2
       type: Transform
   - uid: 2655
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 27.5,19.5
       parent: 2
       type: Transform
   - uid: 2658
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 27.5,21.5
       parent: 2
       type: Transform
   - uid: 2666
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,26.5
       parent: 2
       type: Transform
   - uid: 2668
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 7.5,33.5
       parent: 2
       type: Transform
   - uid: 2670
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 26.5,22.5
       parent: 2
       type: Transform
   - uid: 2671
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 27.5,22.5
       parent: 2
       type: Transform
   - uid: 2675
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 24.5,33.5
       parent: 2
       type: Transform
   - uid: 2676
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 27.5,24.5
       parent: 2
       type: Transform
   - uid: 2677
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,29.5
       parent: 2
       type: Transform
   - uid: 2680
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 25.5,33.5
       parent: 2
       type: Transform
   - uid: 2683
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 26.5,33.5
       parent: 2
       type: Transform
   - uid: 2685
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 23.5,33.5
       parent: 2
       type: Transform
   - uid: 2689
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 17.5,33.5
       parent: 2
       type: Transform
   - uid: 2690
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 15.5,33.5
       parent: 2
       type: Transform
   - uid: 2692
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 19.5,33.5
       parent: 2
       type: Transform
   - uid: 2695
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 9.5,33.5
       parent: 2
       type: Transform
   - uid: 2701
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,26.5
       parent: 2
       type: Transform
   - uid: 2704
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 10.5,33.5
       parent: 2
       type: Transform
   - uid: 2710
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 22.5,19.5
       parent: 2
       type: Transform
   - uid: 2711
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 11.5,33.5
       parent: 2
       type: Transform
   - uid: 2716
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 18.5,33.5
       parent: 2
       type: Transform
   - uid: 2720
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,26.5
       parent: 2
       type: Transform
   - uid: 2721
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 20.5,25.5
       parent: 2
       type: Transform
   - uid: 2722
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 20.5,24.5
       parent: 2
       type: Transform
   - uid: 2723
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 20.5,23.5
       parent: 2
       type: Transform
   - uid: 2729
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 23.5,19.5
       parent: 2
       type: Transform
   - uid: 2733
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 25.5,19.5
       parent: 2
       type: Transform
   - uid: 2736
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 26.5,30.5
       parent: 2
       type: Transform
   - uid: 2737
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 26.5,31.5
       parent: 2
       type: Transform
   - uid: 2738
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 26.5,32.5
       parent: 2
       type: Transform
   - uid: 2781
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,14.5
       parent: 2
       type: Transform
   - uid: 2782
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,14.5
       parent: 2
       type: Transform
   - uid: 2783
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,14.5
       parent: 2
       type: Transform
   - uid: 2785
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 28.5,14.5
       parent: 2
       type: Transform
   - uid: 2786
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 28.5,15.5
       parent: 2
       type: Transform
   - uid: 2787
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 28.5,18.5
       parent: 2
       type: Transform
   - uid: 2788
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 28.5,19.5
       parent: 2
       type: Transform
   - uid: 2796
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,14.5
       parent: 2
       type: Transform
   - uid: 2798
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,15.5
       parent: 2
       type: Transform
   - uid: 2801
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,16.5
       parent: 2
       type: Transform
   - uid: 2802
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,14.5
       parent: 2
       type: Transform
   - uid: 2803
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,14.5
       parent: 2
       type: Transform
   - uid: 2804
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,14.5
       parent: 2
       type: Transform
   - uid: 2805
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,17.5
       parent: 2
       type: Transform
   - uid: 2806
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,18.5
       parent: 2
       type: Transform
   - uid: 2807
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,19.5
       parent: 2
       type: Transform
   - uid: 2808
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,19.5
       parent: 2
       type: Transform
   - uid: 2809
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,19.5
       parent: 2
       type: Transform
   - uid: 2810
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,19.5
       parent: 2
       type: Transform
   - uid: 2834
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,13.5
       parent: 2
       type: Transform
   - uid: 2835
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,14.5
       parent: 2
       type: Transform
   - uid: 2836
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,15.5
       parent: 2
       type: Transform
   - uid: 2837
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,16.5
       parent: 2
       type: Transform
   - uid: 2838
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,17.5
       parent: 2
       type: Transform
   - uid: 2839
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,18.5
       parent: 2
       type: Transform
   - uid: 2840
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,19.5
       parent: 2
       type: Transform
   - uid: 2841
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,20.5
       parent: 2
       type: Transform
   - uid: 2842
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,20.5
       parent: 2
       type: Transform
   - uid: 2843
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,20.5
       parent: 2
       type: Transform
   - uid: 2844
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,20.5
       parent: 2
       type: Transform
   - uid: 2845
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,20.5
       parent: 2
       type: Transform
   - uid: 2846
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,20.5
       parent: 2
       type: Transform
   - uid: 2849
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,9.5
       parent: 2
       type: Transform
   - uid: 2850
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,9.5
       parent: 2
       type: Transform
   - uid: 2851
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,10.5
       parent: 2
       type: Transform
   - uid: 2852
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,11.5
       parent: 2
       type: Transform
   - uid: 2853
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,12.5
       parent: 2
       type: Transform
   - uid: 3010
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,32.5
       parent: 2
       type: Transform
   - uid: 3012
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,31.5
       parent: 2
       type: Transform
   - uid: 3013
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,32.5
       parent: 2
       type: Transform
   - uid: 3014
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,30.5
       parent: 2
       type: Transform
   - uid: 3015
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,29.5
       parent: 2
       type: Transform
   - uid: 3043
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 7.5,32.5
       parent: 2
       type: Transform
   - uid: 3044
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 7.5,31.5
       parent: 2
       type: Transform
   - uid: 3096
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,35.5
       parent: 2
       type: Transform
   - uid: 3098
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 4.5,35.5
       parent: 2
       type: Transform
   - uid: 3348
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-7.5
       parent: 2
       type: Transform
   - uid: 3356
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-11.5
       parent: 2
       type: Transform
   - uid: 3358
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,-12.5
       parent: 2
       type: Transform
   - uid: 3359
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-12.5
       parent: 2
       type: Transform
   - uid: 3360
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-12.5
       parent: 2
       type: Transform
   - uid: 3482
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-8.5
       parent: 2
       type: Transform
   - uid: 3483
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-9.5
       parent: 2
       type: Transform
   - uid: 3484
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-7.5
       parent: 2
       type: Transform
   - uid: 3485
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-7.5
       parent: 2
       type: Transform
   - uid: 3486
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-8.5
       parent: 2
       type: Transform
   - uid: 3487
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-7.5
       parent: 2
       type: Transform
   - uid: 3488
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-12.5
       parent: 2
       type: Transform
   - uid: 3508
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-12.5
       parent: 2
       type: Transform
   - uid: 3511
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-12.5
       parent: 2
       type: Transform
   - uid: 3522
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-11.5
       parent: 2
       type: Transform
   - uid: 3523
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-10.5
       parent: 2
       type: Transform
   - uid: 3525
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-8.5
       parent: 2
       type: Transform
   - uid: 3546
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-10.5
       parent: 2
       type: Transform
   - uid: 3551
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,-10.5
       parent: 2
       type: Transform
   - uid: 3552
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,-10.5
       parent: 2
       type: Transform
   - uid: 3565
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-10.5
       parent: 2
       type: Transform
   - uid: 3593
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,-6.5
       parent: 2
       type: Transform
   - uid: 3599
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-6.5
       parent: 2
       type: Transform
   - uid: 3600
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-6.5
       parent: 2
       type: Transform
   - uid: 3601
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-7.5
       parent: 2
       type: Transform
   - uid: 3607
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-6.5
       parent: 2
       type: Transform
   - uid: 3608
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-6.5
       parent: 2
       type: Transform
   - uid: 3612
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-10.5
       parent: 2
       type: Transform
   - uid: 3614
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-9.5
       parent: 2
       type: Transform
   - uid: 3619
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-8.5
       parent: 2
       type: Transform
   - uid: 3723
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -13.5,-20.5
       parent: 2
       type: Transform
   - uid: 3724
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -13.5,-18.5
       parent: 2
       type: Transform
   - uid: 3725
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -13.5,-19.5
       parent: 2
       type: Transform
   - uid: 3730
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -13.5,-16.5
       parent: 2
       type: Transform
   - uid: 3737
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,-29.5
       parent: 2
       type: Transform
   - uid: 3748
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -13.5,-17.5
       parent: 2
       type: Transform
   - uid: 3753
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,-30.5
       parent: 2
       type: Transform
   - uid: 3759
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-28.5
       parent: 2
       type: Transform
   - uid: 3766
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-28.5
       parent: 2
       type: Transform
   - uid: 3774
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-28.5
       parent: 2
       type: Transform
   - uid: 3775
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -3.5,-28.5
       parent: 2
       type: Transform
   - uid: 3777
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,-28.5
       parent: 2
       type: Transform
   - uid: 3778
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-28.5
       parent: 2
       type: Transform
   - uid: 3787
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,-20.5
       parent: 2
       type: Transform
   - uid: 3790
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,-30.5
       parent: 2
       type: Transform
   - uid: 3796
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -16.5,-30.5
       parent: 2
       type: Transform
   - uid: 3797
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -15.5,-30.5
       parent: 2
       type: Transform
   - uid: 3798
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -18.5,-30.5
       parent: 2
       type: Transform
   - uid: 3799
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -17.5,-30.5
       parent: 2
       type: Transform
   - uid: 3800
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -19.5,-30.5
       parent: 2
       type: Transform
   - uid: 3804
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,-29.5
       parent: 2
       type: Transform
   - uid: 3808
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -21.5,-30.5
       parent: 2
       type: Transform
   - uid: 3840
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,23.5
       parent: 2
       type: Transform
   - uid: 3841
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,22.5
       parent: 2
       type: Transform
   - uid: 3844
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -22.5,-37.5
       parent: 2
       type: Transform
   - uid: 3846
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-21.5
       parent: 2
       type: Transform
   - uid: 3849
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -68.5,11.5
       parent: 2
       type: Transform
   - uid: 3850
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -62.5,-1.5
       parent: 2
       type: Transform
   - uid: 3851
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-22.5
       parent: 2
       type: Transform
   - uid: 3854
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,-24.5
       parent: 2
       type: Transform
   - uid: 3860
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,-37.5
       parent: 2
       type: Transform
   - uid: 3861
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,-36.5
       parent: 2
       type: Transform
   - uid: 3868
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,-28.5
       parent: 2
       type: Transform
   - uid: 3872
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -18.5,-20.5
       parent: 2
       type: Transform
   - uid: 3873
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -19.5,-20.5
       parent: 2
       type: Transform
   - uid: 3881
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -18.5,-15.5
       parent: 2
       type: Transform
   - uid: 3894
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -14.5,-16.5
       parent: 2
       type: Transform
   - uid: 3895
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -14.5,-15.5
       parent: 2
       type: Transform
   - uid: 3896
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -15.5,-15.5
       parent: 2
       type: Transform
   - uid: 3897
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -17.5,-15.5
       parent: 2
       type: Transform
   - uid: 3898
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -21.5,-19.5
       parent: 2
       type: Transform
   - uid: 3899
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -21.5,-20.5
       parent: 2
       type: Transform
   - uid: 3900
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -16.5,-15.5
       parent: 2
       type: Transform
   - uid: 3902
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -19.5,-16.5
       parent: 2
       type: Transform
   - uid: 3903
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -20.5,-16.5
       parent: 2
       type: Transform
   - uid: 3904
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -18.5,-16.5
       parent: 2
       type: Transform
   - uid: 3907
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -20.5,-20.5
       parent: 2
       type: Transform
   - uid: 3908
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -21.5,-18.5
       parent: 2
       type: Transform
   - uid: 3909
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -21.5,-17.5
       parent: 2
       type: Transform
   - uid: 3910
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -21.5,-16.5
       parent: 2
       type: Transform
   - uid: 3929
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 47.5,-11.5
       parent: 2
       type: Transform
   - uid: 3934
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -23.5,-37.5
       parent: 2
       type: Transform
   - uid: 3937
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,-38.5
       parent: 2
       type: Transform
   - uid: 3938
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,-40.5
       parent: 2
       type: Transform
   - uid: 3942
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -25.5,-37.5
       parent: 2
       type: Transform
   - uid: 3945
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -54.5,-10.5
       parent: 2
       type: Transform
   - uid: 3957
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-35.5
       parent: 2
       type: Transform
   - uid: 3958
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -48.5,-13.5
       parent: 2
       type: Transform
   - uid: 3959
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,-30.5
       parent: 2
       type: Transform
   - uid: 3968
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-29.5
       parent: 2
       type: Transform
   - uid: 3969
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-29.5
       parent: 2
       type: Transform
   - uid: 3970
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,-25.5
       parent: 2
       type: Transform
   - uid: 3973
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-25.5
       parent: 2
       type: Transform
   - uid: 3974
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-29.5
       parent: 2
       type: Transform
   - uid: 3975
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-26.5
       parent: 2
       type: Transform
   - uid: 3976
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-27.5
       parent: 2
       type: Transform
   - uid: 3977
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-28.5
       parent: 2
       type: Transform
   - uid: 3978
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-29.5
       parent: 2
       type: Transform
   - uid: 3979
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,-29.5
       parent: 2
       type: Transform
   - uid: 3980
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,-29.5
       parent: 2
       type: Transform
   - uid: 3981
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-29.5
       parent: 2
       type: Transform
   - uid: 3982
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-28.5
       parent: 2
       type: Transform
   - uid: 3983
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-29.5
       parent: 2
       type: Transform
   - uid: 3987
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-25.5
       parent: 2
       type: Transform
   - uid: 3989
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-24.5
       parent: 2
       type: Transform
   - uid: 3991
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,-40.5
       parent: 2
       type: Transform
   - uid: 3992
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,-24.5
       parent: 2
       type: Transform
   - uid: 3997
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-24.5
       parent: 2
       type: Transform
   - uid: 4013
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-35.5
       parent: 2
       type: Transform
   - uid: 4014
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,-35.5
       parent: 2
       type: Transform
   - uid: 4015
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,-35.5
       parent: 2
       type: Transform
   - uid: 4016
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-35.5
       parent: 2
       type: Transform
   - uid: 4017
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-35.5
       parent: 2
       type: Transform
   - uid: 4018
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-35.5
       parent: 2
       type: Transform
   - uid: 4019
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,-35.5
       parent: 2
       type: Transform
   - uid: 4032
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-30.5
       parent: 2
       type: Transform
   - uid: 4042
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 47.5,-0.5
       parent: 2
       type: Transform
   - uid: 4050
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-35.5
       parent: 2
       type: Transform
   - uid: 4052
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-34.5
       parent: 2
       type: Transform
   - uid: 4053
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-29.5
       parent: 2
       type: Transform
   - uid: 4057
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -41.5,-20.5
       parent: 2
       type: Transform
   - uid: 4058
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -45.5,-20.5
       parent: 2
       type: Transform
   - uid: 4060
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -43.5,-20.5
       parent: 2
       type: Transform
   - uid: 4062
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -67.5,-1.5
       parent: 2
       type: Transform
   - uid: 4063
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -41.5,-21.5
       parent: 2
       type: Transform
   - uid: 4064
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-20.5
       parent: 2
       type: Transform
   - uid: 4066
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,23.5
       parent: 2
       type: Transform
   - uid: 4067
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -61.5,0.5
       parent: 2
       type: Transform
   - uid: 4068
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -50.5,-14.5
       parent: 2
       type: Transform
   - uid: 4069
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -16.5,-39.5
       parent: 2
       type: Transform
   - uid: 4072
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -16.5,-40.5
       parent: 2
       type: Transform
   - uid: 4076
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-21.5
       parent: 2
       type: Transform
   - uid: 4096
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -2.5,-28.5
       parent: 2
       type: Transform
   - uid: 4097
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -20.5,-42.5
       parent: 2
       type: Transform
   - uid: 4098
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -16.5,-41.5
       parent: 2
       type: Transform
   - uid: 4099
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -20.5,-43.5
       parent: 2
       type: Transform
   - uid: 4103
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -21.5,-37.5
       parent: 2
       type: Transform
   - uid: 4105
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -16.5,-42.5
       parent: 2
       type: Transform
   - uid: 4107
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -20.5,-37.5
       parent: 2
       type: Transform
   - uid: 4109
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -19.5,-43.5
       parent: 2
       type: Transform
   - uid: 4115
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -18.5,-43.5
       parent: 2
       type: Transform
   - uid: 4116
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,-21.5
       parent: 2
       type: Transform
   - uid: 4131
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 47.5,-3.5
       parent: 2
       type: Transform
   - uid: 4136
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -20.5,-39.5
       parent: 2
       type: Transform
   - uid: 4138
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -20.5,-40.5
       parent: 2
       type: Transform
   - uid: 4141
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -12.5,-43.5
       parent: 2
       type: Transform
   - uid: 4143
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -8.5,-43.5
       parent: 2
       type: Transform
   - uid: 4144
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -10.5,-43.5
       parent: 2
       type: Transform
   - uid: 4155
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-9.5
       parent: 2
       type: Transform
   - uid: 4158
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -58.5,-13.5
       parent: 2
       type: Transform
   - uid: 4160
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -6.5,-43.5
       parent: 2
       type: Transform
   - uid: 4169
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -16.5,-37.5
       parent: 2
       type: Transform
   - uid: 4173
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -4.5,-43.5
       parent: 2
       type: Transform
   - uid: 4174
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -14.5,-43.5
       parent: 2
       type: Transform
   - uid: 4175
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -2.5,-43.5
       parent: 2
       type: Transform
   - uid: 4176
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -17.5,-43.5
       parent: 2
       type: Transform
   - uid: 4179
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -16.5,-43.5
       parent: 2
       type: Transform
   - uid: 4205
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -52.5,20.5
       parent: 2
       type: Transform
   - uid: 4223
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,22.5
       parent: 2
       type: Transform
   - uid: 4225
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -53.5,20.5
       parent: 2
       type: Transform
   - uid: 4231
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,22.5
       parent: 2
       type: Transform
   - uid: 4233
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -43.5,22.5
       parent: 2
       type: Transform
   - uid: 4234
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,22.5
       parent: 2
       type: Transform
   - uid: 4235
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -43.5,21.5
       parent: 2
       type: Transform
   - uid: 4243
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,22.5
       parent: 2
       type: Transform
   - uid: 4246
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,23.5
       parent: 2
       type: Transform
   - uid: 4247
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,23.5
       parent: 2
       type: Transform
   - uid: 4249
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,23.5
       parent: 2
       type: Transform
   - uid: 4251
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -44.5,20.5
       parent: 2
       type: Transform
   - uid: 4253
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -28.5,22.5
       parent: 2
       type: Transform
   - uid: 4254
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -30.5,22.5
       parent: 2
       type: Transform
   - uid: 4257
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -29.5,22.5
       parent: 2
       type: Transform
   - uid: 4261
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -49.5,20.5
       parent: 2
       type: Transform
   - uid: 4264
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -48.5,20.5
       parent: 2
       type: Transform
   - uid: 4273
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,22.5
       parent: 2
       type: Transform
   - uid: 4281
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -43.5,20.5
       parent: 2
       type: Transform
   - uid: 4288
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -50.5,20.5
       parent: 2
       type: Transform
   - uid: 4290
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,-31.5
       parent: 2
       type: Transform
   - uid: 4291
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -51.5,20.5
       parent: 2
       type: Transform
   - uid: 4312
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -59.5,-2.5
       parent: 2
       type: Transform
   - uid: 4313
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -68.5,-1.5
       parent: 2
       type: Transform
   - uid: 4315
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -58.5,-3.5
       parent: 2
       type: Transform
   - uid: 4317
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,22.5
       parent: 2
       type: Transform
   - uid: 4320
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -57.5,-2.5
       parent: 2
       type: Transform
   - uid: 4321
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -18.5,38.5
       parent: 2
       type: Transform
   - uid: 4322
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -19.5,38.5
       parent: 2
       type: Transform
   - uid: 4323
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -20.5,38.5
       parent: 2
       type: Transform
   - uid: 4325
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-26.5
       parent: 2
       type: Transform
   - uid: 4329
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-11.5
       parent: 2
       type: Transform
   - uid: 4330
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-8.5
       parent: 2
       type: Transform
   - uid: 4331
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -54.5,-11.5
       parent: 2
       type: Transform
   - uid: 4332
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -58.5,-7.5
       parent: 2
       type: Transform
   - uid: 4333
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -44.5,-20.5
       parent: 2
       type: Transform
   - uid: 4335
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-18.5
       parent: 2
       type: Transform
   - uid: 4337
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -55.5,20.5
       parent: 2
       type: Transform
   - uid: 4346
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,-32.5
       parent: 2
       type: Transform
   - uid: 4361
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,-33.5
       parent: 2
       type: Transform
   - uid: 4367
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,-34.5
       parent: 2
       type: Transform
   - uid: 4369
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -53.5,-14.5
       parent: 2
       type: Transform
   - uid: 4372
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,-35.5
       parent: 2
       type: Transform
   - uid: 4377
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -27.5,22.5
       parent: 2
       type: Transform
   - uid: 4386
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,9.5
       parent: 2
       type: Transform
   - uid: 4388
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,11.5
       parent: 2
       type: Transform
   - uid: 4389
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -55.5,17.5
       parent: 2
       type: Transform
   - uid: 4390
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -55.5,16.5
       parent: 2
       type: Transform
   - uid: 4391
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -55.5,15.5
       parent: 2
       type: Transform
   - uid: 4392
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -55.5,14.5
       parent: 2
       type: Transform
   - uid: 4393
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -56.5,14.5
       parent: 2
       type: Transform
   - uid: 4394
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -56.5,13.5
       parent: 2
       type: Transform
   - uid: 4395
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -56.5,12.5
       parent: 2
       type: Transform
   - uid: 4396
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -56.5,11.5
       parent: 2
       type: Transform
   - uid: 4397
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -56.5,10.5
       parent: 2
       type: Transform
   - uid: 4398
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -56.5,9.5
       parent: 2
       type: Transform
   - uid: 4399
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -56.5,8.5
       parent: 2
       type: Transform
   - uid: 4405
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 28.5,-27.5
       parent: 2
       type: Transform
   - uid: 4406
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 27.5,-27.5
       parent: 2
       type: Transform
   - uid: 4407
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 26.5,-27.5
       parent: 2
       type: Transform
   - uid: 4408
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 25.5,-27.5
       parent: 2
       type: Transform
   - uid: 4409
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 24.5,-27.5
       parent: 2
       type: Transform
   - uid: 4420
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -1.5,-25.5
       parent: 2
       type: Transform
   - uid: 4425
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -49.5,-14.5
       parent: 2
       type: Transform
   - uid: 4426
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -63.5,-1.5
       parent: 2
       type: Transform
   - uid: 4427
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-24.5
       parent: 2
       type: Transform
   - uid: 4432
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,-25.5
       parent: 2
       type: Transform
   - uid: 4437
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 1.5,-25.5
       parent: 2
       type: Transform
   - uid: 4438
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 0.5,-25.5
       parent: 2
       type: Transform
   - uid: 4439
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -0.5,-25.5
       parent: 2
       type: Transform
   - uid: 4440
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -1.5,-26.5
       parent: 2
       type: Transform
   - uid: 4441
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -1.5,-27.5
       parent: 2
       type: Transform
   - uid: 4447
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -68.5,7.5
       parent: 2
       type: Transform
   - uid: 4451
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-19.5
       parent: 2
       type: Transform
   - uid: 4452
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -54.5,-13.5
       parent: 2
       type: Transform
   - uid: 4453
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-23.5
       parent: 2
       type: Transform
   - uid: 4456
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-23.5
       parent: 2
       type: Transform
   - uid: 4457
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -47.5,-9.5
       parent: 2
       type: Transform
   - uid: 4460
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-20.5
       parent: 2
       type: Transform
   - uid: 4461
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -58.5,-6.5
       parent: 2
       type: Transform
   - uid: 4462
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -54.5,-9.5
       parent: 2
       type: Transform
   - uid: 4464
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-10.5
       parent: 2
       type: Transform
   - uid: 4465
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -58.5,-12.5
       parent: 2
       type: Transform
   - uid: 4480
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-34.5
       parent: 2
       type: Transform
   - uid: 4481
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-34.5
       parent: 2
       type: Transform
   - uid: 4486
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,-33.5
       parent: 2
       type: Transform
   - uid: 4524
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-32.5
       parent: 2
       type: Transform
   - uid: 4533
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-31.5
       parent: 2
       type: Transform
   - uid: 4535
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-35.5
       parent: 2
       type: Transform
   - uid: 4540
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-36.5
       parent: 2
       type: Transform
   - uid: 4545
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-37.5
       parent: 2
       type: Transform
   - uid: 4549
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-29.5
       parent: 2
       type: Transform
   - uid: 4550
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-28.5
       parent: 2
       type: Transform
   - uid: 4554
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,-34.5
       parent: 2
       type: Transform
   - uid: 4556
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-33.5
       parent: 2
       type: Transform
   - uid: 4614
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -54.5,-12.5
       parent: 2
       type: Transform
   - uid: 4616
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -58.5,-11.5
       parent: 2
       type: Transform
   - uid: 4617
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -58.5,-14.5
       parent: 2
       type: Transform
   - uid: 4618
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -52.5,-14.5
       parent: 2
       type: Transform
   - uid: 4619
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -51.5,-14.5
       parent: 2
       type: Transform
   - uid: 4620
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-13.5
       parent: 2
       type: Transform
   - uid: 4621
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -54.5,-14.5
       parent: 2
       type: Transform
   - uid: 4622
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-17.5
       parent: 2
       type: Transform
   - uid: 4623
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-16.5
       parent: 2
       type: Transform
   - uid: 4624
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -48.5,-9.5
       parent: 2
       type: Transform
   - uid: 4625
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -49.5,-9.5
       parent: 2
       type: Transform
   - uid: 4626
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -47.5,-13.5
       parent: 2
       type: Transform
   - uid: 4627
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -51.5,-9.5
       parent: 2
       type: Transform
   - uid: 4630
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -55.5,1.5
       parent: 2
       type: Transform
   - uid: 4631
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-12.5
       parent: 2
       type: Transform
   - uid: 4633
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -49.5,-13.5
       parent: 2
       type: Transform
   - uid: 4640
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -58.5,-15.5
       parent: 2
       type: Transform
   - uid: 4642
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -55.5,-0.5
       parent: 2
       type: Transform
   - uid: 4645
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -55.5,0.5
       parent: 2
       type: Transform
   - uid: 4648
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -66.5,-1.5
       parent: 2
       type: Transform
   - uid: 4649
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -61.5,10.5
       parent: 2
       type: Transform
   - uid: 4652
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -68.5,3.5
       parent: 2
       type: Transform
   - uid: 4659
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-15.5
       parent: 2
       type: Transform
   - uid: 4660
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -56.5,1.5
       parent: 2
       type: Transform
   - uid: 4661
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -55.5,-2.5
       parent: 2
       type: Transform
   - uid: 4662
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-14.5
       parent: 2
       type: Transform
   - uid: 4663
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -61.5,-1.5
       parent: 2
       type: Transform
   - uid: 4664
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -58.5,-2.5
       parent: 2
       type: Transform
   - uid: 4665
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -61.5,1.5
       parent: 2
       type: Transform
   - uid: 4666
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -56.5,-18.5
       parent: 2
       type: Transform
   - uid: 4667
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -61.5,-0.5
       parent: 2
       type: Transform
   - uid: 4668
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -58.5,1.5
       parent: 2
       type: Transform
   - uid: 4669
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -61.5,-2.5
       parent: 2
       type: Transform
   - uid: 4670
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -60.5,-2.5
       parent: 2
       type: Transform
   - uid: 4672
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -57.5,-17.5
       parent: 2
       type: Transform
   - uid: 4673
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -58.5,-16.5
       parent: 2
       type: Transform
   - uid: 4674
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -55.5,-1.5
       parent: 2
       type: Transform
   - uid: 4676
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,10.5
       parent: 2
       type: Transform
   - uid: 4683
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -57.5,-18.5
       parent: 2
       type: Transform
   - uid: 4688
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -49.5,-18.5
       parent: 2
       type: Transform
   - uid: 4691
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -52.5,-18.5
       parent: 2
       type: Transform
   - uid: 4693
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -57.5,-16.5
       parent: 2
       type: Transform
   - uid: 4694
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -56.5,-2.5
       parent: 2
       type: Transform
   - uid: 4696
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-26.5
       parent: 2
       type: Transform
   - uid: 4697
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-26.5
       parent: 2
       type: Transform
   - uid: 4698
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,-26.5
       parent: 2
       type: Transform
   - uid: 4703
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,-26.5
       parent: 2
       type: Transform
   - uid: 4705
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,24.5
       parent: 2
       type: Transform
   - uid: 4706
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,24.5
       parent: 2
       type: Transform
   - uid: 4707
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,25.5
       parent: 2
       type: Transform
   - uid: 4708
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,26.5
       parent: 2
       type: Transform
   - uid: 4709
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,27.5
       parent: 2
       type: Transform
   - uid: 4710
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,28.5
       parent: 2
       type: Transform
   - uid: 4711
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,29.5
       parent: 2
       type: Transform
   - uid: 4712
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,30.5
       parent: 2
       type: Transform
   - uid: 4713
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,31.5
       parent: 2
       type: Transform
   - uid: 4714
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,32.5
       parent: 2
       type: Transform
   - uid: 4715
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,33.5
       parent: 2
       type: Transform
   - uid: 4716
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,33.5
       parent: 2
       type: Transform
   - uid: 4717
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,34.5
       parent: 2
       type: Transform
   - uid: 4718
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,35.5
       parent: 2
       type: Transform
   - uid: 4719
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,35.5
       parent: 2
       type: Transform
   - uid: 4720
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,36.5
       parent: 2
       type: Transform
   - uid: 4721
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,36.5
       parent: 2
       type: Transform
   - uid: 4722
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,37.5
       parent: 2
       type: Transform
   - uid: 4723
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,37.5
       parent: 2
       type: Transform
   - uid: 4724
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,-27.5
       parent: 2
       type: Transform
   - uid: 4725
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,-28.5
       parent: 2
       type: Transform
   - uid: 4726
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,-28.5
       parent: 2
       type: Transform
   - uid: 4728
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-28.5
       parent: 2
       type: Transform
   - uid: 4729
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-28.5
       parent: 2
       type: Transform
   - uid: 4730
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-28.5
       parent: 2
       type: Transform
   - uid: 4731
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-29.5
       parent: 2
       type: Transform
   - uid: 4732
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,-29.5
       parent: 2
       type: Transform
   - uid: 4736
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,-29.5
       parent: 2
       type: Transform
   - uid: 4737
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,-30.5
       parent: 2
       type: Transform
   - uid: 4750
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,-28.5
       parent: 2
       type: Transform
   - uid: 4762
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 28.5,1.5
       parent: 2
       type: Transform
   - uid: 4763
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 29.5,1.5
       parent: 2
       type: Transform
   - uid: 4910
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-26.5
       parent: 2
       type: Transform
   - uid: 4911
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-26.5
       parent: 2
       type: Transform
   - uid: 4912
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-26.5
       parent: 2
       type: Transform
   - uid: 4913
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-26.5
       parent: 2
       type: Transform
   - uid: 4914
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,-26.5
       parent: 2
       type: Transform
   - uid: 4915
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,-26.5
       parent: 2
       type: Transform
   - uid: 4918
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -14.5,-39.5
       parent: 2
       type: Transform
   - uid: 4919
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -12.5,-39.5
       parent: 2
       type: Transform
   - uid: 4920
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -10.5,-39.5
       parent: 2
       type: Transform
   - uid: 4921
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -8.5,-39.5
       parent: 2
       type: Transform
   - uid: 4922
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -6.5,-39.5
       parent: 2
       type: Transform
   - uid: 4923
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -4.5,-39.5
       parent: 2
       type: Transform
   - uid: 4924
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -2.5,-39.5
       parent: 2
       type: Transform
   - uid: 4949
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -14.5,-42.5
       parent: 2
       type: Transform
   - uid: 4950
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -14.5,-41.5
       parent: 2
       type: Transform
   - uid: 4951
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -14.5,-40.5
       parent: 2
       type: Transform
   - uid: 4952
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -12.5,-42.5
       parent: 2
       type: Transform
   - uid: 4953
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -12.5,-41.5
       parent: 2
       type: Transform
   - uid: 4954
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -12.5,-40.5
       parent: 2
       type: Transform
   - uid: 4955
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -10.5,-42.5
       parent: 2
       type: Transform
   - uid: 4956
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -10.5,-41.5
       parent: 2
       type: Transform
   - uid: 4957
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -10.5,-40.5
       parent: 2
       type: Transform
   - uid: 4958
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -8.5,-42.5
       parent: 2
       type: Transform
   - uid: 4959
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -8.5,-41.5
       parent: 2
       type: Transform
   - uid: 4960
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -8.5,-40.5
       parent: 2
       type: Transform
   - uid: 4961
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -6.5,-42.5
       parent: 2
       type: Transform
   - uid: 4962
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -6.5,-41.5
       parent: 2
       type: Transform
   - uid: 4963
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -6.5,-40.5
       parent: 2
       type: Transform
   - uid: 4964
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -4.5,-42.5
       parent: 2
       type: Transform
   - uid: 4965
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -4.5,-41.5
       parent: 2
       type: Transform
   - uid: 4966
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -4.5,-40.5
       parent: 2
       type: Transform
   - uid: 4967
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -2.5,-42.5
       parent: 2
       type: Transform
   - uid: 4968
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -2.5,-41.5
       parent: 2
       type: Transform
   - uid: 4969
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -2.5,-40.5
       parent: 2
       type: Transform
   - uid: 5066
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -61.5,11.5
       parent: 2
       type: Transform
   - uid: 5067
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -61.5,12.5
       parent: 2
       type: Transform
   - uid: 5068
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -56.5,7.5
       parent: 2
       type: Transform
   - uid: 5069
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -56.5,6.5
       parent: 2
       type: Transform
   - uid: 5070
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -56.5,5.5
       parent: 2
       type: Transform
   - uid: 5077
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -66.5,12.5
       parent: 2
       type: Transform
   - uid: 5080
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -61.5,5.5
       parent: 2
       type: Transform
   - uid: 5081
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,12.5
       parent: 2
       type: Transform
   - uid: 5083
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -68.5,12.5
       parent: 2
       type: Transform
   - uid: 5092
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -68.5,-0.5
       parent: 2
       type: Transform
   - uid: 5094
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -67.5,12.5
       parent: 2
       type: Transform
   - uid: 5097
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -62.5,12.5
       parent: 2
       type: Transform
   - uid: 5098
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -63.5,12.5
       parent: 2
       type: Transform
   - uid: 5102
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -60.5,11.5
       parent: 2
       type: Transform
   - uid: 5103
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -57.5,11.5
       parent: 2
       type: Transform
   - uid: 5209
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -61.5,8.5
       parent: 2
       type: Transform
   - uid: 5402
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,-34.5
       parent: 2
       type: Transform
   - uid: 6400
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -22.5,35.5
       parent: 2
       type: Transform
   - uid: 7380
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -25.5,-40.5
       parent: 2
       type: Transform
   - uid: 7467
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -61.5,-9.5
       parent: 2
       type: Transform
   - uid: 7488
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -55.5,-18.5
       parent: 2
       type: Transform
   - uid: 7536
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -61.5,-7.5
       parent: 2
       type: Transform
   - uid: 7539
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -60.5,-7.5
       parent: 2
       type: Transform
   - uid: 7541
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -59.5,-7.5
       parent: 2
       type: Transform
   - uid: 8046
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -23.5,-40.5
       parent: 2
       type: Transform
   - uid: 8628
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,35.5
       parent: 2
       type: Transform
   - uid: 8691
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 30.5,1.5
       parent: 2
       type: Transform
   - uid: 8750
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,12.5
       parent: 2
       type: Transform
   - uid: 8751
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,9.5
       parent: 2
       type: Transform
   - uid: 8752
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,12.5
       parent: 2
       type: Transform
   - uid: 8753
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,9.5
       parent: 2
       type: Transform
   - uid: 8755
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,11.5
       parent: 2
       type: Transform
   - uid: 8756
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,9.5
       parent: 2
       type: Transform
   - uid: 8757
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,12.5
       parent: 2
       type: Transform
   - uid: 8758
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,12.5
       parent: 2
       type: Transform
   - uid: 8759
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,10.5
       parent: 2
       type: Transform
   - uid: 10072
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 18.5,-31.5
       parent: 2
       type: Transform
   - uid: 10073
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 16.5,-31.5
       parent: 2
       type: Transform
   - uid: 10074
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 15.5,-31.5
       parent: 2
       type: Transform
   - uid: 10134
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 50.5,26.5
       parent: 2
       type: Transform
   - uid: 10175
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 50.5,31.5
       parent: 2
       type: Transform
   - uid: 10176
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 50.5,32.5
       parent: 2
       type: Transform
   - uid: 10177
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,32.5
       parent: 2
       type: Transform
   - uid: 10178
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 51.5,33.5
       parent: 2
       type: Transform
   - uid: 10179
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 52.5,33.5
       parent: 2
       type: Transform
   - uid: 10180
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 52.5,34.5
       parent: 2
       type: Transform
   - uid: 10182
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 50.5,27.5
       parent: 2
       type: Transform
   - uid: 10183
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,31.5
       parent: 2
       type: Transform
   - uid: 10186
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 52.5,25.5
       parent: 2
       type: Transform
   - uid: 10187
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 52.5,24.5
       parent: 2
       type: Transform
   - uid: 10188
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 56.5,24.5
       parent: 2
       type: Transform
   - uid: 10189
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 56.5,25.5
       parent: 2
       type: Transform
   - uid: 10191
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 57.5,26.5
       parent: 2
       type: Transform
   - uid: 10192
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,26.5
       parent: 2
       type: Transform
   - uid: 10193
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,27.5
       parent: 2
       type: Transform
   - uid: 10194
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 59.5,27.5
       parent: 2
       type: Transform
   - uid: 10195
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 59.5,31.5
       parent: 2
       type: Transform
   - uid: 10196
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,31.5
       parent: 2
       type: Transform
   - uid: 10197
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 58.5,32.5
       parent: 2
       type: Transform
   - uid: 10198
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 57.5,32.5
       parent: 2
       type: Transform
   - uid: 10200
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 56.5,33.5
       parent: 2
       type: Transform
   - uid: 10201
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 56.5,34.5
       parent: 2
       type: Transform
   - uid: 10205
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,27.5
       parent: 2
       type: Transform
   - uid: 10230
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 57.5,25.5
       parent: 2
       type: Transform
   - uid: 10247
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -13.5,-43.5
       parent: 2
       type: Transform
   - uid: 10291
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -22.5,-39.5
       parent: 2
       type: Transform
   - uid: 10428
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,-43.5
       parent: 2
       type: Transform
   - uid: 10430
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-43.5
       parent: 2
       type: Transform
   - uid: 10581
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-25.5
       parent: 2
       type: Transform
   - uid: 10625
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 57.5,33.5
       parent: 2
       type: Transform
   - uid: 10865
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 59.5,30.5
       parent: 2
       type: Transform
   - uid: 10866
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 59.5,29.5
       parent: 2
       type: Transform
   - uid: 10867
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 59.5,28.5
       parent: 2
       type: Transform
   - uid: 11076
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-26.5
       parent: 2
       type: Transform
   - uid: 11089
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-26.5
       parent: 2
       type: Transform
   - uid: 11090
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-26.5
       parent: 2
       type: Transform
   - uid: 11091
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,-26.5
       parent: 2
       type: Transform
   - uid: 11093
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-25.5
       parent: 2
       type: Transform
   - uid: 11094
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-25.5
       parent: 2
       type: Transform
   - uid: 11095
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-25.5
       parent: 2
       type: Transform
   - uid: 11096
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,-25.5
       parent: 2
       type: Transform
   - uid: 11097
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-26.5
       parent: 2
       type: Transform
   - uid: 11098
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 4.5,-26.5
       parent: 2
       type: Transform
   - uid: 11099
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-26.5
       parent: 2
       type: Transform
   - uid: 11100
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,-26.5
       parent: 2
       type: Transform
   - uid: 11101
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-26.5
       parent: 2
       type: Transform
   - uid: 11466
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -70.5,11.5
       parent: 2
       type: Transform
   - uid: 11468
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -70.5,7.5
       parent: 2
       type: Transform
   - uid: 11476
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -70.5,-0.5
       parent: 2
       type: Transform
   - uid: 11477
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -70.5,1.5
       parent: 2
       type: Transform
   - uid: 11478
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -69.5,1.5
       parent: 2
       type: Transform
   - uid: 11479
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -70.5,3.5
       parent: 2
       type: Transform
   - uid: 11749
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 2.5,-30.5
       parent: 2
       type: Transform
   - uid: 11751
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-29.5
       parent: 2
       type: Transform
   - uid: 11752
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -0.5,-29.5
       parent: 2
       type: Transform
   - uid: 11753
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 1.5,-30.5
       parent: 2
       type: Transform
   - uid: 11760
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 1.5,-29.5
       parent: 2
       type: Transform
   - uid: 11854
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -58.5,-9.5
       parent: 2
       type: Transform
   - uid: 11862
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -59.5,-11.5
       parent: 2
       type: Transform
   - uid: 12158
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 47.5,-8.5
       parent: 2
       type: Transform
   - uid: 12208
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -60.5,-11.5
       parent: 2
       type: Transform
   - uid: 12209
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -61.5,-11.5
       parent: 2
       type: Transform
   - uid: 12214
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -55.5,-21.5
       parent: 2
       type: Transform
   - uid: 12223
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -52.5,-21.5
       parent: 2
       type: Transform
   - uid: 12717
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -0.5,-35.5
       parent: 2
       type: Transform
   - uid: 12718
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-35.5
       parent: 2
       type: Transform
   - uid: 12719
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 1.5,-35.5
       parent: 2
       type: Transform
   - uid: 12720
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 1.5,-34.5
       parent: 2
       type: Transform
   - uid: 12721
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 2.5,-34.5
       parent: 2
@@ -76403,2181 +79202,2981 @@ entities:
   entities:
   - uid: 428
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 37.5,20.5
       parent: 2
       type: Transform
   - uid: 430
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,35.5
       parent: 2
       type: Transform
   - uid: 720
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-29.5
       parent: 2
       type: Transform
   - uid: 2472
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-27.5
       parent: 2
       type: Transform
   - uid: 2473
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-27.5
       parent: 2
       type: Transform
   - uid: 2474
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,-27.5
       parent: 2
       type: Transform
   - uid: 2475
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-27.5
       parent: 2
       type: Transform
   - uid: 2769
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 28.5,21.5
       parent: 2
       type: Transform
   - uid: 3273
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-27.5
       parent: 2
       type: Transform
   - uid: 3274
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,-28.5
       parent: 2
       type: Transform
   - uid: 3275
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,-27.5
       parent: 2
       type: Transform
   - uid: 3276
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-28.5
       parent: 2
       type: Transform
   - uid: 3277
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-27.5
       parent: 2
       type: Transform
   - uid: 3278
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,-27.5
       parent: 2
       type: Transform
   - uid: 3279
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,-26.5
       parent: 2
       type: Transform
   - uid: 3280
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 47.5,-26.5
       parent: 2
       type: Transform
   - uid: 3281
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 48.5,-26.5
       parent: 2
       type: Transform
   - uid: 3282
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 48.5,-25.5
       parent: 2
       type: Transform
   - uid: 4400
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-27.5
       parent: 2
       type: Transform
   - uid: 8470
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -57.5,14.5
       parent: 2
       type: Transform
   - uid: 8471
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -57.5,12.5
       parent: 2
       type: Transform
   - uid: 8472
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -57.5,13.5
       parent: 2
       type: Transform
   - uid: 8473
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -58.5,14.5
       parent: 2
       type: Transform
   - uid: 8474
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -58.5,15.5
       parent: 2
       type: Transform
   - uid: 8475
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -57.5,15.5
       parent: 2
       type: Transform
   - uid: 8476
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -56.5,15.5
       parent: 2
       type: Transform
   - uid: 8477
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -57.5,16.5
       parent: 2
       type: Transform
   - uid: 8478
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -56.5,16.5
       parent: 2
       type: Transform
   - uid: 8479
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -56.5,17.5
       parent: 2
       type: Transform
   - uid: 8480
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -62.5,14.5
       parent: 2
       type: Transform
   - uid: 8481
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -60.5,12.5
       parent: 2
       type: Transform
   - uid: 8482
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -61.5,13.5
       parent: 2
       type: Transform
   - uid: 8483
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -62.5,13.5
       parent: 2
       type: Transform
   - uid: 8484
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -61.5,14.5
       parent: 2
       type: Transform
   - uid: 8485
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -60.5,13.5
       parent: 2
       type: Transform
   - uid: 8486
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -63.5,13.5
       parent: 2
       type: Transform
   - uid: 8495
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 12.5,40.5
       parent: 2
       type: Transform
   - uid: 8549
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 29.5,21.5
       parent: 2
       type: Transform
   - uid: 8550
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 30.5,21.5
       parent: 2
       type: Transform
   - uid: 8551
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 31.5,21.5
       parent: 2
       type: Transform
   - uid: 8552
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 32.5,21.5
       parent: 2
       type: Transform
   - uid: 8553
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 33.5,21.5
       parent: 2
       type: Transform
   - uid: 8554
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 32.5,22.5
       parent: 2
       type: Transform
   - uid: 8555
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 32.5,23.5
       parent: 2
       type: Transform
   - uid: 8556
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 32.5,24.5
       parent: 2
       type: Transform
   - uid: 8557
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 33.5,22.5
       parent: 2
       type: Transform
   - uid: 8559
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 31.5,23.5
       parent: 2
       type: Transform
   - uid: 8560
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 31.5,24.5
       parent: 2
       type: Transform
   - uid: 8561
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 31.5,25.5
       parent: 2
       type: Transform
   - uid: 8564
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 30.5,24.5
       parent: 2
       type: Transform
   - uid: 8565
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 30.5,25.5
       parent: 2
       type: Transform
   - uid: 8566
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 29.5,22.5
       parent: 2
       type: Transform
   - uid: 8568
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 29.5,24.5
       parent: 2
       type: Transform
   - uid: 8569
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 29.5,25.5
       parent: 2
       type: Transform
   - uid: 8570
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 28.5,22.5
       parent: 2
       type: Transform
   - uid: 8571
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 28.5,23.5
       parent: 2
       type: Transform
   - uid: 8572
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 28.5,24.5
       parent: 2
       type: Transform
   - uid: 8573
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 28.5,25.5
       parent: 2
       type: Transform
   - uid: 8574
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 28.5,33.5
       parent: 2
       type: Transform
   - uid: 8575
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 27.5,31.5
       parent: 2
       type: Transform
   - uid: 8576
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 28.5,32.5
       parent: 2
       type: Transform
   - uid: 8577
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 27.5,32.5
       parent: 2
       type: Transform
   - uid: 8578
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 29.5,26.5
       parent: 2
       type: Transform
   - uid: 8579
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 27.5,33.5
       parent: 2
       type: Transform
   - uid: 8580
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 28.5,26.5
       parent: 2
       type: Transform
   - uid: 8581
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 31.5,30.5
       parent: 2
       type: Transform
   - uid: 8582
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 31.5,29.5
       parent: 2
       type: Transform
   - uid: 8583
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 32.5,29.5
       parent: 2
       type: Transform
   - uid: 8584
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 33.5,28.5
       parent: 2
       type: Transform
   - uid: 8585
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 32.5,28.5
       parent: 2
       type: Transform
   - uid: 8586
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 33.5,29.5
       parent: 2
       type: Transform
   - uid: 8587
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 33.5,30.5
       parent: 2
       type: Transform
   - uid: 8588
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 32.5,30.5
       parent: 2
       type: Transform
   - uid: 8589
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 31.5,31.5
       parent: 2
       type: Transform
   - uid: 8590
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 32.5,31.5
       parent: 2
       type: Transform
   - uid: 8591
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 34.5,29.5
       parent: 2
       type: Transform
   - uid: 8592
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 34.5,28.5
       parent: 2
       type: Transform
   - uid: 8593
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 30.5,31.5
       parent: 2
       type: Transform
   - uid: 8594
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 30.5,30.5
       parent: 2
       type: Transform
   - uid: 8595
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 31.5,32.5
       parent: 2
       type: Transform
   - uid: 8596
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 28.5,34.5
       parent: 2
       type: Transform
   - uid: 8597
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 25.5,35.5
       parent: 2
       type: Transform
   - uid: 8598
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 27.5,35.5
       parent: 2
       type: Transform
   - uid: 8599
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 27.5,34.5
       parent: 2
       type: Transform
   - uid: 8600
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 25.5,34.5
       parent: 2
       type: Transform
   - uid: 8601
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 26.5,35.5
       parent: 2
       type: Transform
   - uid: 8602
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 26.5,34.5
       parent: 2
       type: Transform
   - uid: 8603
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 29.5,34.5
       parent: 2
       type: Transform
   - uid: 8604
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 25.5,36.5
       parent: 2
       type: Transform
   - uid: 8605
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 26.5,36.5
       parent: 2
       type: Transform
   - uid: 8606
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 24.5,35.5
       parent: 2
       type: Transform
   - uid: 8607
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 24.5,34.5
       parent: 2
       type: Transform
   - uid: 8608
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 23.5,34.5
       parent: 2
       type: Transform
   - uid: 8609
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 18.5,34.5
       parent: 2
       type: Transform
   - uid: 8610
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 16.5,36.5
       parent: 2
       type: Transform
   - uid: 8611
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 17.5,34.5
       parent: 2
       type: Transform
   - uid: 8612
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 17.5,35.5
       parent: 2
       type: Transform
   - uid: 8613
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 16.5,35.5
       parent: 2
       type: Transform
   - uid: 8614
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 16.5,34.5
       parent: 2
       type: Transform
   - uid: 8615
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 15.5,35.5
       parent: 2
       type: Transform
   - uid: 8616
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 8.5,34.5
       parent: 2
       type: Transform
   - uid: 8617
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 18.5,35.5
       parent: 2
       type: Transform
   - uid: 8618
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 17.5,36.5
       parent: 2
       type: Transform
   - uid: 8619
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 19.5,34.5
       parent: 2
       type: Transform
   - uid: 8620
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 9.5,34.5
       parent: 2
       type: Transform
   - uid: 8621
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 10.5,34.5
       parent: 2
       type: Transform
   - uid: 8622
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 11.5,35.5
       parent: 2
       type: Transform
   - uid: 8623
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 10.5,35.5
       parent: 2
       type: Transform
   - uid: 8624
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 9.5,35.5
       parent: 2
       type: Transform
   - uid: 8625
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 8.5,35.5
       parent: 2
       type: Transform
   - uid: 8626
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 10.5,36.5
       parent: 2
       type: Transform
   - uid: 8627
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 9.5,36.5
       parent: 2
       type: Transform
   - uid: 8629
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 8.5,36.5
       parent: 2
       type: Transform
   - uid: 8630
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 34.5,10.5
       parent: 2
       type: Transform
   - uid: 8631
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 35.5,10.5
       parent: 2
       type: Transform
   - uid: 8632
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 36.5,10.5
       parent: 2
       type: Transform
   - uid: 8633
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 37.5,10.5
       parent: 2
       type: Transform
   - uid: 8634
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 38.5,10.5
       parent: 2
       type: Transform
   - uid: 8635
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 39.5,10.5
       parent: 2
       type: Transform
   - uid: 8636
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 40.5,10.5
       parent: 2
       type: Transform
   - uid: 8637
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 39.5,11.5
       parent: 2
       type: Transform
   - uid: 8638
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 39.5,12.5
       parent: 2
       type: Transform
   - uid: 8639
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 38.5,11.5
       parent: 2
       type: Transform
   - uid: 8640
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 38.5,12.5
       parent: 2
       type: Transform
   - uid: 8641
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 37.5,11.5
       parent: 2
       type: Transform
   - uid: 8642
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 37.5,12.5
       parent: 2
       type: Transform
   - uid: 8647
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 34.5,11.5
       parent: 2
       type: Transform
   - uid: 8649
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 38.5,13.5
       parent: 2
       type: Transform
   - uid: 8650
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 38.5,14.5
       parent: 2
       type: Transform
   - uid: 8651
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 38.5,15.5
       parent: 2
       type: Transform
   - uid: 8652
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 38.5,16.5
       parent: 2
       type: Transform
   - uid: 8653
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 38.5,17.5
       parent: 2
       type: Transform
   - uid: 8654
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 38.5,18.5
       parent: 2
       type: Transform
   - uid: 8655
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 37.5,13.5
       parent: 2
       type: Transform
   - uid: 8656
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 37.5,14.5
       parent: 2
       type: Transform
   - uid: 8657
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 37.5,15.5
       parent: 2
       type: Transform
   - uid: 8658
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 37.5,16.5
       parent: 2
       type: Transform
   - uid: 8659
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 37.5,17.5
       parent: 2
       type: Transform
   - uid: 8660
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 37.5,18.5
       parent: 2
       type: Transform
   - uid: 8663
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 36.5,15.5
       parent: 2
       type: Transform
   - uid: 8664
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 36.5,16.5
       parent: 2
       type: Transform
   - uid: 8665
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 36.5,17.5
       parent: 2
       type: Transform
   - uid: 8666
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 36.5,18.5
       parent: 2
       type: Transform
   - uid: 8667
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 37.5,19.5
       parent: 2
       type: Transform
   - uid: 8668
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 36.5,19.5
       parent: 2
       type: Transform
   - uid: 8671
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 35.5,15.5
       parent: 2
       type: Transform
   - uid: 8672
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 35.5,16.5
       parent: 2
       type: Transform
   - uid: 8673
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 35.5,17.5
       parent: 2
       type: Transform
   - uid: 8674
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 35.5,18.5
       parent: 2
       type: Transform
   - uid: 8675
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 35.5,19.5
       parent: 2
       type: Transform
   - uid: 8676
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 36.5,21.5
       parent: 2
       type: Transform
   - uid: 8677
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 36.5,20.5
       parent: 2
       type: Transform
   - uid: 8679
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 34.5,14.5
       parent: 2
       type: Transform
   - uid: 8680
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 34.5,15.5
       parent: 2
       type: Transform
   - uid: 8681
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 34.5,16.5
       parent: 2
       type: Transform
   - uid: 8682
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 34.5,17.5
       parent: 2
       type: Transform
   - uid: 8683
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 34.5,18.5
       parent: 2
       type: Transform
   - uid: 8684
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 34.5,19.5
       parent: 2
       type: Transform
   - uid: 8685
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 34.5,20.5
       parent: 2
       type: Transform
   - uid: 8686
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 34.5,21.5
       parent: 2
       type: Transform
   - uid: 8687
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 34.5,22.5
       parent: 2
       type: Transform
   - uid: 8688
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 33.5,23.5
       parent: 2
       type: Transform
   - uid: 8689
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 35.5,20.5
       parent: 2
       type: Transform
   - uid: 8690
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 35.5,21.5
       parent: 2
       type: Transform
   - uid: 8692
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 1.5,35.5
       parent: 2
       type: Transform
   - uid: 8693
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 1.5,36.5
       parent: 2
       type: Transform
   - uid: 8694
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,35.5
       parent: 2
       type: Transform
   - uid: 8695
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,36.5
       parent: 2
       type: Transform
   - uid: 8696
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -0.5,35.5
       parent: 2
       type: Transform
   - uid: 8697
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -0.5,36.5
       parent: 2
       type: Transform
   - uid: 8698
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -1.5,35.5
       parent: 2
       type: Transform
   - uid: 8699
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -1.5,36.5
       parent: 2
       type: Transform
   - uid: 8700
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -2.5,35.5
       parent: 2
       type: Transform
   - uid: 8701
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -2.5,36.5
       parent: 2
       type: Transform
   - uid: 8702
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -3.5,36.5
       parent: 2
       type: Transform
   - uid: 8703
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -4.5,37.5
       parent: 2
       type: Transform
   - uid: 8704
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 3.5,39.5
       parent: 2
       type: Transform
   - uid: 8705
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -3.5,37.5
       parent: 2
       type: Transform
   - uid: 8706
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 2.5,39.5
       parent: 2
       type: Transform
   - uid: 8707
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -2.5,37.5
       parent: 2
       type: Transform
   - uid: 8708
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 2.5,40.5
       parent: 2
       type: Transform
   - uid: 8709
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -1.5,37.5
       parent: 2
       type: Transform
   - uid: 8710
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 3.5,38.5
       parent: 2
       type: Transform
   - uid: 8711
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -0.5,37.5
       parent: 2
       type: Transform
   - uid: 8712
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 4.5,38.5
       parent: 2
       type: Transform
   - uid: 8713
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 2.5,35.5
       parent: 2
       type: Transform
   - uid: 8714
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,37.5
       parent: 2
       type: Transform
   - uid: 8715
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -4.5,38.5
       parent: 2
       type: Transform
   - uid: 8716
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -3.5,38.5
       parent: 2
       type: Transform
   - uid: 8717
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -4.5,39.5
       parent: 2
       type: Transform
   - uid: 8718
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -2.5,38.5
       parent: 2
       type: Transform
   - uid: 8719
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -3.5,39.5
       parent: 2
       type: Transform
   - uid: 8720
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -1.5,38.5
       parent: 2
       type: Transform
   - uid: 8721
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 5.5,38.5
       parent: 2
       type: Transform
   - uid: 8722
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 4.5,39.5
       parent: 2
       type: Transform
   - uid: 8723
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 4.5,40.5
       parent: 2
       type: Transform
   - uid: 8724
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 3.5,40.5
       parent: 2
       type: Transform
   - uid: 8725
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 5.5,39.5
       parent: 2
       type: Transform
   - uid: 8727
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 13.5,41.5
       parent: 2
       type: Transform
   - uid: 8728
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 13.5,40.5
       parent: 2
       type: Transform
   - uid: 8729
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 12.5,41.5
       parent: 2
       type: Transform
   - uid: 8730
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 14.5,40.5
       parent: 2
       type: Transform
   - uid: 8731
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 14.5,39.5
       parent: 2
       type: Transform
   - uid: 8732
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 15.5,40.5
       parent: 2
       type: Transform
   - uid: 8733
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 15.5,39.5
       parent: 2
       type: Transform
   - uid: 8734
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 16.5,40.5
       parent: 2
       type: Transform
   - uid: 8735
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 16.5,39.5
       parent: 2
       type: Transform
   - uid: 8736
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 17.5,40.5
       parent: 2
       type: Transform
   - uid: 8737
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 13.5,39.5
       parent: 2
       type: Transform
   - uid: 8738
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 15.5,38.5
       parent: 2
       type: Transform
   - uid: 8739
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 16.5,38.5
       parent: 2
       type: Transform
   - uid: 8740
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 17.5,39.5
       parent: 2
       type: Transform
   - uid: 9580
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-22.5
       parent: 2
       type: Transform
   - uid: 11692
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-44.5
       parent: 2
       type: Transform
   - uid: 11693
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-45.5
       parent: 2
       type: Transform
   - uid: 11694
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-43.5
       parent: 2
       type: Transform
   - uid: 11695
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-44.5
       parent: 2
       type: Transform
   - uid: 11696
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-44.5
       parent: 2
       type: Transform
   - uid: 11697
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,-45.5
       parent: 2
       type: Transform
   - uid: 11698
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,-44.5
       parent: 2
       type: Transform
   - uid: 11699
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,-45.5
       parent: 2
       type: Transform
   - uid: 11700
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,-44.5
       parent: 2
       type: Transform
   - uid: 11701
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,-44.5
       parent: 2
       type: Transform
   - uid: 11702
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-44.5
       parent: 2
       type: Transform
   - uid: 11703
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-45.5
       parent: 2
       type: Transform
   - uid: 11704
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,-45.5
       parent: 2
       type: Transform
   - uid: 11705
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-45.5
       parent: 2
       type: Transform
   - uid: 11706
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-44.5
       parent: 2
       type: Transform
   - uid: 11707
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-44.5
       parent: 2
       type: Transform
   - uid: 11708
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-44.5
       parent: 2
       type: Transform
   - uid: 11709
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-44.5
       parent: 2
       type: Transform
   - uid: 11710
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-45.5
       parent: 2
       type: Transform
   - uid: 11711
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-44.5
       parent: 2
       type: Transform
   - uid: 11712
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-45.5
       parent: 2
       type: Transform
   - uid: 11713
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-45.5
       parent: 2
       type: Transform
   - uid: 11714
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-44.5
       parent: 2
       type: Transform
   - uid: 11715
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-44.5
       parent: 2
       type: Transform
   - uid: 11716
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-43.5
       parent: 2
       type: Transform
   - uid: 11717
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-42.5
       parent: 2
       type: Transform
   - uid: 11718
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-43.5
       parent: 2
       type: Transform
   - uid: 11719
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,-30.5
       parent: 2
       type: Transform
   - uid: 11731
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-29.5
       parent: 2
       type: Transform
   - uid: 11732
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-29.5
       parent: 2
       type: Transform
   - uid: 11733
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-30.5
       parent: 2
       type: Transform
   - uid: 11734
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-29.5
       parent: 2
       type: Transform
   - uid: 11735
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-28.5
       parent: 2
       type: Transform
   - uid: 11736
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-27.5
       parent: 2
       type: Transform
   - uid: 11737
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,-27.5
       parent: 2
       type: Transform
   - uid: 11738
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,-28.5
       parent: 2
       type: Transform
   - uid: 11739
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-27.5
       parent: 2
       type: Transform
   - uid: 11763
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 4.5,-29.5
       parent: 2
       type: Transform
   - uid: 11764
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-28.5
       parent: 2
       type: Transform
   - uid: 11767
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-30.5
       parent: 2
       type: Transform
   - uid: 11773
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-30.5
       parent: 2
       type: Transform
   - uid: 11774
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-31.5
       parent: 2
       type: Transform
   - uid: 11775
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-31.5
       parent: 2
       type: Transform
   - uid: 11776
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-30.5
       parent: 2
       type: Transform
   - uid: 11777
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-29.5
       parent: 2
       type: Transform
   - uid: 11778
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-29.5
       parent: 2
       type: Transform
   - uid: 11779
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-30.5
       parent: 2
       type: Transform
   - uid: 11780
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-28.5
       parent: 2
       type: Transform
   - uid: 11781
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,-28.5
       parent: 2
       type: Transform
   - uid: 11782
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,-29.5
       parent: 2
       type: Transform
   - uid: 11783
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,-28.5
       parent: 2
       type: Transform
   - uid: 11784
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-28.5
       parent: 2
       type: Transform
   - uid: 11785
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-28.5
       parent: 2
       type: Transform
   - uid: 11786
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-27.5
       parent: 2
       type: Transform
   - uid: 11787
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,-27.5
       parent: 2
       type: Transform
   - uid: 11788
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-29.5
       parent: 2
       type: Transform
   - uid: 11789
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,-29.5
       parent: 2
       type: Transform
   - uid: 11791
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-28.5
       parent: 2
       type: Transform
   - uid: 11792
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-28.5
       parent: 2
       type: Transform
   - uid: 11793
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-28.5
       parent: 2
       type: Transform
   - uid: 11794
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-28.5
       parent: 2
       type: Transform
   - uid: 11795
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-28.5
       parent: 2
       type: Transform
   - uid: 11796
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-29.5
       parent: 2
       type: Transform
   - uid: 11797
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-29.5
       parent: 2
       type: Transform
   - uid: 11798
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-29.5
       parent: 2
       type: Transform
   - uid: 11799
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-29.5
       parent: 2
       type: Transform
   - uid: 11800
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,-30.5
       parent: 2
       type: Transform
   - uid: 11801
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-30.5
       parent: 2
       type: Transform
   - uid: 11802
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-29.5
       parent: 2
       type: Transform
   - uid: 11806
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,-29.5
       parent: 2
       type: Transform
   - uid: 11807
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,-29.5
       parent: 2
       type: Transform
   - uid: 11808
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-28.5
       parent: 2
       type: Transform
   - uid: 11809
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,-28.5
       parent: 2
       type: Transform
   - uid: 11813
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,-38.5
       parent: 2
       type: Transform
   - uid: 11814
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,-37.5
       parent: 2
       type: Transform
   - uid: 11815
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-37.5
       parent: 2
       type: Transform
   - uid: 11816
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-38.5
       parent: 2
       type: Transform
   - uid: 11817
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-39.5
       parent: 2
       type: Transform
   - uid: 11818
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-39.5
       parent: 2
       type: Transform
   - uid: 11819
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-38.5
       parent: 2
       type: Transform
   - uid: 11820
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-37.5
       parent: 2
       type: Transform
   - uid: 11821
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-36.5
       parent: 2
       type: Transform
   - uid: 11822
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-36.5
       parent: 2
       type: Transform
   - uid: 11823
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-35.5
       parent: 2
       type: Transform
   - uid: 11824
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-36.5
       parent: 2
       type: Transform
   - uid: 11825
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-37.5
       parent: 2
       type: Transform
   - uid: 11831
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-38.5
       parent: 2
       type: Transform
   - uid: 11832
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-38.5
       parent: 2
       type: Transform
   - uid: 11833
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-37.5
       parent: 2
       type: Transform
   - uid: 11834
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-37.5
       parent: 2
       type: Transform
   - uid: 11835
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-36.5
       parent: 2
       type: Transform
   - uid: 11836
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-36.5
       parent: 2
       type: Transform
   - uid: 11837
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-37.5
       parent: 2
       type: Transform
   - uid: 11838
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,-36.5
       parent: 2
       type: Transform
   - uid: 11839
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,-29.5
       parent: 2
       type: Transform
   - uid: 11840
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,-30.5
       parent: 2
       type: Transform
   - uid: 11841
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,-31.5
       parent: 2
       type: Transform
   - uid: 11842
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,-32.5
       parent: 2
       type: Transform
   - uid: 11843
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-31.5
       parent: 2
       type: Transform
   - uid: 11844
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-30.5
       parent: 2
       type: Transform
   - uid: 11845
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,-25.5
       parent: 2
       type: Transform
   - uid: 11846
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-25.5
       parent: 2
       type: Transform
   - uid: 11847
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-24.5
       parent: 2
       type: Transform
   - uid: 11848
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-27.5
       parent: 2
       type: Transform
   - uid: 11849
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-28.5
       parent: 2
       type: Transform
   - uid: 11850
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,-28.5
       parent: 2
       type: Transform
   - uid: 11851
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,-29.5
       parent: 2
       type: Transform
   - uid: 11856
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -41.5,-23.5
       parent: 2
       type: Transform
   - uid: 11857
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -40.5,-22.5
       parent: 2
       type: Transform
   - uid: 11860
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-21.5
       parent: 2
       type: Transform
   - uid: 11861
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -41.5,-22.5
       parent: 2
       type: Transform
   - uid: 11875
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,34.5
       parent: 2
       type: Transform
   - uid: 11876
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,35.5
       parent: 2
       type: Transform
   - uid: 11877
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,36.5
       parent: 2
       type: Transform
   - uid: 11878
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,36.5
       parent: 2
       type: Transform
   - uid: 11879
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,37.5
       parent: 2
       type: Transform
   - uid: 11880
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,38.5
       parent: 2
       type: Transform
   - uid: 11881
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,39.5
       parent: 2
       type: Transform
   - uid: 11882
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,39.5
       parent: 2
       type: Transform
   - uid: 11883
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,40.5
       parent: 2
       type: Transform
   - uid: 11884
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,40.5
       parent: 2
       type: Transform
   - uid: 11885
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,40.5
       parent: 2
       type: Transform
   - uid: 11886
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,41.5
       parent: 2
       type: Transform
   - uid: 11887
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,41.5
       parent: 2
       type: Transform
   - uid: 11888
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,41.5
       parent: 2
       type: Transform
   - uid: 11889
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,42.5
       parent: 2
       type: Transform
   - uid: 11890
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,42.5
       parent: 2
       type: Transform
   - uid: 11891
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,42.5
       parent: 2
       type: Transform
   - uid: 11892
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,41.5
       parent: 2
       type: Transform
   - uid: 11893
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,41.5
       parent: 2
       type: Transform
   - uid: 11894
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,41.5
       parent: 2
       type: Transform
   - uid: 11895
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,40.5
       parent: 2
       type: Transform
   - uid: 11896
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,39.5
       parent: 2
       type: Transform
   - uid: 11897
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,38.5
       parent: 2
       type: Transform
   - uid: 11898
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,37.5
       parent: 2
       type: Transform
   - uid: 11899
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,34.5
       parent: 2
       type: Transform
   - uid: 11900
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,35.5
       parent: 2
       type: Transform
   - uid: 11901
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,36.5
       parent: 2
       type: Transform
   - uid: 11902
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,34.5
       parent: 2
       type: Transform
   - uid: 11903
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,35.5
       parent: 2
       type: Transform
   - uid: 11904
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,36.5
       parent: 2
       type: Transform
   - uid: 11905
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,35.5
       parent: 2
       type: Transform
   - uid: 11906
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,36.5
       parent: 2
       type: Transform
   - uid: 11907
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,36.5
       parent: 2
       type: Transform
   - uid: 11908
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,37.5
       parent: 2
       type: Transform
   - uid: 11909
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,37.5
       parent: 2
       type: Transform
   - uid: 11910
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,37.5
       parent: 2
       type: Transform
   - uid: 11911
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,38.5
       parent: 2
       type: Transform
   - uid: 11912
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,38.5
       parent: 2
       type: Transform
   - uid: 11913
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,37.5
       parent: 2
       type: Transform
   - uid: 11914
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,38.5
       parent: 2
       type: Transform
   - uid: 11915
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,39.5
       parent: 2
       type: Transform
   - uid: 11916
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,39.5
       parent: 2
       type: Transform
   - uid: 11917
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,38.5
       parent: 2
       type: Transform
   - uid: 11918
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,40.5
       parent: 2
       type: Transform
   - uid: 11919
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,40.5
       parent: 2
       type: Transform
   - uid: 11920
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,47.5
       parent: 2
       type: Transform
   - uid: 11921
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,46.5
       parent: 2
       type: Transform
   - uid: 11922
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,47.5
       parent: 2
       type: Transform
   - uid: 11923
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,46.5
       parent: 2
       type: Transform
   - uid: 11924
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,47.5
       parent: 2
       type: Transform
   - uid: 11925
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,46.5
       parent: 2
       type: Transform
   - uid: 11926
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,47.5
       parent: 2
       type: Transform
   - uid: 11927
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,46.5
       parent: 2
       type: Transform
   - uid: 11928
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,46.5
       parent: 2
       type: Transform
   - uid: 11929
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,45.5
       parent: 2
       type: Transform
   - uid: 11930
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,45.5
       parent: 2
       type: Transform
   - uid: 11931
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,45.5
       parent: 2
       type: Transform
   - uid: 11932
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,45.5
       parent: 2
       type: Transform
   - uid: 11933
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,44.5
       parent: 2
       type: Transform
   - uid: 11934
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,44.5
       parent: 2
       type: Transform
   - uid: 11935
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,44.5
       parent: 2
       type: Transform
   - uid: 11936
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,45.5
       parent: 2
       type: Transform
   - uid: 11937
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,46.5
       parent: 2
       type: Transform
   - uid: 11938
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,48.5
       parent: 2
       type: Transform
   - uid: 11939
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,48.5
       parent: 2
       type: Transform
   - uid: 11940
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,48.5
       parent: 2
       type: Transform
   - uid: 12224
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,-23.5
       parent: 2
       type: Transform
   - uid: 12225
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-22.5
       parent: 2
       type: Transform
   - uid: 12226
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-23.5
       parent: 2
       type: Transform
   - uid: 12227
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-24.5
       parent: 2
       type: Transform
   - uid: 12228
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,-24.5
       parent: 2
       type: Transform
   - uid: 12722
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 4.5,-28.5
       parent: 2
       type: Transform
   - uid: 12723
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-27.5
       parent: 2
       type: Transform
   - uid: 12724
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,-28.5
       parent: 2
       type: Transform
   - uid: 12725
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,-29.5
       parent: 2
       type: Transform
   - uid: 12726
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-28.5
       parent: 2
       type: Transform
@@ -78585,16 +82184,22 @@ entities:
   entities:
   - uid: 11803
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-27.5
       parent: 2
       type: Transform
   - uid: 11804
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,-27.5
       parent: 2
       type: Transform
   - uid: 11805
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,-28.5
       parent: 2
       type: Transform
@@ -78602,26 +82207,36 @@ entities:
   entities:
   - uid: 11863
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,39.5
       parent: 2
       type: Transform
   - uid: 11864
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,40.5
       parent: 2
       type: Transform
   - uid: 11865
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,40.5
       parent: 2
       type: Transform
   - uid: 11866
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,39.5
       parent: 2
       type: Transform
   - uid: 11867
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,39.5
       parent: 2
       type: Transform
@@ -78629,16 +82244,22 @@ entities:
   entities:
   - uid: 11720
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-26.5
       parent: 2
       type: Transform
   - uid: 11721
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-26.5
       parent: 2
       type: Transform
   - uid: 11722
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-27.5
       parent: 2
       type: Transform
@@ -78646,21 +82267,29 @@ entities:
   entities:
   - uid: 8563
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,23.5
       parent: 2
       type: Transform
   - uid: 8567
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,23.5
       parent: 2
       type: Transform
   - uid: 8643
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,22.5
       parent: 2
       type: Transform
   - uid: 8644
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,22.5
       parent: 2
       type: Transform
@@ -78668,21 +82297,29 @@ entities:
   entities:
   - uid: 8646
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,12.5
       parent: 2
       type: Transform
   - uid: 8662
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,11.5
       parent: 2
       type: Transform
   - uid: 10860
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,12.5
       parent: 2
       type: Transform
   - uid: 11826
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,-36.5
       parent: 2
       type: Transform
@@ -78690,156 +82327,218 @@ entities:
   entities:
   - uid: 8645
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,11.5
       parent: 2
       type: Transform
   - uid: 8648
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,13.5
       parent: 2
       type: Transform
   - uid: 8661
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,13.5
       parent: 2
       type: Transform
   - uid: 8669
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,12.5
       parent: 2
       type: Transform
   - uid: 8670
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,14.5
       parent: 2
       type: Transform
   - uid: 8678
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,13.5
       parent: 2
       type: Transform
   - uid: 10859
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,14.5
       parent: 2
       type: Transform
   - uid: 11723
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-26.5
       parent: 2
       type: Transform
   - uid: 11724
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-27.5
       parent: 2
       type: Transform
   - uid: 11725
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-28.5
       parent: 2
       type: Transform
   - uid: 11726
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-28.5
       parent: 2
       type: Transform
   - uid: 11727
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-28.5
       parent: 2
       type: Transform
   - uid: 11728
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-27.5
       parent: 2
       type: Transform
   - uid: 11729
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-26.5
       parent: 2
       type: Transform
   - uid: 11730
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-29.5
       parent: 2
       type: Transform
   - uid: 11827
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-36.5
       parent: 2
       type: Transform
   - uid: 11828
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-36.5
       parent: 2
       type: Transform
   - uid: 11829
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-37.5
       parent: 2
       type: Transform
   - uid: 11830
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,-37.5
       parent: 2
       type: Transform
   - uid: 11868
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,38.5
       parent: 2
       type: Transform
   - uid: 11869
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,38.5
       parent: 2
       type: Transform
   - uid: 11870
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,37.5
       parent: 2
       type: Transform
   - uid: 11871
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,39.5
       parent: 2
       type: Transform
   - uid: 11872
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,38.5
       parent: 2
       type: Transform
   - uid: 11873
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,37.5
       parent: 2
       type: Transform
   - uid: 11874
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,36.5
       parent: 2
       type: Transform
   - uid: 12730
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-27.5
       parent: 2
       type: Transform
   - uid: 12731
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-26.5
       parent: 2
       type: Transform
   - uid: 12732
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-26.5
       parent: 2
       type: Transform
   - uid: 12733
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-27.5
       parent: 2
       type: Transform
   - uid: 12734
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,-27.5
       parent: 2
       type: Transform
@@ -78847,16 +82546,22 @@ entities:
   entities:
   - uid: 12727
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,-28.5
       parent: 2
       type: Transform
   - uid: 12728
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-28.5
       parent: 2
       type: Transform
   - uid: 12729
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-27.5
       parent: 2
       type: Transform
@@ -78864,200 +82569,272 @@ entities:
   entities:
   - uid: 5122
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -31.5,33.5
       parent: 2
       type: Transform
   - uid: 7661
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -30.5,32.5
       parent: 2
       type: Transform
   - uid: 7665
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -31.5,24.5
       parent: 2
       type: Transform
   - uid: 7667
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,24.5
       parent: 2
       type: Transform
   - uid: 7668
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,24.5
       parent: 2
       type: Transform
   - uid: 7669
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,24.5
       parent: 2
       type: Transform
   - uid: 7670
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,24.5
       parent: 2
       type: Transform
   - uid: 7671
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,33.5
       parent: 2
       type: Transform
   - uid: 7672
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,33.5
       parent: 2
       type: Transform
   - uid: 7673
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,33.5
       parent: 2
       type: Transform
   - uid: 7674
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,33.5
       parent: 2
       type: Transform
   - uid: 7677
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -45.5,32.5
       parent: 2
       type: Transform
   - uid: 7684
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -45.5,33.5
       parent: 2
       type: Transform
   - uid: 7701
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,32.5
       parent: 2
       type: Transform
   - uid: 7702
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,25.5
       parent: 2
       type: Transform
   - uid: 7704
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -45.5,24.5
       parent: 2
       type: Transform
   - uid: 7712
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -45.5,27.5
       parent: 2
       type: Transform
   - uid: 7715
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -45.5,29.5
       parent: 2
       type: Transform
   - uid: 7716
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,25.5
       parent: 2
       type: Transform
   - uid: 7717
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -45.5,25.5
       parent: 2
       type: Transform
   - uid: 7725
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -31.5,29.5
       parent: 2
       type: Transform
   - uid: 7729
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -32.5,24.5
       parent: 2
       type: Transform
   - uid: 7730
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -32.5,33.5
       parent: 2
       type: Transform
   - uid: 7751
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,29.5
       parent: 2
       type: Transform
   - uid: 7752
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,29.5
       parent: 2
       type: Transform
   - uid: 7763
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -44.5,29.5
       parent: 2
       type: Transform
   - uid: 7764
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -36.5,30.5
       parent: 2
       type: Transform
   - uid: 7768
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -45.5,26.5
       parent: 2
       type: Transform
   - uid: 7771
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -42.5,25.5
       parent: 2
       type: Transform
   - uid: 7786
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -42.5,26.5
       parent: 2
       type: Transform
   - uid: 7798
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,29.5
       parent: 2
       type: Transform
   - uid: 7799
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,28.5
       parent: 2
       type: Transform
   - uid: 7800
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,26.5
       parent: 2
       type: Transform
   - uid: 7803
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,27.5
       parent: 2
       type: Transform
   - uid: 7805
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,30.5
       parent: 2
       type: Transform
   - uid: 7806
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,31.5
       parent: 2
@@ -79143,4356 +82920,5952 @@ entities:
   entities:
   - uid: 4
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-6.5
       parent: 2
       type: Transform
   - uid: 5
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 14.5,-0.5
       parent: 2
       type: Transform
   - uid: 6
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-10.5
       parent: 2
       type: Transform
   - uid: 13
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-3.5
       parent: 2
       type: Transform
   - uid: 19
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 24.5,-8.5
       parent: 2
       type: Transform
   - uid: 21
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-5.5
       parent: 2
       type: Transform
   - uid: 23
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-3.5
       parent: 2
       type: Transform
   - uid: 24
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-4.5
       parent: 2
       type: Transform
   - uid: 25
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,7.5
       parent: 2
       type: Transform
   - uid: 29
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 21.5,-8.5
       parent: 2
       type: Transform
   - uid: 30
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 23.5,-8.5
       parent: 2
       type: Transform
   - uid: 31
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,-3.5
       parent: 2
       type: Transform
   - uid: 32
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,-16.5
       parent: 2
       type: Transform
   - uid: 34
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-16.5
       parent: 2
       type: Transform
   - uid: 35
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,-16.5
       parent: 2
       type: Transform
   - uid: 36
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-7.5
       parent: 2
       type: Transform
   - uid: 45
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,-16.5
       parent: 2
       type: Transform
   - uid: 47
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,6.5
       parent: 2
       type: Transform
   - uid: 49
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,-8.5
       parent: 2
       type: Transform
   - uid: 51
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,-3.5
       parent: 2
       type: Transform
   - uid: 53
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 6.5,-8.5
       parent: 2
       type: Transform
   - uid: 54
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 21.5,-3.5
       parent: 2
       type: Transform
   - uid: 58
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,-16.5
       parent: 2
       type: Transform
   - uid: 79
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 24.5,-3.5
       parent: 2
       type: Transform
   - uid: 82
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-7.5
       parent: 2
       type: Transform
   - uid: 83
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-6.5
       parent: 2
       type: Transform
   - uid: 84
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 23.5,-3.5
       parent: 2
       type: Transform
   - uid: 85
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-5.5
       parent: 2
       type: Transform
   - uid: 86
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-4.5
       parent: 2
       type: Transform
   - uid: 87
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-3.5
       parent: 2
       type: Transform
   - uid: 88
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -1.5,-5.5
       parent: 2
       type: Transform
   - uid: 91
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,-6.5
       parent: 2
       type: Transform
   - uid: 92
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -1.5,-4.5
       parent: 2
       type: Transform
   - uid: 93
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -1.5,-7.5
       parent: 2
       type: Transform
   - uid: 94
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -0.5,-7.5
       parent: 2
       type: Transform
   - uid: 96
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -2.5,-7.5
       parent: 2
       type: Transform
   - uid: 100
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,-5.5
       parent: 2
       type: Transform
   - uid: 102
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,-1.5
       parent: 2
       type: Transform
   - uid: 104
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,1.5
       parent: 2
       type: Transform
   - uid: 105
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,0.5
       parent: 2
       type: Transform
   - uid: 108
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,0.5
       parent: 2
       type: Transform
   - uid: 111
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,1.5
       parent: 2
       type: Transform
   - uid: 115
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-4.5
       parent: 2
       type: Transform
   - uid: 117
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-6.5
       parent: 2
       type: Transform
   - uid: 118
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-5.5
       parent: 2
       type: Transform
   - uid: 119
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-9.5
       parent: 2
       type: Transform
   - uid: 120
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-7.5
       parent: 2
       type: Transform
   - uid: 122
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 6.5,-9.5
       parent: 2
       type: Transform
   - uid: 125
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 13.5,-17.5
       parent: 2
       type: Transform
   - uid: 127
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-15.5
       parent: 2
       type: Transform
   - uid: 132
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-15.5
       parent: 2
       type: Transform
   - uid: 133
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-15.5
       parent: 2
       type: Transform
   - uid: 136
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-17.5
       parent: 2
       type: Transform
   - uid: 138
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-15.5
       parent: 2
       type: Transform
   - uid: 144
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-15.5
       parent: 2
       type: Transform
   - uid: 146
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-15.5
       parent: 2
       type: Transform
   - uid: 147
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-14.5
       parent: 2
       type: Transform
   - uid: 152
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-9.5
       parent: 2
       type: Transform
   - uid: 153
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-8.5
       parent: 2
       type: Transform
   - uid: 156
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 17.5,-19.5
       parent: 2
       type: Transform
   - uid: 164
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 14.5,-21.5
       parent: 2
       type: Transform
   - uid: 165
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-16.5
       parent: 2
       type: Transform
   - uid: 166
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 17.5,-20.5
       parent: 2
       type: Transform
   - uid: 167
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 13.5,-16.5
       parent: 2
       type: Transform
   - uid: 168
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 13.5,-15.5
       parent: 2
       type: Transform
   - uid: 172
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-15.5
       parent: 2
       type: Transform
   - uid: 173
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-16.5
       parent: 2
       type: Transform
   - uid: 174
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-17.5
       parent: 2
       type: Transform
   - uid: 175
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-18.5
       parent: 2
       type: Transform
   - uid: 177
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-20.5
       parent: 2
       type: Transform
   - uid: 183
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 4.5,-21.5
       parent: 2
       type: Transform
   - uid: 186
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-21.5
       parent: 2
       type: Transform
   - uid: 187
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-21.5
       parent: 2
       type: Transform
   - uid: 188
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,-21.5
       parent: 2
       type: Transform
   - uid: 189
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-21.5
       parent: 2
       type: Transform
   - uid: 194
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-21.5
       parent: 2
       type: Transform
   - uid: 195
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-20.5
       parent: 2
       type: Transform
   - uid: 197
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 17.5,-21.5
       parent: 2
       type: Transform
   - uid: 200
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 16.5,-21.5
       parent: 2
       type: Transform
   - uid: 203
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 18.5,-21.5
       parent: 2
       type: Transform
   - uid: 204
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 19.5,-21.5
       parent: 2
       type: Transform
   - uid: 219
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 20.5,-21.5
       parent: 2
       type: Transform
   - uid: 220
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 21.5,-21.5
       parent: 2
       type: Transform
   - uid: 221
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 22.5,-21.5
       parent: 2
       type: Transform
   - uid: 236
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-21.5
       parent: 2
       type: Transform
   - uid: 237
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-20.5
       parent: 2
       type: Transform
   - uid: 238
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-18.5
       parent: 2
       type: Transform
   - uid: 239
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-17.5
       parent: 2
       type: Transform
   - uid: 240
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-16.5
       parent: 2
       type: Transform
   - uid: 251
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,-22.5
       parent: 2
       type: Transform
   - uid: 256
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,-22.5
       parent: 2
       type: Transform
   - uid: 261
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,-22.5
       parent: 2
       type: Transform
   - uid: 263
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,-22.5
       parent: 2
       type: Transform
   - uid: 267
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,-22.5
       parent: 2
       type: Transform
   - uid: 268
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-22.5
       parent: 2
       type: Transform
   - uid: 270
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-13.5
       parent: 2
       type: Transform
   - uid: 272
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-21.5
       parent: 2
       type: Transform
   - uid: 291
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 20.5,-8.5
       parent: 2
       type: Transform
   - uid: 292
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 19.5,-8.5
       parent: 2
       type: Transform
   - uid: 300
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-20.5
       parent: 2
       type: Transform
   - uid: 303
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-21.5
       parent: 2
       type: Transform
   - uid: 304
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,-21.5
       parent: 2
       type: Transform
   - uid: 315
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-17.5
       parent: 2
       type: Transform
   - uid: 317
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-9.5
       parent: 2
       type: Transform
   - uid: 318
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-8.5
       parent: 2
       type: Transform
   - uid: 319
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-12.5
       parent: 2
       type: Transform
   - uid: 320
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-11.5
       parent: 2
       type: Transform
   - uid: 321
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-14.5
       parent: 2
       type: Transform
   - uid: 322
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-13.5
       parent: 2
       type: Transform
   - uid: 323
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-15.5
       parent: 2
       type: Transform
   - uid: 324
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-16.5
       parent: 2
       type: Transform
   - uid: 325
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-19.5
       parent: 2
       type: Transform
   - uid: 326
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 0.5,-18.5
       parent: 2
       type: Transform
   - uid: 327
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-21.5
       parent: 2
       type: Transform
   - uid: 339
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 7.5,-9.5
       parent: 2
       type: Transform
   - uid: 341
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 8.5,-10.5
       parent: 2
       type: Transform
   - uid: 353
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 4.5,1.5
       parent: 2
       type: Transform
   - uid: 354
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 6.5,-0.5
       parent: 2
       type: Transform
   - uid: 355
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 5.5,1.5
       parent: 2
       type: Transform
   - uid: 356
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 0.5,1.5
       parent: 2
       type: Transform
   - uid: 361
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,1.5
       parent: 2
       type: Transform
   - uid: 362
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,1.5
       parent: 2
       type: Transform
   - uid: 363
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,1.5
       parent: 2
       type: Transform
   - uid: 365
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,1.5
       parent: 2
       type: Transform
   - uid: 367
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-8.5
       parent: 2
       type: Transform
   - uid: 369
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,1.5
       parent: 2
       type: Transform
   - uid: 370
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,1.5
       parent: 2
       type: Transform
   - uid: 371
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,1.5
       parent: 2
       type: Transform
   - uid: 372
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,1.5
       parent: 2
       type: Transform
   - uid: 373
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,1.5
       parent: 2
       type: Transform
   - uid: 377
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,5.5
       parent: 2
       type: Transform
   - uid: 378
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,5.5
       parent: 2
       type: Transform
   - uid: 387
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,5.5
       parent: 2
       type: Transform
   - uid: 389
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 16.5,10.5
       parent: 2
       type: Transform
   - uid: 391
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,5.5
       parent: 2
       type: Transform
   - uid: 392
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,5.5
       parent: 2
       type: Transform
   - uid: 395
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 29.5,5.5
       parent: 2
       type: Transform
   - uid: 396
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,5.5
       parent: 2
       type: Transform
   - uid: 397
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,5.5
       parent: 2
       type: Transform
   - uid: 400
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,0.5
       parent: 2
       type: Transform
   - uid: 401
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,5.5
       parent: 2
       type: Transform
   - uid: 402
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,5.5
       parent: 2
       type: Transform
   - uid: 403
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,5.5
       parent: 2
       type: Transform
   - uid: 405
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,6.5
       parent: 2
       type: Transform
   - uid: 406
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,10.5
       parent: 2
       type: Transform
   - uid: 407
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,1.5
       parent: 2
       type: Transform
   - uid: 408
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,9.5
       parent: 2
       type: Transform
   - uid: 410
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,10.5
       parent: 2
       type: Transform
   - uid: 411
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,10.5
       parent: 2
       type: Transform
   - uid: 412
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,10.5
       parent: 2
       type: Transform
   - uid: 414
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,10.5
       parent: 2
       type: Transform
   - uid: 415
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-1.5
       parent: 2
       type: Transform
   - uid: 419
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,10.5
       parent: 2
       type: Transform
   - uid: 422
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,8.5
       parent: 2
       type: Transform
   - uid: 424
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,9.5
       parent: 2
       type: Transform
   - uid: 425
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,5.5
       parent: 2
       type: Transform
   - uid: 432
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,12.5
       parent: 2
       type: Transform
   - uid: 440
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,15.5
       parent: 2
       type: Transform
   - uid: 441
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,10.5
       parent: 2
       type: Transform
   - uid: 442
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,15.5
       parent: 2
       type: Transform
   - uid: 444
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,15.5
       parent: 2
       type: Transform
   - uid: 445
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,15.5
       parent: 2
       type: Transform
   - uid: 446
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,15.5
       parent: 2
       type: Transform
   - uid: 447
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,15.5
       parent: 2
       type: Transform
   - uid: 448
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,14.5
       parent: 2
       type: Transform
   - uid: 449
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,15.5
       parent: 2
       type: Transform
   - uid: 451
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,11.5
       parent: 2
       type: Transform
   - uid: 454
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,29.5
       parent: 2
       type: Transform
   - uid: 455
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,28.5
       parent: 2
       type: Transform
   - uid: 516
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 38.5,-4.5
       parent: 2
       type: Transform
   - uid: 517
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-5.5
       parent: 2
       type: Transform
   - uid: 518
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 38.5,-6.5
       parent: 2
       type: Transform
   - uid: 519
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 38.5,-7.5
       parent: 2
       type: Transform
   - uid: 521
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 38.5,-9.5
       parent: 2
       type: Transform
   - uid: 523
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 26.5,-9.5
       parent: 2
       type: Transform
   - uid: 524
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 27.5,-9.5
       parent: 2
       type: Transform
   - uid: 525
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 28.5,-9.5
       parent: 2
       type: Transform
   - uid: 526
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 29.5,-9.5
       parent: 2
       type: Transform
   - uid: 527
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 30.5,-9.5
       parent: 2
       type: Transform
   - uid: 528
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 31.5,-9.5
       parent: 2
       type: Transform
   - uid: 529
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 32.5,-9.5
       parent: 2
       type: Transform
   - uid: 530
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,-2.5
       parent: 2
       type: Transform
   - uid: 532
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 35.5,-9.5
       parent: 2
       type: Transform
   - uid: 533
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 36.5,-9.5
       parent: 2
       type: Transform
   - uid: 534
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 37.5,-9.5
       parent: 2
       type: Transform
   - uid: 546
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 21.5,14.5
       parent: 2
       type: Transform
   - uid: 547
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 38.5,-13.5
       parent: 2
       type: Transform
   - uid: 589
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-4.5
       parent: 2
       type: Transform
   - uid: 590
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-5.5
       parent: 2
       type: Transform
   - uid: 591
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,-6.5
       parent: 2
       type: Transform
   - uid: 592
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 36.5,-6.5
       parent: 2
       type: Transform
   - uid: 607
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,-8.5
       parent: 2
       type: Transform
   - uid: 608
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-8.5
       parent: 2
       type: Transform
   - uid: 956
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 26.5,-6.5
       parent: 2
       type: Transform
   - uid: 1040
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,-3.5
       parent: 2
       type: Transform
   - uid: 1282
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 28.5,-7.5
       parent: 2
       type: Transform
   - uid: 1283
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 28.5,-8.5
       parent: 2
       type: Transform
   - uid: 1284
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 28.5,-6.5
       parent: 2
       type: Transform
   - uid: 1337
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 8.5,-15.5
       parent: 2
       type: Transform
   - uid: 1366
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 7.5,-0.5
       parent: 2
       type: Transform
   - uid: 1397
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 8.5,-14.5
       parent: 2
       type: Transform
   - uid: 1407
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 12.5,-0.5
       parent: 2
       type: Transform
   - uid: 1409
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 13.5,-0.5
       parent: 2
       type: Transform
   - uid: 1410
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 8.5,-0.5
       parent: 2
       type: Transform
   - uid: 2145
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -29.5,19.5
       parent: 2
       type: Transform
   - uid: 2147
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,16.5
       parent: 2
       type: Transform
   - uid: 2150
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,8.5
       parent: 2
       type: Transform
   - uid: 2153
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,9.5
       parent: 2
       type: Transform
   - uid: 2162
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,20.5
       parent: 2
       type: Transform
   - uid: 2163
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,19.5
       parent: 2
       type: Transform
   - uid: 2164
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,23.5
       parent: 2
       type: Transform
   - uid: 2165
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,22.5
       parent: 2
       type: Transform
   - uid: 2166
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,21.5
       parent: 2
       type: Transform
   - uid: 2168
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -19.5,34.5
       parent: 2
       type: Transform
   - uid: 2184
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 34.5,-13.5
       parent: 2
       type: Transform
   - uid: 2187
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,15.5
       parent: 2
       type: Transform
   - uid: 2193
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,19.5
       parent: 2
       type: Transform
   - uid: 2216
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 10.5,20.5
       parent: 2
       type: Transform
   - uid: 2246
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,20.5
       parent: 2
       type: Transform
   - uid: 2248
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,19.5
       parent: 2
       type: Transform
   - uid: 2280
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 29.5,-13.5
       parent: 2
       type: Transform
   - uid: 2281
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 26.5,-13.5
       parent: 2
       type: Transform
   - uid: 2291
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-19.5
       parent: 2
       type: Transform
   - uid: 2292
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 37.5,-23.5
       parent: 2
       type: Transform
   - uid: 2294
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 36.5,-23.5
       parent: 2
       type: Transform
   - uid: 2295
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,-19.5
       parent: 2
       type: Transform
   - uid: 2296
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,-19.5
       parent: 2
       type: Transform
   - uid: 2298
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 38.5,-21.5
       parent: 2
       type: Transform
   - uid: 2301
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 28.5,-19.5
       parent: 2
       type: Transform
   - uid: 2303
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,-19.5
       parent: 2
       type: Transform
   - uid: 2304
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-19.5
       parent: 2
       type: Transform
   - uid: 2305
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-18.5
       parent: 2
       type: Transform
   - uid: 2306
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-17.5
       parent: 2
       type: Transform
   - uid: 2307
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 25.5,-16.5
       parent: 2
       type: Transform
   - uid: 2308
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 37.5,-13.5
       parent: 2
       type: Transform
   - uid: 2309
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-14.5
       parent: 2
       type: Transform
   - uid: 2310
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-17.5
       parent: 2
       type: Transform
   - uid: 2311
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-17.5
       parent: 2
       type: Transform
   - uid: 2312
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-16.5
       parent: 2
       type: Transform
   - uid: 2313
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,-15.5
       parent: 2
       type: Transform
   - uid: 2334
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 38.5,-23.5
       parent: 2
       type: Transform
   - uid: 2335
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 38.5,-22.5
       parent: 2
       type: Transform
   - uid: 2336
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 29.5,-19.5
       parent: 2
       type: Transform
   - uid: 2337
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 37.5,-19.5
       parent: 2
       type: Transform
   - uid: 2339
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,-17.5
       parent: 2
       type: Transform
   - uid: 2340
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 35.5,-23.5
       parent: 2
       type: Transform
   - uid: 2341
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 34.5,-23.5
       parent: 2
       type: Transform
   - uid: 2342
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 33.5,-23.5
       parent: 2
       type: Transform
   - uid: 2343
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 33.5,-22.5
       parent: 2
       type: Transform
   - uid: 2344
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 33.5,-20.5
       parent: 2
       type: Transform
   - uid: 2345
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 29.5,-20.5
       parent: 2
       type: Transform
   - uid: 2347
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 29.5,-22.5
       parent: 2
       type: Transform
   - uid: 2348
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 29.5,-23.5
       parent: 2
       type: Transform
   - uid: 2349
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 30.5,-23.5
       parent: 2
       type: Transform
   - uid: 2350
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 31.5,-23.5
       parent: 2
       type: Transform
   - uid: 2351
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 32.5,-23.5
       parent: 2
       type: Transform
   - uid: 2370
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,-18.5
       parent: 2
       type: Transform
   - uid: 2371
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,-19.5
       parent: 2
       type: Transform
   - uid: 2372
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 40.5,-20.5
       parent: 2
       type: Transform
   - uid: 2374
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 39.5,-21.5
       parent: 2
       type: Transform
   - uid: 2456
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 42.5,-18.5
       parent: 2
       type: Transform
   - uid: 2541
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,5.5
       parent: 2
       type: Transform
   - uid: 2542
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 34.5,5.5
       parent: 2
       type: Transform
   - uid: 2543
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 35.5,5.5
       parent: 2
       type: Transform
   - uid: 2544
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 37.5,5.5
       parent: 2
       type: Transform
   - uid: 2546
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,5.5
       parent: 2
       type: Transform
   - uid: 2550
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 38.5,6.5
       parent: 2
       type: Transform
   - uid: 2566
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 21.5,12.5
       parent: 2
       type: Transform
   - uid: 2587
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 18.5,15.5
       parent: 2
       type: Transform
   - uid: 2592
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 21.5,15.5
       parent: 2
       type: Transform
   - uid: 2596
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,29.5
       parent: 2
       type: Transform
   - uid: 2600
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,26.5
       parent: 2
       type: Transform
   - uid: 2602
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,27.5
       parent: 2
       type: Transform
   - uid: 2611
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,8.5
       parent: 2
       type: Transform
   - uid: 2612
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,27.5
       parent: 2
       type: Transform
   - uid: 2613
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,28.5
       parent: 2
       type: Transform
   - uid: 2616
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 21.5,6.5
       parent: 2
       type: Transform
   - uid: 2617
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 20.5,15.5
       parent: 2
       type: Transform
   - uid: 2625
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 21.5,13.5
       parent: 2
       type: Transform
   - uid: 2631
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,-9.5
       parent: 2
       type: Transform
   - uid: 2634
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 17.5,10.5
       parent: 2
       type: Transform
   - uid: 2637
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 17.5,15.5
       parent: 2
       type: Transform
   - uid: 2648
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 18.5,10.5
       parent: 2
       type: Transform
   - uid: 2681
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 4.5,29.5
       parent: 2
       type: Transform
   - uid: 2684
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 19.5,10.5
       parent: 2
       type: Transform
   - uid: 2705
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 2.5,29.5
       parent: 2
       type: Transform
   - uid: 2706
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-3.5
       parent: 2
       type: Transform
   - uid: 2712
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 19.5,15.5
       parent: 2
       type: Transform
   - uid: 2724
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 21.5,7.5
       parent: 2
       type: Transform
   - uid: 2725
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 21.5,8.5
       parent: 2
       type: Transform
   - uid: 2726
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 21.5,9.5
       parent: 2
       type: Transform
   - uid: 2727
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 21.5,11.5
       parent: 2
       type: Transform
   - uid: 2728
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 21.5,10.5
       parent: 2
       type: Transform
   - uid: 2760
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 4.5,-9.5
       parent: 2
       type: Transform
   - uid: 2777
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-8.5
       parent: 2
       type: Transform
   - uid: 2978
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-9.5
       parent: 2
       type: Transform
   - uid: 2983
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-9.5
       parent: 2
       type: Transform
   - uid: 2987
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 14.5,10.5
       parent: 2
       type: Transform
   - uid: 3007
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 15.5,10.5
       parent: 2
       type: Transform
   - uid: 3008
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 28.5,5.5
       parent: 2
       type: Transform
   - uid: 3018
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 27.5,5.5
       parent: 2
       type: Transform
   - uid: 3023
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 2
       type: Transform
   - uid: 3091
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 6.5,31.5
       parent: 2
       type: Transform
   - uid: 3092
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 4.5,31.5
       parent: 2
       type: Transform
   - uid: 3093
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 3.5,31.5
       parent: 2
       type: Transform
   - uid: 3099
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 3.5,32.5
       parent: 2
       type: Transform
   - uid: 3102
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-2.5
       parent: 2
       type: Transform
   - uid: 3111
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -0.5,-0.5
       parent: 2
       type: Transform
   - uid: 3119
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-7.5
       parent: 2
       type: Transform
   - uid: 3120
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,1.5
       parent: 2
       type: Transform
   - uid: 3126
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-2.5
       parent: 2
       type: Transform
   - uid: 3127
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,1.5
       parent: 2
       type: Transform
   - uid: 3128
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,0.5
       parent: 2
       type: Transform
   - uid: 3129
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-0.5
       parent: 2
       type: Transform
   - uid: 3130
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-0.5
       parent: 2
       type: Transform
   - uid: 3131
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-0.5
       parent: 2
       type: Transform
   - uid: 3132
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-0.5
       parent: 2
       type: Transform
   - uid: 3133
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -8.5,1.5
       parent: 2
       type: Transform
   - uid: 3134
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -11.5,1.5
       parent: 2
       type: Transform
   - uid: 3136
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -12.5,1.5
       parent: 2
       type: Transform
   - uid: 3139
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-8.5
       parent: 2
       type: Transform
   - uid: 3141
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-8.5
       parent: 2
       type: Transform
   - uid: 3144
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-6.5
       parent: 2
       type: Transform
   - uid: 3145
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,1.5
       parent: 2
       type: Transform
   - uid: 3146
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-9.5
       parent: 2
       type: Transform
   - uid: 3286
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 2
       type: Transform
   - uid: 3287
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 6.5,-3.5
       parent: 2
       type: Transform
   - uid: 3288
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,-0.5
       parent: 2
       type: Transform
   - uid: 3289
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,0.5
       parent: 2
       type: Transform
   - uid: 3290
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,1.5
       parent: 2
       type: Transform
   - uid: 3291
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,-4.5
       parent: 2
       type: Transform
   - uid: 3292
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,-1.5
       parent: 2
       type: Transform
   - uid: 3293
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,-2.5
       parent: 2
       type: Transform
   - uid: 3294
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -9.5,-2.5
       parent: 2
       type: Transform
   - uid: 3296
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,-7.5
       parent: 2
       type: Transform
   - uid: 3297
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,-6.5
       parent: 2
       type: Transform
   - uid: 3299
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -7.5,-8.5
       parent: 2
       type: Transform
   - uid: 3302
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -11.5,-2.5
       parent: 2
       type: Transform
   - uid: 3303
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -12.5,-2.5
       parent: 2
       type: Transform
   - uid: 3304
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -12.5,-3.5
       parent: 2
       type: Transform
   - uid: 3314
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,-12.5
       parent: 2
       type: Transform
   - uid: 3315
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-6.5
       parent: 2
       type: Transform
   - uid: 3318
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -8.5,-2.5
       parent: 2
       type: Transform
   - uid: 3319
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -12.5,-4.5
       parent: 2
       type: Transform
   - uid: 3321
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -8.5,-6.5
       parent: 2
       type: Transform
   - uid: 3322
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -9.5,-6.5
       parent: 2
       type: Transform
   - uid: 3327
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,-12.5
       parent: 2
       type: Transform
   - uid: 3328
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-12.5
       parent: 2
       type: Transform
   - uid: 3329
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-8.5
       parent: 2
       type: Transform
   - uid: 3330
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-12.5
       parent: 2
       type: Transform
   - uid: 3331
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-10.5
       parent: 2
       type: Transform
   - uid: 3332
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-7.5
       parent: 2
       type: Transform
   - uid: 3333
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-11.5
       parent: 2
       type: Transform
   - uid: 3334
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-9.5
       parent: 2
       type: Transform
   - uid: 3335
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-12.5
       parent: 2
       type: Transform
   - uid: 3340
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-12.5
       parent: 2
       type: Transform
   - uid: 3341
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-12.5
       parent: 2
       type: Transform
   - uid: 3342
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-12.5
       parent: 2
       type: Transform
   - uid: 3343
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-12.5
       parent: 2
       type: Transform
   - uid: 3345
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-12.5
       parent: 2
       type: Transform
   - uid: 3347
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -10.5,-6.5
       parent: 2
       type: Transform
   - uid: 3349
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -24.5,-6.5
       parent: 2
       type: Transform
   - uid: 3350
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,0.5
       parent: 2
       type: Transform
   - uid: 3351
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-3.5
       parent: 2
       type: Transform
   - uid: 3352
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,0.5
       parent: 2
       type: Transform
   - uid: 3353
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-4.5
       parent: 2
       type: Transform
   - uid: 3354
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-5.5
       parent: 2
       type: Transform
   - uid: 3355
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -16.5,-6.5
       parent: 2
       type: Transform
   - uid: 3362
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,1.5
       parent: 2
       type: Transform
   - uid: 3363
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -18.5,1.5
       parent: 2
       type: Transform
   - uid: 3364
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,1.5
       parent: 2
       type: Transform
   - uid: 3365
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,1.5
       parent: 2
       type: Transform
   - uid: 3366
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -21.5,1.5
       parent: 2
       type: Transform
   - uid: 3369
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,1.5
       parent: 2
       type: Transform
   - uid: 3370
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 14.5,5.5
       parent: 2
       type: Transform
   - uid: 3381
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 17.5,5.5
       parent: 2
       type: Transform
   - uid: 3382
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -33.5,-20.5
       parent: 2
       type: Transform
   - uid: 3458
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -20.5,-4.5
       parent: 2
       type: Transform
   - uid: 3459
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -19.5,-4.5
       parent: 2
       type: Transform
   - uid: 3460
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -17.5,-4.5
       parent: 2
       type: Transform
   - uid: 3463
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -20.5,-2.5
       parent: 2
       type: Transform
   - uid: 3467
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -25.5,1.5
       parent: 2
       type: Transform
   - uid: 3468
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -25.5,0.5
       parent: 2
       type: Transform
   - uid: 3469
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -25.5,-0.5
       parent: 2
       type: Transform
   - uid: 3470
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -25.5,-1.5
       parent: 2
       type: Transform
   - uid: 3471
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -25.5,-2.5
       parent: 2
       type: Transform
   - uid: 3472
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -25.5,-3.5
       parent: 2
       type: Transform
   - uid: 3473
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -21.5,-3.5
       parent: 2
       type: Transform
   - uid: 3475
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -24.5,-3.5
       parent: 2
       type: Transform
   - uid: 3479
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -26.5,-6.5
       parent: 2
       type: Transform
   - uid: 3480
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -25.5,-6.5
       parent: 2
       type: Transform
   - uid: 3489
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -26.5,1.5
       parent: 2
       type: Transform
   - uid: 3491
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,1.5
       parent: 2
       type: Transform
   - uid: 3492
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -31.5,1.5
       parent: 2
       type: Transform
   - uid: 3493
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -31.5,0.5
       parent: 2
       type: Transform
   - uid: 3494
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -31.5,-0.5
       parent: 2
       type: Transform
   - uid: 3495
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -31.5,-1.5
       parent: 2
       type: Transform
   - uid: 3496
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -31.5,-2.5
       parent: 2
       type: Transform
   - uid: 3497
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -31.5,-3.5
       parent: 2
       type: Transform
   - uid: 3498
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -26.5,-3.5
       parent: 2
       type: Transform
   - uid: 3500
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -29.5,-3.5
       parent: 2
       type: Transform
   - uid: 3558
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-6.5
       parent: 2
       type: Transform
   - uid: 3559
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,-6.5
       parent: 2
       type: Transform
   - uid: 3566
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-7.5
       parent: 2
       type: Transform
   - uid: 3567
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-8.5
       parent: 2
       type: Transform
   - uid: 3568
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-9.5
       parent: 2
       type: Transform
   - uid: 3569
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-10.5
       parent: 2
       type: Transform
   - uid: 3570
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -30.5,-11.5
       parent: 2
       type: Transform
   - uid: 3571
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-7.5
       parent: 2
       type: Transform
   - uid: 3572
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-12.5
       parent: 2
       type: Transform
   - uid: 3573
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-12.5
       parent: 2
       type: Transform
   - uid: 3574
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,-12.5
       parent: 2
       type: Transform
   - uid: 3575
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-12.5
       parent: 2
       type: Transform
   - uid: 3576
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-12.5
       parent: 2
       type: Transform
   - uid: 3577
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-12.5
       parent: 2
       type: Transform
   - uid: 3578
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-11.5
       parent: 2
       type: Transform
   - uid: 3579
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -29.5,-11.5
       parent: 2
       type: Transform
   - uid: 3594
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,-3.5
       parent: 2
       type: Transform
   - uid: 3598
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-11.5
       parent: 2
       type: Transform
   - uid: 3629
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-12.5
       parent: 2
       type: Transform
   - uid: 3631
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -32.5,-12.5
       parent: 2
       type: Transform
   - uid: 3632
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,-12.5
       parent: 2
       type: Transform
   - uid: 3633
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,-12.5
       parent: 2
       type: Transform
   - uid: 3635
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-12.5
       parent: 2
       type: Transform
   - uid: 3636
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-12.5
       parent: 2
       type: Transform
   - uid: 3637
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-12.5
       parent: 2
       type: Transform
   - uid: 3639
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-12.5
       parent: 2
       type: Transform
   - uid: 3643
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-3.5
       parent: 2
       type: Transform
   - uid: 3644
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -31.5,-11.5
       parent: 2
       type: Transform
   - uid: 3687
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -39.5,-6.5
       parent: 2
       type: Transform
   - uid: 3688
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -39.5,-5.5
       parent: 2
       type: Transform
   - uid: 3689
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -39.5,-4.5
       parent: 2
       type: Transform
   - uid: 3690
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -39.5,-3.5
       parent: 2
       type: Transform
   - uid: 3691
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -39.5,-2.5
       parent: 2
       type: Transform
   - uid: 3692
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -39.5,-1.5
       parent: 2
       type: Transform
   - uid: 3693
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -38.5,-1.5
       parent: 2
       type: Transform
   - uid: 3694
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -37.5,-1.5
       parent: 2
       type: Transform
   - uid: 3695
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -36.5,-1.5
       parent: 2
       type: Transform
   - uid: 3696
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,-1.5
       parent: 2
       type: Transform
   - uid: 3697
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -34.5,-1.5
       parent: 2
       type: Transform
   - uid: 3698
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -34.5,-2.5
       parent: 2
       type: Transform
   - uid: 3709
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,1.5
       parent: 2
       type: Transform
   - uid: 3710
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,1.5
       parent: 2
       type: Transform
   - uid: 3711
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,1.5
       parent: 2
       type: Transform
   - uid: 3712
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,1.5
       parent: 2
       type: Transform
   - uid: 3713
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-12.5
       parent: 2
       type: Transform
   - uid: 3714
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-16.5
       parent: 2
       type: Transform
   - uid: 3715
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-13.5
       parent: 2
       type: Transform
   - uid: 3716
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-15.5
       parent: 2
       type: Transform
   - uid: 3717
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-16.5
       parent: 2
       type: Transform
   - uid: 3718
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-17.5
       parent: 2
       type: Transform
   - uid: 3719
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-18.5
       parent: 2
       type: Transform
   - uid: 3720
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-19.5
       parent: 2
       type: Transform
   - uid: 3721
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -4.5,-20.5
       parent: 2
       type: Transform
   - uid: 3726
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,-16.5
       parent: 2
       type: Transform
   - uid: 3727
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,-16.5
       parent: 2
       type: Transform
   - uid: 3728
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -11.5,-16.5
       parent: 2
       type: Transform
   - uid: 3729
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-16.5
       parent: 2
       type: Transform
   - uid: 3732
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -12.5,-20.5
       parent: 2
       type: Transform
   - uid: 3733
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-20.5
       parent: 2
       type: Transform
   - uid: 3734
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -9.5,-20.5
       parent: 2
       type: Transform
   - uid: 3735
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-20.5
       parent: 2
       type: Transform
   - uid: 3740
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 3.5,-23.5
       parent: 2
       type: Transform
   - uid: 3741
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 4.5,-23.5
       parent: 2
       type: Transform
   - uid: 3742
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-21.5
       parent: 2
       type: Transform
   - uid: 3743
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-23.5
       parent: 2
       type: Transform
   - uid: 3744
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-24.5
       parent: 2
       type: Transform
   - uid: 3745
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-22.5
       parent: 2
       type: Transform
   - uid: 3746
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-23.5
       parent: 2
       type: Transform
   - uid: 3747
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,-24.5
       parent: 2
       type: Transform
   - uid: 3767
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-25.5
       parent: 2
       type: Transform
   - uid: 3768
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-27.5
       parent: 2
       type: Transform
   - uid: 3776
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -18.5,-24.5
       parent: 2
       type: Transform
   - uid: 3779
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -15.5,-24.5
       parent: 2
       type: Transform
   - uid: 3783
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,-27.5
       parent: 2
       type: Transform
   - uid: 3784
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,-26.5
       parent: 2
       type: Transform
   - uid: 3785
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,-25.5
       parent: 2
       type: Transform
   - uid: 3786
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -14.5,-24.5
       parent: 2
       type: Transform
   - uid: 3788
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -14.5,-21.5
       parent: 2
       type: Transform
   - uid: 3801
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -20.5,-24.5
       parent: 2
       type: Transform
   - uid: 3805
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -21.5,-25.5
       parent: 2
       type: Transform
   - uid: 3806
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -21.5,-24.5
       parent: 2
       type: Transform
   - uid: 3836
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,-16.5
       parent: 2
       type: Transform
   - uid: 3839
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,6.5
       parent: 2
       type: Transform
   - uid: 3845
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-16.5
       parent: 2
       type: Transform
   - uid: 3847
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -52.5,-2.5
       parent: 2
       type: Transform
   - uid: 3848
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -54.5,-2.5
       parent: 2
       type: Transform
   - uid: 3855
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-16.5
       parent: 2
       type: Transform
   - uid: 3856
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-16.5
       parent: 2
       type: Transform
   - uid: 3874
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -21.5,-21.5
       parent: 2
       type: Transform
   - uid: 3960
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,-25.5
       parent: 2
       type: Transform
   - uid: 3962
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -27.5,-25.5
       parent: 2
       type: Transform
   - uid: 3963
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -28.5,-25.5
       parent: 2
       type: Transform
   - uid: 3971
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -23.5,-29.5
       parent: 2
       type: Transform
   - uid: 3972
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -33.5,-19.5
       parent: 2
       type: Transform
   - uid: 4061
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-1.5
       parent: 2
       type: Transform
   - uid: 4071
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,-20.5
       parent: 2
       type: Transform
   - uid: 4077
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-16.5
       parent: 2
       type: Transform
   - uid: 4080
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -24.5,-16.5
       parent: 2
       type: Transform
   - uid: 4090
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -22.5,-16.5
       parent: 2
       type: Transform
   - uid: 4101
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -22.5,-20.5
       parent: 2
       type: Transform
   - uid: 4102
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-7.5
       parent: 2
       type: Transform
   - uid: 4117
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -27.5,-16.5
       parent: 2
       type: Transform
   - uid: 4119
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -29.5,-16.5
       parent: 2
       type: Transform
   - uid: 4120
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -28.5,-16.5
       parent: 2
       type: Transform
   - uid: 4122
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,-16.5
       parent: 2
       type: Transform
   - uid: 4123
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -33.5,-16.5
       parent: 2
       type: Transform
   - uid: 4124
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-2.5
       parent: 2
       type: Transform
   - uid: 4125
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-20.5
       parent: 2
       type: Transform
   - uid: 4127
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -29.5,-21.5
       parent: 2
       type: Transform
   - uid: 4128
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,-19.5
       parent: 2
       type: Transform
   - uid: 4130
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-0.5
       parent: 2
       type: Transform
   - uid: 4132
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -49.5,-2.5
       parent: 2
       type: Transform
   - uid: 4140
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -23.5,-16.5
       parent: 2
       type: Transform
   - uid: 4145
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-3.5
       parent: 2
       type: Transform
   - uid: 4147
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-16.5
       parent: 2
       type: Transform
   - uid: 4148
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-16.5
       parent: 2
       type: Transform
   - uid: 4150
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -29.5,-17.5
       parent: 2
       type: Transform
   - uid: 4154
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-5.5
       parent: 2
       type: Transform
   - uid: 4156
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,1.5
       parent: 2
       type: Transform
   - uid: 4157
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,-21.5
       parent: 2
       type: Transform
   - uid: 4163
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -24.5,-20.5
       parent: 2
       type: Transform
   - uid: 4164
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -34.5,-21.5
       parent: 2
       type: Transform
   - uid: 4165
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,-18.5
       parent: 2
       type: Transform
   - uid: 4168
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -28.5,-21.5
       parent: 2
       type: Transform
   - uid: 4170
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -33.5,-21.5
       parent: 2
       type: Transform
   - uid: 4171
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-12.5
       parent: 2
       type: Transform
   - uid: 4184
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,-21.5
       parent: 2
       type: Transform
   - uid: 4202
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,9.5
       parent: 2
       type: Transform
   - uid: 4206
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -36.5,10.5
       parent: 2
       type: Transform
   - uid: 4207
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -36.5,5.5
       parent: 2
       type: Transform
   - uid: 4208
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -41.5,10.5
       parent: 2
       type: Transform
   - uid: 4211
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -34.5,17.5
       parent: 2
       type: Transform
   - uid: 4212
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -38.5,16.5
       parent: 2
       type: Transform
   - uid: 4213
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -38.5,13.5
       parent: 2
       type: Transform
   - uid: 4214
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -26.5,10.5
       parent: 2
       type: Transform
   - uid: 4218
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -37.5,17.5
       parent: 2
       type: Transform
   - uid: 4220
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,5.5
       parent: 2
       type: Transform
   - uid: 4221
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -34.5,5.5
       parent: 2
       type: Transform
   - uid: 4226
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -33.5,17.5
       parent: 2
       type: Transform
   - uid: 4232
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,9.5
       parent: 2
       type: Transform
   - uid: 4236
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -43.5,9.5
       parent: 2
       type: Transform
   - uid: 4237
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -29.5,9.5
       parent: 2
       type: Transform
   - uid: 4238
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -41.5,5.5
       parent: 2
       type: Transform
   - uid: 4239
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,5.5
       parent: 2
       type: Transform
   - uid: 4241
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -34.5,9.5
       parent: 2
       type: Transform
   - uid: 4244
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -40.5,10.5
       parent: 2
       type: Transform
   - uid: 4248
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,15.5
       parent: 2
       type: Transform
   - uid: 4250
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -41.5,15.5
       parent: 2
       type: Transform
   - uid: 4255
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,18.5
       parent: 2
       type: Transform
   - uid: 4258
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,15.5
       parent: 2
       type: Transform
   - uid: 4260
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -49.5,19.5
       parent: 2
       type: Transform
   - uid: 4262
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-1.5
       parent: 2
       type: Transform
   - uid: 4263
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -49.5,14.5
       parent: 2
       type: Transform
   - uid: 4265
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -43.5,19.5
       parent: 2
       type: Transform
   - uid: 4266
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -49.5,16.5
       parent: 2
       type: Transform
   - uid: 4267
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -38.5,17.5
       parent: 2
       type: Transform
   - uid: 4269
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -41.5,14.5
       parent: 2
       type: Transform
   - uid: 4274
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -25.5,6.5
       parent: 2
       type: Transform
   - uid: 4276
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -45.5,15.5
       parent: 2
       type: Transform
   - uid: 4277
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -47.5,15.5
       parent: 2
       type: Transform
   - uid: 4278
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -40.5,5.5
       parent: 2
       type: Transform
   - uid: 4280
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,7.5
       parent: 2
       type: Transform
   - uid: 4282
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,6.5
       parent: 2
       type: Transform
   - uid: 4292
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -28.5,19.5
       parent: 2
       type: Transform
   - uid: 4293
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,14.5
       parent: 2
       type: Transform
   - uid: 4294
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -49.5,13.5
       parent: 2
       type: Transform
   - uid: 4296
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -49.5,18.5
       parent: 2
       type: Transform
   - uid: 4297
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -43.5,15.5
       parent: 2
       type: Transform
   - uid: 4299
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -48.5,15.5
       parent: 2
       type: Transform
   - uid: 4300
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -49.5,15.5
       parent: 2
       type: Transform
   - uid: 4301
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -44.5,15.5
       parent: 2
       type: Transform
   - uid: 4302
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -46.5,15.5
       parent: 2
       type: Transform
   - uid: 4304
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -29.5,5.5
       parent: 2
       type: Transform
   - uid: 4305
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -45.5,9.5
       parent: 2
       type: Transform
   - uid: 4307
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -48.5,9.5
       parent: 2
       type: Transform
   - uid: 4308
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,12.5
       parent: 2
       type: Transform
   - uid: 4316
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-5.5
       parent: 2
       type: Transform
   - uid: 4318
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-6.5
       parent: 2
       type: Transform
   - uid: 4319
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-4.5
       parent: 2
       type: Transform
   - uid: 4324
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,-7.5
       parent: 2
       type: Transform
   - uid: 4326
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,0.5
       parent: 2
       type: Transform
   - uid: 4327
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -47.5,1.5
       parent: 2
       type: Transform
   - uid: 4328
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,1.5
       parent: 2
       type: Transform
   - uid: 4336
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,6.5
       parent: 2
       type: Transform
   - uid: 4340
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -44.5,9.5
       parent: 2
       type: Transform
   - uid: 4342
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -48.5,12.5
       parent: 2
       type: Transform
   - uid: 4345
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -28.5,13.5
       parent: 2
       type: Transform
   - uid: 4348
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,17.5
       parent: 2
       type: Transform
   - uid: 4351
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -30.5,9.5
       parent: 2
       type: Transform
   - uid: 4352
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -27.5,5.5
       parent: 2
       type: Transform
   - uid: 4353
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -33.5,5.5
       parent: 2
       type: Transform
   - uid: 4354
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -33.5,9.5
       parent: 2
       type: Transform
   - uid: 4355
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -28.5,5.5
       parent: 2
       type: Transform
   - uid: 4356
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -27.5,19.5
       parent: 2
       type: Transform
   - uid: 4358
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -27.5,13.5
       parent: 2
       type: Transform
   - uid: 4360
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,13.5
       parent: 2
       type: Transform
   - uid: 4362
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -30.5,16.5
       parent: 2
       type: Transform
   - uid: 4364
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -27.5,16.5
       parent: 2
       type: Transform
   - uid: 4366
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -30.5,19.5
       parent: 2
       type: Transform
   - uid: 4368
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -29.5,16.5
       parent: 2
       type: Transform
   - uid: 4370
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -28.5,16.5
       parent: 2
       type: Transform
   - uid: 4374
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,19.5
       parent: 2
       type: Transform
   - uid: 4375
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -29.5,13.5
       parent: 2
       type: Transform
   - uid: 4376
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,20.5
       parent: 2
       type: Transform
   - uid: 4378
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -26.5,21.5
       parent: 2
       type: Transform
   - uid: 4380
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,10.5
       parent: 2
       type: Transform
   - uid: 4382
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -41.5,9.5
       parent: 2
       type: Transform
   - uid: 4402
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 25.5,-21.5
       parent: 2
       type: Transform
   - uid: 4411
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-25.5
       parent: 2
       type: Transform
   - uid: 4412
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-25.5
       parent: 2
       type: Transform
   - uid: 4413
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-24.5
       parent: 2
       type: Transform
   - uid: 4414
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,-24.5
       parent: 2
       type: Transform
   - uid: 4418
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,-24.5
       parent: 2
       type: Transform
   - uid: 4419
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-24.5
       parent: 2
       type: Transform
   - uid: 4421
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-25.5
       parent: 2
       type: Transform
   - uid: 4422
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-25.5
       parent: 2
       type: Transform
   - uid: 4428
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-21.5
       parent: 2
       type: Transform
   - uid: 4429
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-21.5
       parent: 2
       type: Transform
   - uid: 4430
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -45.5,-16.5
       parent: 2
       type: Transform
   - uid: 4431
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -44.5,-16.5
       parent: 2
       type: Transform
   - uid: 4444
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -39.5,1.5
       parent: 2
       type: Transform
   - uid: 4445
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,11.5
       parent: 2
       type: Transform
   - uid: 4446
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-0.5
       parent: 2
       type: Transform
   - uid: 4448
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-3.5
       parent: 2
       type: Transform
   - uid: 4449
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -43.5,-16.5
       parent: 2
       type: Transform
   - uid: 4450
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-4.5
       parent: 2
       type: Transform
   - uid: 4628
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -46.5,0.5
       parent: 2
       type: Transform
   - uid: 4635
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-2.5
       parent: 2
       type: Transform
   - uid: 4647
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -53.5,5.5
       parent: 2
       type: Transform
   - uid: 4656
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-6.5
       parent: 2
       type: Transform
   - uid: 4658
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,-29.5
       parent: 2
       type: Transform
   - uid: 4677
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -47.5,5.5
       parent: 2
       type: Transform
   - uid: 4678
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -48.5,5.5
       parent: 2
       type: Transform
   - uid: 4679
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -49.5,5.5
       parent: 2
       type: Transform
   - uid: 4680
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -52.5,5.5
       parent: 2
       type: Transform
   - uid: 4681
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -51.5,5.5
       parent: 2
       type: Transform
   - uid: 4855
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 16.5,-2.5
       parent: 2
       type: Transform
   - uid: 4858
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,-28.5
       parent: 2
       type: Transform
   - uid: 4863
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,-25.5
       parent: 2
       type: Transform
   - uid: 4867
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -9.5,-4.5
       parent: 2
       type: Transform
   - uid: 4869
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -9.5,-3.5
       parent: 2
       type: Transform
   - uid: 5005
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,1.5
       parent: 2
       type: Transform
   - uid: 5010
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -40.5,-12.5
       parent: 2
       type: Transform
   - uid: 5012
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -41.5,1.5
       parent: 2
       type: Transform
   - uid: 5071
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -55.5,5.5
       parent: 2
       type: Transform
   - uid: 5126
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -44.5,-17.5
       parent: 2
       type: Transform
   - uid: 5127
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -44.5,-18.5
       parent: 2
       type: Transform
   - uid: 5290
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -30.5,13.5
       parent: 2
       type: Transform
   - uid: 5307
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -42.5,-11.5
       parent: 2
       type: Transform
   - uid: 5483
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,-2.5
       parent: 2
       type: Transform
   - uid: 5564
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,-26.5
       parent: 2
       type: Transform
   - uid: 5576
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -22.5,-27.5
       parent: 2
       type: Transform
   - uid: 5602
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,-19.5
       parent: 2
       type: Transform
   - uid: 5603
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-19.5
       parent: 2
       type: Transform
   - uid: 6099
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -41.5,13.5
       parent: 2
       type: Transform
   - uid: 6685
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -38.5,14.5
       parent: 2
       type: Transform
   - uid: 6721
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -35.5,17.5
       parent: 2
       type: Transform
   - uid: 6928
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -31.5,-17.5
       parent: 2
       type: Transform
   - uid: 6929
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -48.5,7.5
       parent: 2
       type: Transform
   - uid: 7093
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -33.5,-17.5
       parent: 2
       type: Transform
   - uid: 7239
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -33.5,13.5
       parent: 2
       type: Transform
   - uid: 7490
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -54.5,1.5
       parent: 2
       type: Transform
   - uid: 7574
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -52.5,17.5
       parent: 2
       type: Transform
   - uid: 7681
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -47.5,9.5
       parent: 2
       type: Transform
   - uid: 7710
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -48.5,6.5
       parent: 2
       type: Transform
   - uid: 7767
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -38.5,15.5
       parent: 2
       type: Transform
   - uid: 8007
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -48.5,10.5
       parent: 2
       type: Transform
   - uid: 8008
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -49.5,12.5
       parent: 2
       type: Transform
   - uid: 8059
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -36.5,17.5
       parent: 2
       type: Transform
   - uid: 8371
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -53.5,17.5
       parent: 2
       type: Transform
   - uid: 8378
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -42.5,5.5
       parent: 2
       type: Transform
   - uid: 8382
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -42.5,6.5
       parent: 2
       type: Transform
   - uid: 8383
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -42.5,7.5
       parent: 2
       type: Transform
   - uid: 8384
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -42.5,8.5
       parent: 2
       type: Transform
   - uid: 8529
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -48.5,8.5
       parent: 2
       type: Transform
   - uid: 8748
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 30.5,9.5
       parent: 2
       type: Transform
   - uid: 8749
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -44.5,5.5
       parent: 2
       type: Transform
   - uid: 8831
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -23.5,-25.5
       parent: 2
       type: Transform
   - uid: 8886
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -32.5,-17.5
       parent: 2
       type: Transform
   - uid: 8890
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -42.5,-10.5
       parent: 2
       type: Transform
   - uid: 8969
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,31.5
       parent: 2
       type: Transform
   - uid: 8971
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 3.5,33.5
       parent: 2
       type: Transform
   - uid: 9091
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -52.5,18.5
       parent: 2
       type: Transform
   - uid: 9092
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -52.5,19.5
       parent: 2
       type: Transform
   - uid: 9093
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -51.5,18.5
       parent: 2
       type: Transform
   - uid: 9099
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -53.5,7.5
       parent: 2
       type: Transform
   - uid: 9101
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -54.5,8.5
       parent: 2
       type: Transform
   - uid: 9102
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -55.5,8.5
       parent: 2
       type: Transform
   - uid: 9106
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -52.5,10.5
       parent: 2
       type: Transform
   - uid: 9107
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -52.5,12.5
       parent: 2
       type: Transform
   - uid: 9108
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -52.5,13.5
       parent: 2
       type: Transform
   - uid: 9111
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -54.5,14.5
       parent: 2
       type: Transform
   - uid: 9112
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -53.5,13.5
       parent: 2
       type: Transform
   - uid: 9113
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -54.5,13.5
       parent: 2
       type: Transform
   - uid: 9307
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -32.5,-19.5
       parent: 2
       type: Transform
   - uid: 9308
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -31.5,-19.5
       parent: 2
       type: Transform
   - uid: 9309
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -30.5,-17.5
       parent: 2
       type: Transform
   - uid: 9310
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -41.5,-12.5
       parent: 2
       type: Transform
   - uid: 9311
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -41.5,-8.5
       parent: 2
       type: Transform
   - uid: 9312
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -41.5,-10.5
       parent: 2
       type: Transform
   - uid: 9313
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -41.5,-9.5
       parent: 2
       type: Transform
   - uid: 9314
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -41.5,-7.5
       parent: 2
       type: Transform
   - uid: 9609
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -39.5,5.5
       parent: 2
       type: Transform
   - uid: 9694
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,-9.5
       parent: 2
       type: Transform
   - uid: 9709
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-20.5
       parent: 2
       type: Transform
   - uid: 9710
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-19.5
       parent: 2
       type: Transform
   - uid: 9711
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-18.5
       parent: 2
       type: Transform
   - uid: 9712
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-17.5
       parent: 2
       type: Transform
   - uid: 9899
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,-18.5
       parent: 2
       type: Transform
   - uid: 9902
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,-18.5
       parent: 2
       type: Transform
   - uid: 9909
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -35.5,-19.5
       parent: 2
       type: Transform
   - uid: 9910
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -34.5,-19.5
       parent: 2
       type: Transform
   - uid: 10099
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-24.5
       parent: 2
       type: Transform
   - uid: 10100
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 1.5,-23.5
       parent: 2
       type: Transform
   - uid: 10199
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,5.5
       parent: 2
       type: Transform
   - uid: 10219
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 2.5,14.5
       parent: 2
       type: Transform
   - uid: 10473
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,-2.5
       parent: 2
       type: Transform
   - uid: 10671
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,19.5
       parent: 2
       type: Transform
   - uid: 10674
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 11.5,14.5
       parent: 2
       type: Transform
   - uid: 10731
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,36.5
       parent: 2
       type: Transform
   - uid: 10732
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,36.5
       parent: 2
       type: Transform
   - uid: 10733
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -8.5,33.5
       parent: 2
       type: Transform
   - uid: 10734
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -7.5,33.5
       parent: 2
       type: Transform
   - uid: 10735
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,34.5
       parent: 2
       type: Transform
   - uid: 10736
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -6.5,33.5
       parent: 2
       type: Transform
   - uid: 10738
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -2.5,32.5
       parent: 2
       type: Transform
   - uid: 10739
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -1.5,32.5
       parent: 2
       type: Transform
   - uid: 10740
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -0.5,31.5
       parent: 2
       type: Transform
   - uid: 10741
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,31.5
       parent: 2
       type: Transform
   - uid: 10742
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -2.5,29.5
       parent: 2
       type: Transform
   - uid: 10744
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -2.5,28.5
       parent: 2
       type: Transform
   - uid: 10745
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -1.5,28.5
       parent: 2
       type: Transform
   - uid: 10746
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -0.5,28.5
       parent: 2
       type: Transform
   - uid: 10751
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 0.5,31.5
       parent: 2
       type: Transform
   - uid: 10772
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -36.5,0.5
       parent: 2
       type: Transform
   - uid: 10773
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -19.5,35.5
       parent: 2
       type: Transform
   - uid: 10777
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -18.5,37.5
       parent: 2
       type: Transform
   - uid: 10781
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -37.5,0.5
       parent: 2
       type: Transform
   - uid: 10782
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -23.5,19.5
       parent: 2
       type: Transform
   - uid: 10783
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -25.5,19.5
       parent: 2
       type: Transform
   - uid: 10800
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -24.5,16.5
       parent: 2
       type: Transform
   - uid: 10801
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -25.5,16.5
       parent: 2
       type: Transform
   - uid: 10802
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -24.5,13.5
       parent: 2
       type: Transform
   - uid: 10814
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -24.5,12.5
       parent: 2
       type: Transform
   - uid: 10816
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -25.5,12.5
       parent: 2
       type: Transform
   - uid: 10819
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -23.5,16.5
       parent: 2
       type: Transform
   - uid: 10820
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -23.5,13.5
       parent: 2
       type: Transform
   - uid: 10852
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-2.5
       parent: 2
       type: Transform
   - uid: 10853
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -3.5,-1.5
       parent: 2
       type: Transform
   - uid: 10956
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,6.5
       parent: 2
       type: Transform
   - uid: 10957
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,6.5
       parent: 2
       type: Transform
   - uid: 10958
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 33.5,6.5
       parent: 2
       type: Transform
   - uid: 10959
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -38.5,0.5
       parent: 2
       type: Transform
   - uid: 10960
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -39.5,0.5
       parent: 2
       type: Transform
   - uid: 10966
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,11.5
       parent: 2
       type: Transform
   - uid: 10972
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,11.5
       parent: 2
       type: Transform
   - uid: 10989
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 12.5,14.5
       parent: 2
       type: Transform
   - uid: 10990
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,14.5
       parent: 2
       type: Transform
   - uid: 10991
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,14.5
       parent: 2
       type: Transform
   - uid: 10992
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 15.5,14.5
       parent: 2
       type: Transform
   - uid: 10993
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 9.5,12.5
       parent: 2
       type: Transform
   - uid: 10995
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,12.5
       parent: 2
       type: Transform
   - uid: 10996
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,12.5
       parent: 2
       type: Transform
   - uid: 10997
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 14.5,12.5
       parent: 2
       type: Transform
   - uid: 10998
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 17.5,13.5
       parent: 2
       type: Transform
   - uid: 10999
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 18.5,13.5
       parent: 2
       type: Transform
   - uid: 11000
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,13.5
       parent: 2
       type: Transform
   - uid: 11001
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 13.5,11.5
       parent: 2
       type: Transform
   - uid: 11058
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-18.5
       parent: 2
       type: Transform
   - uid: 11059
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-15.5
       parent: 2
       type: Transform
   - uid: 11060
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -2.5,-14.5
       parent: 2
       type: Transform
   - uid: 11061
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -1.5,-14.5
       parent: 2
       type: Transform
   - uid: 11063
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 25.5,-22.5
       parent: 2
       type: Transform
   - uid: 11065
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 26.5,-23.5
       parent: 2
       type: Transform
   - uid: 11066
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 27.5,-23.5
       parent: 2
       type: Transform
   - uid: 11067
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 26.5,-22.5
       parent: 2
       type: Transform
   - uid: 11109
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 5.5,-24.5
       parent: 2
       type: Transform
   - uid: 11111
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-24.5
       parent: 2
       type: Transform
   - uid: 11112
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 6.5,-25.5
       parent: 2
       type: Transform
   - uid: 11171
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -4.5,-21.5
       parent: 2
       type: Transform
   - uid: 11172
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -4.5,-22.5
       parent: 2
       type: Transform
   - uid: 11173
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -4.5,-23.5
       parent: 2
       type: Transform
   - uid: 11174
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -4.5,-24.5
       parent: 2
       type: Transform
   - uid: 11539
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,0.5
       parent: 2
       type: Transform
   - uid: 11540
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-0.5
       parent: 2
       type: Transform
   - uid: 11541
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 23.5,-1.5
       parent: 2
       type: Transform
   - uid: 11542
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 24.5,-1.5
       parent: 2
       type: Transform
   - uid: 11543
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 26.5,-1.5
       parent: 2
       type: Transform
   - uid: 11544
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 27.5,-1.5
       parent: 2
       type: Transform
   - uid: 11556
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 22.5,0.5
       parent: 2
       type: Transform
   - uid: 11557
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 21.5,0.5
       parent: 2
       type: Transform
   - uid: 11558
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 20.5,0.5
       parent: 2
       type: Transform
   - uid: 11559
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,0.5
       parent: 2
       type: Transform
   - uid: 11560
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 19.5,-2.5
       parent: 2
       type: Transform
   - uid: 11586
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 31.5,-5.5
       parent: 2
       type: Transform
   - uid: 11597
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 32.5,-5.5
       parent: 2
       type: Transform
   - uid: 12346
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -54.5,5.5
       parent: 2
       type: Transform
@@ -83500,118 +88873,160 @@ entities:
   entities:
   - uid: 2437
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 46.5,-18.5
       parent: 2
       type: Transform
   - uid: 2439
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 45.5,-18.5
       parent: 2
       type: Transform
   - uid: 2440
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 41.5,-18.5
       parent: 2
       type: Transform
   - uid: 2538
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 40.5,-21.5
       parent: 2
       type: Transform
   - uid: 3238
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 39.5,-25.5
       parent: 2
       type: Transform
   - uid: 3239
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 38.5,-25.5
       parent: 2
       type: Transform
   - uid: 3749
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: -1.5707963267948966 rad
       pos: -32.5,-18.5
       parent: 2
       type: Transform
   - uid: 4259
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -50.5,10.5
       parent: 2
       type: Transform
   - uid: 7664
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -5.5,-10.5
       parent: 2
       type: Transform
   - uid: 9064
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -53.5,8.5
       parent: 2
       type: Transform
   - uid: 9100
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -52.5,8.5
       parent: 2
       type: Transform
   - uid: 9104
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: -52.5,9.5
       parent: 2
       type: Transform
   - uid: 9116
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -50.5,9.5
       parent: 2
       type: Transform
   - uid: 9647
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 8.5,12.5
       parent: 2
       type: Transform
   - uid: 10799
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -24.5,24.5
       parent: 2
       type: Transform
   - uid: 10829
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -23.5,24.5
       parent: 2
       type: Transform
   - uid: 10855
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -23.5,23.5
       parent: 2
       type: Transform
   - uid: 10856
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -23.5,15.5
       parent: 2
       type: Transform
   - uid: 10932
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -23.5,27.5
       parent: 2
       type: Transform
   - uid: 10933
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: -23.5,28.5
       parent: 2
       type: Transform
   - uid: 10994
     components:
+    - flags: PvsPriority
+      type: MetaData
     - pos: 7.5,12.5
       parent: 2
       type: Transform
@@ -83641,103 +89056,12 @@ entities:
       type: Transform
 - proto: WarpPoint
   entities:
-  - uid: 12046
-    components:
-    - pos: -66.5,5.5
-      parent: 2
-      type: Transform
-    - location: Evacuation
-      type: WarpPoint
-  - uid: 12049
-    components:
-    - pos: -12.5,42.5
-      parent: 2
-      type: Transform
-    - location: Perma
-      type: WarpPoint
-  - uid: 12052
-    components:
-    - pos: 29.5,16.5
-      parent: 2
-      type: Transform
-    - location: Vault
-      type: WarpPoint
   - uid: 12057
     components:
     - pos: 53.5,29.5
       parent: 2
       type: Transform
     - location: Abandonded AI Sat
-      type: WarpPoint
-- proto: WarpPointBeaconCargo
-  entities:
-  - uid: 12045
-    components:
-    - pos: -51.5,-6.5
-      parent: 2
-      type: Transform
-    - location: Cargo
-      type: WarpPoint
-- proto: WarpPointBeaconCommand
-  entities:
-  - uid: 12050
-    components:
-    - pos: 11.5,23.5
-      parent: 2
-      type: Transform
-    - location: HoP's Office
-      type: WarpPoint
-  - uid: 12051
-    components:
-    - pos: 19.5,30.5
-      parent: 2
-      type: Transform
-    - location: Bridge
-      type: WarpPoint
-- proto: WarpPointBeaconEngineering
-  entities:
-  - uid: 12056
-    components:
-    - pos: -9.5,-19.5
-      parent: 2
-      type: Transform
-    - location: Engineering
-      type: WarpPoint
-- proto: WarpPointBeaconMedical
-  entities:
-  - uid: 12047
-    components:
-    - pos: -32.5,7.5
-      parent: 2
-      type: Transform
-    - location: Medical
-      type: WarpPoint
-- proto: WarpPointBeaconScience
-  entities:
-  - uid: 12055
-    components:
-    - pos: -18.5,-1.5
-      parent: 2
-      type: Transform
-    - location: Science
-      type: WarpPoint
-- proto: WarpPointBeaconSecurity
-  entities:
-  - uid: 12048
-    components:
-    - pos: -8.5,15.5
-      parent: 2
-      type: Transform
-    - location: Security
-      type: WarpPoint
-- proto: WarpPointBeaconService
-  entities:
-  - uid: 12054
-    components:
-    - pos: 12.5,-12.5
-      parent: 2
-      type: Transform
-    - location: Service Department
       type: WarpPoint
 - proto: WarpPointBombing
   entities:
@@ -84088,12 +89412,6 @@ entities:
       type: Transform
 - proto: WindoorSecureArmoryLocked
   entities:
-  - uid: 1200
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -10.5,26.5
-      parent: 2
-      type: Transform
   - uid: 1201
     components:
     - rot: 1.5707963267948966 rad
@@ -84162,6 +89480,11 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: 14.5,21.5
+      parent: 2
+      type: Transform
+  - uid: 2656
+    components:
+    - pos: 14.5,21.5
       parent: 2
       type: Transform
 - proto: WindoorSecureMedicalLocked
@@ -84238,6 +89561,12 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: -13.5,5.5
+      parent: 2
+      type: Transform
+  - uid: 12048
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -10.5,26.5
       parent: 2
       type: Transform
 - proto: WindoorServiceLocked
@@ -84821,12 +90150,16 @@ entities:
   entities:
   - uid: 2375
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 38.5,-20.5
       parent: 2
       type: Transform
   - uid: 2376
     components:
+    - flags: PvsPriority
+      type: MetaData
     - rot: 3.141592653589793 rad
       pos: 38.5,-18.5
       parent: 2

--- a/Resources/Maps/_CD/ferrous.yml
+++ b/Resources/Maps/_CD/ferrous.yml
@@ -9,6 +9,7 @@ tilemap:
   11: FloorAsteroidTile
   17: FloorBlueCircuit
   19: FloorBrokenWood
+  25: FloorClown
   29: FloorDark
   34: FloorDarkMono
   38: FloorDarkPlastic
@@ -82,7 +83,7 @@ entities:
           version: 6
         1,0:
           ind: 1,0
-          tiles: aQAAAAAAagAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAAAWgAAAAAAWgAAAAAAeQAAAAAAIgAAAAAAIgAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAADWQAAAAADWQAAAAADWQAAAAACeQAAAAAAWQAAAAACeQAAAAAAWQAAAAADWQAAAAAAWQAAAAACWQAAAAABWQAAAAAAWQAAAAADWQAAAAABWQAAAAADWQAAAAABWQAAAAADWQAAAAABWQAAAAABWQAAAAACWQAAAAADWQAAAAAAWQAAAAABWQAAAAACWQAAAAABWQAAAAABWQAAAAABWQAAAAADWQAAAAADWQAAAAACWQAAAAABeQAAAAAAWQAAAAABWQAAAAABWQAAAAADWQAAAAABWQAAAAACWQAAAAAAWQAAAAAAWQAAAAADWQAAAAAAWQAAAAADWQAAAAADWQAAAAADWQAAAAACeQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAdgAAAAABdgAAAAADdgAAAAAAdwAAAAAAdwAAAAACeQAAAAAAWQAAAAADWQAAAAABWQAAAAABeQAAAAAAWQAAAAACWQAAAAAAWQAAAAADWQAAAAADeQAAAAAAeQAAAAAAdgAAAAADdgAAAAAAdgAAAAAAdwAAAAAAdwAAAAADeQAAAAAAWQAAAAADWQAAAAACWQAAAAABeQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAEwAAAAAFEwAAAAAEdgAAAAAAdwAAAAACdwAAAAAAeQAAAAAAWQAAAAACeQAAAAAAWQAAAAACeQAAAAAAWQAAAAABWQAAAAADWQAAAAACWQAAAAADeQAAAAAAeQAAAAAAdgAAAAABEwAAAAAGdgAAAAADdwAAAAACdwAAAAAAeQAAAAAAWQAAAAADWQAAAAABWQAAAAABeQAAAAAAeQAAAAAAHQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAHQAAAAAAHQAAAAADHQAAAAABeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAagAAAAACagAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACeQAAAAAAHQAAAAADHQAAAAABHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAagAAAAADeQAAAAAAeQAAAAAAaQAAAAAAaQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAagAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAADWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAADWQAAAAAAeQAAAAAAHQAAAAADHQAAAAACeQAAAAAAHQAAAAABHQAAAAACHQAAAAAA
+          tiles: aQAAAAAAagAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAAAWgAAAAAAWgAAAAAAeQAAAAAAIgAAAAAAIgAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAADWQAAAAADWQAAAAADWQAAAAACeQAAAAAAWQAAAAACeQAAAAAAWQAAAAADWQAAAAAAWQAAAAACWQAAAAABWQAAAAAAWQAAAAADWQAAAAABWQAAAAADWQAAAAABWQAAAAADWQAAAAABWQAAAAABWQAAAAACWQAAAAADWQAAAAAAWQAAAAABWQAAAAACWQAAAAABWQAAAAABWQAAAAABWQAAAAADWQAAAAADWQAAAAACWQAAAAABeQAAAAAAWQAAAAABWQAAAAABWQAAAAADWQAAAAABWQAAAAACWQAAAAAAWQAAAAAAWQAAAAADWQAAAAAAWQAAAAADWQAAAAADWQAAAAADWQAAAAACeQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAdgAAAAABdgAAAAADdgAAAAAAdwAAAAAAdwAAAAACeQAAAAAAWQAAAAADWQAAAAABWQAAAAABeQAAAAAAWQAAAAACWQAAAAAAWQAAAAADWQAAAAADeQAAAAAAeQAAAAAAdgAAAAADdgAAAAAAdgAAAAAAdwAAAAAAdwAAAAADeQAAAAAAWQAAAAADWQAAAAACWQAAAAABeQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAEwAAAAAFEwAAAAAEdgAAAAAAdwAAAAACdwAAAAAAeQAAAAAAWQAAAAACeQAAAAAAWQAAAAACeQAAAAAAWQAAAAABWQAAAAADWQAAAAACWQAAAAADeQAAAAAAeQAAAAAAdgAAAAABEwAAAAAGdgAAAAADdwAAAAACdwAAAAAAeQAAAAAAWQAAAAADWQAAAAABWQAAAAABeQAAAAAAeQAAAAAAHQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdgAAAAAAeQAAAAAAWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAHQAAAAAAHQAAAAADHQAAAAABeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACeQAAAAAAHQAAAAADHQAAAAABHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAGQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAagAAAAACeQAAAAAAGQAAAAAAeQAAAAAAGQAAAAAAeQAAAAAAWQAAAAAAWQAAAAADWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAGQAAAAAAGQAAAAAAGQAAAAAAeQAAAAAAWQAAAAACWQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAADWQAAAAAAeQAAAAAAHQAAAAADHQAAAAACeQAAAAAAHQAAAAABHQAAAAACHQAAAAAA
           version: 6
         1,1:
           ind: 1,1
@@ -1940,6 +1941,9 @@ entities:
             5068: -10,-17
             5069: -10,-17
             5070: -10,-17
+            5079: 19,13
+            5080: 19,13
+            5081: 19,12
         - node:
             color: '#FFFFFFFF'
             id: DirtHeavy
@@ -4073,6 +4077,17 @@ entities:
             4915: 40,5
             4916: 45,5
             4917: 46,4
+            5082: 17,11
+            5083: 18,11
+            5084: 18,12
+            5085: 18,13
+            5086: 18,14
+            5087: 19,14
+            5088: 19,14
+            5089: 19,13
+            5090: 20,12
+            5091: 20,12
+            5092: 20,11
         - node:
             cleanable: True
             color: '#FFFFFFFF'
@@ -4958,6 +4973,11 @@ entities:
             5062: -17,-3
             5063: -17,-2
             5064: -17,-1
+            5093: 19,11
+            5094: 18,12
+            5095: 19,13
+            5096: 20,13
+            5097: 20,12
         - node:
             color: '#FFFFFFFF'
             id: DirtMedium
@@ -6205,7 +6225,9 @@ entities:
           4,2:
             0: 65535
           4,3:
-            0: 65535
+            0: 62463
+            1: 1024
+            2: 2048
           4,4:
             0: 65535
           4,-1:
@@ -6307,7 +6329,8 @@ entities:
           5,2:
             0: 65535
           5,3:
-            0: 65535
+            1: 1
+            0: 65534
           6,0:
             0: 65535
           6,1:
@@ -6516,15 +6539,15 @@ entities:
             0: 65535
           4,-6:
             0: 16383
-            1: 49152
+            3: 49152
           4,-5:
             0: 62259
-            1: 3276
+            3: 3276
           5,-6:
             0: 36863
-            1: 28672
+            3: 28672
           5,-5:
-            1: 1911
+            3: 1911
             0: 63624
           6,-6:
             0: 65535
@@ -6854,10 +6877,10 @@ entities:
             0: 65535
           -6,-8:
             0: 49151
-            2: 16384
+            4: 16384
           -6,-7:
             0: 63487
-            3: 2048
+            2: 2048
           -5,-8:
             0: 65535
           -5,-7:
@@ -6952,7 +6975,7 @@ entities:
             0: 60608
           -14,-5:
             0: 65532
-            4: 3
+            5: 3
           -13,-5:
             0: 65523
           -15,-4:
@@ -7089,10 +7112,10 @@ entities:
             0: 3276
           0,-10:
             0: 4369
-            4: 25088
+            5: 25088
           0,-9:
             0: 29457
-            4: 36078
+            5: 36078
           7,6:
             0: 65535
           13,-6:
@@ -7381,14 +7404,44 @@ entities:
             0: 273
           -14,-6:
             0: 52224
-            4: 13056
+            5: 13056
           -13,-6:
             0: 13056
           1,-9:
-            4: 12288
+            5: 12288
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14975
           moles:
           - 21.824879
           - 82.10312
@@ -7422,21 +7475,6 @@ entities:
           moles:
           - 21.6852
           - 81.57766
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.14975
-          moles:
-          - 21.824879
-          - 82.10312
           - 0
           - 0
           - 0
@@ -7522,6 +7560,33 @@ entities:
       - 3263
       - 3262
       - 3260
+      type: DeviceList
+    - joinedGrid: 2
+      type: AtmosDevice
+  - uid: 2634
+    components:
+    - pos: -36.5,-1.5
+      parent: 2
+      type: Transform
+    - devices:
+      - 6846
+      - 6847
+      - 9250
+      type: DeviceList
+    - joinedGrid: 2
+      type: AtmosDevice
+  - uid: 2648
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -24.5,-10.5
+      parent: 2
+      type: Transform
+    - devices:
+      - 12549
+      - 6826
+      - 10999
+      - 9251
+      - 9254
       type: DeviceList
     - joinedGrid: 2
       type: AtmosDevice
@@ -7903,6 +7968,7 @@ entities:
       - 9211
       - 9208
       - 9175
+      - 12843
       type: DeviceList
     - joinedGrid: 2
       type: AtmosDevice
@@ -7932,19 +7998,7 @@ entities:
       - 9249
       - 6827
       - 6828
-      type: DeviceList
-    - joinedGrid: 2
-      type: AtmosDevice
-  - uid: 9251
-    components:
-    - pos: -36.5,-1.5
-      parent: 2
-      type: Transform
-    - devices:
-      - 9239
-      - 6846
-      - 6847
-      - 9250
+      - 6775
       type: DeviceList
     - joinedGrid: 2
       type: AtmosDevice
@@ -7997,20 +8051,6 @@ entities:
       - 9257
       - 6751
       - 6756
-      type: DeviceList
-    - joinedGrid: 2
-      type: AtmosDevice
-  - uid: 9266
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -24.5,-10.5
-      parent: 2
-      type: Transform
-    - devices:
-      - 9243
-      - 9254
-      - 6826
-      - 6825
       type: DeviceList
     - joinedGrid: 2
       type: AtmosDevice
@@ -8338,6 +8378,7 @@ entities:
       - 9616
       - 9619
       - 9618
+      - 12846
       type: DeviceList
     - joinedGrid: 2
       type: AtmosDevice
@@ -8592,6 +8633,19 @@ entities:
       - 9850
       - 9844
       - 9851
+      type: DeviceList
+    - joinedGrid: 2
+      type: AtmosDevice
+  - uid: 11025
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -21.5,-8.5
+      parent: 2
+      type: Transform
+    - devices:
+      - 12852
+      - 11000
+      - 6793
       type: DeviceList
     - joinedGrid: 2
       type: AtmosDevice
@@ -9980,16 +10034,6 @@ entities:
       pos: -20.5,12.5
       parent: 2
       type: Transform
-- proto: AirlockMaintTheatreLocked
-  entities:
-  - uid: 2682
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: 3.141592653589793 rad
-      pos: 20.5,10.5
-      parent: 2
-      type: Transform
 - proto: AirlockMedicalGlassLocked
   entities:
   - uid: 331
@@ -10264,6 +10308,16 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: 16.5,-15.5
+      parent: 2
+      type: Transform
+- proto: AirlockServiceLocked
+  entities:
+  - uid: 12789
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: 20.5,10.5
       parent: 2
       type: Transform
 - proto: AirlockShuttle
@@ -11647,12 +11701,6 @@ entities:
       type: Transform
 - proto: BarricadeBlock
   entities:
-  - uid: 3380
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 20.5,10.5
-      parent: 2
-      type: Transform
   - uid: 11195
     components:
     - pos: -5.5,-11.5
@@ -11798,6 +11846,17 @@ entities:
       pos: -20.5,-17.5
       parent: 2
       type: Transform
+- proto: BedsheetClown
+  entities:
+  - uid: 12866
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 12865
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: BedsheetCMO
   entities:
   - uid: 11261
@@ -11867,6 +11926,17 @@ entities:
     - pos: -38.5,25.5
       parent: 2
       type: Transform
+- proto: BedsheetMime
+  entities:
+  - uid: 12860
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 12859
+      type: Transform
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
 - proto: BedsheetQM
   entities:
   - uid: 7455
@@ -14767,6 +14837,16 @@ entities:
     - pos: 13.5,23.5
       parent: 2
       type: Transform
+  - uid: 2682
+    components:
+    - pos: 19.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 2684
+    components:
+    - pos: 19.5,13.5
+      parent: 2
+      type: Transform
   - uid: 2771
     components:
     - pos: 16.5,-3.5
@@ -15295,6 +15375,21 @@ entities:
   - uid: 3439
     components:
     - pos: 1.5,-14.5
+      parent: 2
+      type: Transform
+  - uid: 3589
+    components:
+    - pos: 19.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 3590
+    components:
+    - pos: 20.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 3605
+    components:
+    - pos: 19.5,11.5
       parent: 2
       type: Transform
   - uid: 3811
@@ -21137,11 +21232,6 @@ entities:
     - pos: 16.5,14.5
       parent: 2
       type: Transform
-  - uid: 12546
-    components:
-    - pos: 17.5,14.5
-      parent: 2
-      type: Transform
   - uid: 12547
     components:
     - pos: 18.5,14.5
@@ -21150,11 +21240,6 @@ entities:
   - uid: 12548
     components:
     - pos: 19.5,14.5
-      parent: 2
-      type: Transform
-  - uid: 12549
-    components:
-    - pos: 20.5,14.5
       parent: 2
       type: Transform
   - uid: 12550
@@ -29797,26 +29882,6 @@ entities:
     - pos: 15.5,12.5
       parent: 2
       type: Transform
-  - uid: 11010
-    components:
-    - pos: 17.5,14.5
-      parent: 2
-      type: Transform
-  - uid: 11011
-    components:
-    - pos: 18.5,14.5
-      parent: 2
-      type: Transform
-  - uid: 11012
-    components:
-    - pos: 20.5,14.5
-      parent: 2
-      type: Transform
-  - uid: 11013
-    components:
-    - pos: 20.5,13.5
-      parent: 2
-      type: Transform
   - uid: 11033
     components:
     - pos: -37.5,-0.5
@@ -30901,6 +30966,12 @@ entities:
       pos: -33.5,-27.5
       parent: 2
       type: Transform
+  - uid: 6696
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 19.5,13.5
+      parent: 2
+      type: Transform
   - uid: 7463
     components:
     - rot: -1.5707963267948966 rad
@@ -31068,6 +31139,12 @@ entities:
   - uid: 12810
     components:
     - pos: -8.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 12868
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 18.5,11.5
       parent: 2
       type: Transform
 - proto: ChairWood
@@ -31661,11 +31738,6 @@ entities:
     - pos: 40.5,8.5
       parent: 2
       type: Transform
-  - uid: 11025
-    components:
-    - pos: 19.5,12.5
-      parent: 2
-      type: Transform
   - uid: 11051
     components:
     - pos: -32.5,-2.5
@@ -31799,11 +31871,6 @@ entities:
     - pos: 37.5,6.5
       parent: 2
       type: Transform
-  - uid: 11023
-    components:
-    - pos: 18.5,12.5
-      parent: 2
-      type: Transform
   - uid: 11027
     components:
     - pos: 12.5,12.5
@@ -31852,6 +31919,11 @@ entities:
   - uid: 11588
     components:
     - pos: 21.5,-2.5
+      parent: 2
+      type: Transform
+  - uid: 12853
+    components:
+    - pos: 16.5,14.5
       parent: 2
       type: Transform
 - proto: ClosetWallEmergencyFilledRandom
@@ -32917,14 +32989,14 @@ entities:
       type: Transform
 - proto: CrateArtifactContainer
   entities:
+  - uid: 6825
+    components:
+    - pos: -33.5,-7.5
+      parent: 2
+      type: Transform
   - uid: 9763
     components:
     - pos: -28.5,-11.5
-      parent: 2
-      type: Transform
-  - uid: 9767
-    components:
-    - pos: -33.5,-7.5
       parent: 2
       type: Transform
 - proto: CrateCoffin
@@ -33135,9 +33207,9 @@ entities:
     - pos: 2.5,33.5
       parent: 2
       type: Transform
-  - uid: 11032
+  - uid: 11017
     components:
-    - pos: 16.5,12.5
+    - pos: 15.5,11.5
       parent: 2
       type: Transform
 - proto: CrateTrashCartJani
@@ -37451,6 +37523,13 @@ entities:
     - pos: 45.513157,3.7170155
       parent: 2
       type: Transform
+- proto: DrinkSpaceLube
+  entities:
+  - uid: 12857
+    components:
+    - pos: 20.617603,13.860225
+      parent: 2
+      type: Transform
 - proto: EmergencyLight
   entities:
   - uid: 641
@@ -38767,6 +38846,9 @@ entities:
     - pos: -28.5,-6.5
       parent: 2
       type: Transform
+    - deviceLists:
+      - 2648
+      type: DeviceNetwork
   - uid: 9255
     components:
     - pos: -30.5,-3.5
@@ -38910,6 +38992,17 @@ entities:
     - pos: -26.5,11.5
       parent: 2
       type: Transform
+  - uid: 12852
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -21.5,-9.5
+      parent: 2
+      type: Transform
+    - configurators:
+      - invalid
+      deviceLists:
+      - 11025
+      type: DeviceNetwork
 - proto: FirelockEdge
   entities:
   - uid: 3261
@@ -39259,6 +39352,9 @@ entities:
       pos: -34.5,-4.5
       parent: 2
       type: Transform
+    - deviceLists:
+      - 2634
+      type: DeviceNetwork
   - uid: 9256
     components:
     - pos: -20.5,-7.5
@@ -40163,6 +40259,20 @@ entities:
   - uid: 10848
     components:
     - pos: -15.39901,13.638652
+      parent: 2
+      type: Transform
+- proto: FoodPieApple
+  entities:
+  - uid: 12858
+    components:
+    - pos: 20.470167,14.672701
+      parent: 2
+      type: Transform
+- proto: FoodPieBananaCream
+  entities:
+  - uid: 12790
+    components:
+    - pos: 17.402325,11.374113
       parent: 2
       type: Transform
 - proto: FoodPlate
@@ -41163,14 +41273,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 6824
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -28.5,-8.5
-      parent: 2
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
   - uid: 6868
     components:
     - pos: 3.5,15.5
@@ -41763,16 +41865,13 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 12782
+  - uid: 12839
     components:
-    - pos: -37.5,-2.5
+    - pos: -43.5,6.5
       parent: 2
       type: Transform
-  - uid: 12786
-    components:
-    - pos: -36.5,-3.5
-      parent: 2
-      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
 - proto: GasPipeFourway
   entities:
   - uid: 1720
@@ -41890,6 +41989,20 @@ entities:
   - uid: 9699
     components:
     - pos: 11.5,-19.5
+      parent: 2
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 9762
+    components:
+    - pos: -22.5,-6.5
+      parent: 2
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 9767
+    components:
+    - pos: -32.5,6.5
       parent: 2
       type: Transform
     - color: '#990000FF'
@@ -47241,14 +47354,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 6696
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -43.5,4.5
-      parent: 2
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
   - uid: 6697
     components:
     - rot: -1.5707963267948966 rad
@@ -47894,6 +47999,14 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
+  - uid: 6824
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -29.5,-7.5
+      parent: 2
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
   - uid: 6830
     components:
     - rot: -1.5707963267948966 rad
@@ -47938,14 +48051,6 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: -32.5,-5.5
-      parent: 2
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
-  - uid: 6837
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -33.5,-5.5
       parent: 2
       type: Transform
     - color: '#990000FF'
@@ -53075,6 +53180,13 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
+  - uid: 9266
+    components:
+    - pos: -33.5,-6.5
+      parent: 2
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 9271
     components:
     - rot: 3.141592653589793 rad
@@ -53259,6 +53371,45 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
+  - uid: 10997
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -36.5,-4.5
+      parent: 2
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 11010
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -37.5,-5.5
+      parent: 2
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 11015
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -28.5,-8.5
+      parent: 2
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 11024
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -29.5,-9.5
+      parent: 2
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 11032
+    components:
+    - pos: -28.5,-8.5
+      parent: 2
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 11743
     components:
     - rot: -1.5707963267948966 rad
@@ -53329,6 +53480,13 @@ entities:
       type: Transform
     - color: '#0055CCFF'
       type: AtmosPipeColor
+  - uid: 12546
+    components:
+    - pos: -22.5,-7.5
+      parent: 2
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 12683
     components:
     - rot: 3.141592653589793 rad
@@ -53374,23 +53532,62 @@ entities:
       pos: -1.5,-30.5
       parent: 2
       type: Transform
-  - uid: 12783
+  - uid: 12832
     components:
     - rot: 3.141592653589793 rad
-      pos: -37.5,-4.5
+      pos: -43.5,5.5
       parent: 2
       type: Transform
-  - uid: 12787
-    components:
-    - pos: -37.5,-3.5
-      parent: 2
-      type: Transform
-  - uid: 12788
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 12840
     components:
     - rot: -1.5707963267948966 rad
-      pos: -37.5,-3.5
+      pos: -44.5,6.5
       parent: 2
       type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 12841
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -45.5,6.5
+      parent: 2
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 12842
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -46.5,6.5
+      parent: 2
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 12844
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -31.5,6.5
+      parent: 2
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 12845
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -30.5,6.5
+      parent: 2
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 12847
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -27.5,-8.5
+      parent: 2
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
 - proto: GasPipeTJunction
   entities:
   - uid: 718
@@ -54285,14 +54482,6 @@ entities:
       type: Transform
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 6796
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -22.5,-6.5
-      parent: 2
-      type: Transform
-    - color: '#990000FF'
-      type: AtmosPipeColor
   - uid: 6798
     components:
     - rot: 3.141592653589793 rad
@@ -54321,6 +54510,16 @@ entities:
       pos: -32.5,-8.5
       parent: 2
       type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 6837
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -43.5,4.5
+      parent: 2
+      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 6838
     components:
     - pos: -32.5,-4.5
@@ -54727,8 +54926,7 @@ entities:
       type: AtmosPipeColor
   - uid: 7959
     components:
-    - rot: -1.5707963267948966 rad
-      pos: -32.5,6.5
+    - pos: -33.5,-5.5
       parent: 2
       type: Transform
     - color: '#990000FF'
@@ -55034,16 +55232,12 @@ entities:
       type: AtmosPipeColor
   - uid: 9761
     components:
-    - rot: 3.141592653589793 rad
-      pos: -36.5,-4.5
+    - rot: 1.5707963267948966 rad
+      pos: -28.5,-9.5
       parent: 2
       type: Transform
-  - uid: 9762
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -37.5,-5.5
-      parent: 2
-      type: Transform
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 9799
     components:
     - rot: -1.5707963267948966 rad
@@ -55056,6 +55250,14 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: -18.5,-5.5
+      parent: 2
+      type: Transform
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
+  - uid: 11011
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -29.5,-8.5
       parent: 2
       type: Transform
     - color: '#0055CCFF'
@@ -55595,6 +55797,9 @@ entities:
       pos: -23.5,-9.5
       parent: 2
       type: Transform
+    - deviceLists:
+      - 11025
+      type: DeviceNetwork
     - joinedGrid: 2
       type: AtmosDevice
     - color: '#0055CCFF'
@@ -55611,10 +55816,13 @@ entities:
       type: AtmosPipeColor
   - uid: 6826
     components:
-    - rot: 3.141592653589793 rad
-      pos: -29.5,-7.5
+    - rot: -1.5707963267948966 rad
+      pos: -26.5,-8.5
       parent: 2
       type: Transform
+    - deviceLists:
+      - 2648
+      type: DeviceNetwork
     - joinedGrid: 2
       type: AtmosDevice
     - color: '#0055CCFF'
@@ -55635,6 +55843,9 @@ entities:
       pos: -38.5,-4.5
       parent: 2
       type: Transform
+    - deviceLists:
+      - 2634
+      type: DeviceNetwork
     - joinedGrid: 2
       type: AtmosDevice
     - color: '#0055CCFF'
@@ -56128,6 +56339,19 @@ entities:
       type: AtmosDevice
     - color: '#0055CCFF'
       type: AtmosPipeColor
+  - uid: 9251
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -29.5,-10.5
+      parent: 2
+      type: Transform
+    - deviceLists:
+      - 2648
+      type: DeviceNetwork
+    - joinedGrid: 2
+      type: AtmosDevice
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
   - uid: 9260
     components:
     - rot: 3.141592653589793 rad
@@ -56395,14 +56619,6 @@ entities:
       type: AtmosDevice
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 12790
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -38.5,-3.5
-      parent: 2
-      type: Transform
-    - joinedGrid: 2
-      type: AtmosDevice
   - uid: 12791
     components:
     - rot: 1.5707963267948966 rad
@@ -56411,6 +56627,8 @@ entities:
       type: Transform
     - joinedGrid: 2
       type: AtmosDevice
+    - color: '#0055CCFF'
+      type: AtmosPipeColor
 - proto: GasVentScrubber
   entities:
   - uid: 505
@@ -56709,6 +56927,19 @@ entities:
       type: AtmosDevice
     - color: '#990000FF'
       type: AtmosPipeColor
+  - uid: 6775
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -33.5,-7.5
+      parent: 2
+      type: Transform
+    - deviceLists:
+      - 9247
+      type: DeviceNetwork
+    - joinedGrid: 2
+      type: AtmosDevice
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 6783
     components:
     - rot: -1.5707963267948966 rad
@@ -56739,16 +56970,6 @@ entities:
       type: AtmosDevice
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 6825
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -29.5,-8.5
-      parent: 2
-      type: Transform
-    - joinedGrid: 2
-      type: AtmosDevice
-    - color: '#990000FF'
-      type: AtmosPipeColor
   - uid: 6828
     components:
     - rot: 3.141592653589793 rad
@@ -56765,6 +56986,9 @@ entities:
       pos: -38.5,-5.5
       parent: 2
       type: Transform
+    - deviceLists:
+      - 2634
+      type: DeviceNetwork
     - joinedGrid: 2
       type: AtmosDevice
     - color: '#990000FF'
@@ -57473,6 +57697,45 @@ entities:
       type: AtmosDevice
     - color: '#990000FF'
       type: AtmosPipeColor
+  - uid: 10999
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -28.5,-10.5
+      parent: 2
+      type: Transform
+    - deviceLists:
+      - 2648
+      type: DeviceNetwork
+    - joinedGrid: 2
+      type: AtmosDevice
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 11000
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -22.5,-8.5
+      parent: 2
+      type: Transform
+    - deviceLists:
+      - 11025
+      type: DeviceNetwork
+    - joinedGrid: 2
+      type: AtmosDevice
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 12549
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -27.5,-9.5
+      parent: 2
+      type: Transform
+    - deviceLists:
+      - 2648
+      type: DeviceNetwork
+    - joinedGrid: 2
+      type: AtmosDevice
+    - color: '#990000FF'
+      type: AtmosPipeColor
   - uid: 12686
     components:
     - pos: -35.5,28.5
@@ -57492,14 +57755,32 @@ entities:
       type: AtmosDevice
     - color: '#990000FF'
       type: AtmosPipeColor
-  - uid: 12789
+  - uid: 12843
     components:
     - rot: 1.5707963267948966 rad
-      pos: -38.5,-2.5
+      pos: -47.5,6.5
       parent: 2
       type: Transform
+    - deviceLists:
+      - 9212
+      type: DeviceNetwork
     - joinedGrid: 2
       type: AtmosDevice
+    - color: '#990000FF'
+      type: AtmosPipeColor
+  - uid: 12846
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -29.5,6.5
+      parent: 2
+      type: Transform
+    - deviceLists:
+      - 9621
+      type: DeviceNetwork
+    - joinedGrid: 2
+      type: AtmosDevice
+    - color: '#990000FF'
+      type: AtmosPipeColor
 - proto: GravityGenerator
   entities:
   - uid: 3988
@@ -58199,6 +58480,12 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: -34.5,-5.5
+      parent: 2
+      type: Transform
+  - uid: 3704
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 19.5,10.5
       parent: 2
       type: Transform
   - uid: 3771
@@ -59271,6 +59558,12 @@ entities:
     - pos: -2.5,13.5
       parent: 2
       type: Transform
+  - uid: 12786
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 18.5,10.5
+      parent: 2
+      type: Transform
 - proto: GrilleBroken
   entities:
   - uid: 10206
@@ -60112,6 +60405,42 @@ entities:
     - pos: -47.5,27.5
       parent: 2
       type: Transform
+- proto: LockerClown
+  entities:
+  - uid: 12865
+    components:
+    - pos: 20.5,12.5
+      parent: 2
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 12866
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
 - proto: LockerDetectiveFilled
   entities:
   - uid: 1163
@@ -60258,6 +60587,42 @@ entities:
     - pos: -37.5,29.5
       parent: 2
       type: Transform
+- proto: LockerMime
+  entities:
+  - uid: 12859
+    components:
+    - pos: 18.5,14.5
+      parent: 2
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 12860
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
 - proto: LockerParamedicFilled
   entities:
   - uid: 7747
@@ -60783,9 +61148,9 @@ entities:
     - pos: 37.5,8.5
       parent: 2
       type: Transform
-  - uid: 11024
+  - uid: 11013
     components:
-    - pos: 18.5,14.5
+    - pos: 11.5,12.5
       parent: 2
       type: Transform
   - uid: 11055
@@ -61288,6 +61653,43 @@ entities:
       type: Transform
     - joinedGrid: 2
       type: AtmosDevice
+- proto: Paper
+  entities:
+  - uid: 12862
+    components:
+    - pos: 17.562048,11.72828
+      parent: 2
+      type: Transform
+  - uid: 12863
+    components:
+    - pos: 17.28427,11.714391
+      parent: 2
+      type: Transform
+  - uid: 12864
+    components:
+    - pos: 20.277325,13.513002
+      parent: 2
+      type: Transform
+  - uid: 12869
+    components:
+    - pos: 19.381493,14.638002
+      parent: 2
+      type: Transform
+  - uid: 12870
+    components:
+    - pos: 19.839825,14.693558
+      parent: 2
+      type: Transform
+  - uid: 12871
+    components:
+    - pos: 19.860659,14.41578
+      parent: 2
+      type: Transform
+  - uid: 12872
+    components:
+    - pos: 19.485659,14.450502
+      parent: 2
+      type: Transform
 - proto: PaperBin10
   entities:
   - uid: 2235
@@ -61745,11 +62147,6 @@ entities:
       pos: -6.5,6.5
       parent: 2
       type: Transform
-  - uid: 3589
-    components:
-    - pos: -29.5,-8.5
-      parent: 2
-      type: Transform
   - uid: 8817
     components:
     - rot: -1.5707963267948966 rad
@@ -61764,6 +62161,12 @@ entities:
   - uid: 11229
     components:
     - pos: -33.5,7.5
+      parent: 2
+      type: Transform
+  - uid: 12850
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -29.5,-7.5
       parent: 2
       type: Transform
 - proto: PowerDrill
@@ -63814,6 +64217,12 @@ entities:
       pos: 20.5,8.5
       parent: 2
       type: Transform
+  - uid: 3584
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 18.5,12.5
+      parent: 2
+      type: Transform
   - uid: 4433
     components:
     - pos: 35.5,-24.5
@@ -64270,15 +64679,9 @@ entities:
     - pos: 9.5,11.5
       parent: 2
       type: Transform
-  - uid: 11015
+  - uid: 11023
     components:
-    - rot: 1.5707963267948966 rad
-      pos: 15.5,12.5
-      parent: 2
-      type: Transform
-  - uid: 11017
-    components:
-    - pos: 20.5,14.5
+    - pos: 19.5,14.5
       parent: 2
       type: Transform
   - uid: 11029
@@ -64521,6 +64924,12 @@ entities:
   - uid: 12773
     components:
     - pos: -9.5,-7.5
+      parent: 2
+      type: Transform
+  - uid: 12788
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 15.5,12.5
       parent: 2
       type: Transform
 - proto: Protolathe
@@ -66654,9 +67063,10 @@ entities:
       type: Item
 - proto: SheetPlasma
   entities:
-  - uid: 3590
+  - uid: 12851
     components:
-    - pos: -29.556845,-7.5545425
+    - rot: 3.141592653589793 rad
+      pos: -29.431866,-8.324578
       parent: 2
       type: Transform
 - proto: SheetPlasteel10
@@ -69968,16 +70378,6 @@ entities:
       pos: -26.5,-1.5
       parent: 2
       type: Transform
-  - uid: 3584
-    components:
-    - pos: -29.5,-7.5
-      parent: 2
-      type: Transform
-  - uid: 3585
-    components:
-    - pos: -29.5,-8.5
-      parent: 2
-      type: Transform
   - uid: 3649
     components:
     - pos: -22.5,0.5
@@ -70183,12 +70583,6 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: 0.5,6.5
-      parent: 2
-      type: Transform
-  - uid: 6775
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -22.5,-6.5
       parent: 2
       type: Transform
   - uid: 7034
@@ -70660,6 +71054,18 @@ entities:
   - uid: 12755
     components:
     - pos: -31.5,21.5
+      parent: 2
+      type: Transform
+  - uid: 12848
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -29.5,-8.5
+      parent: 2
+      type: Transform
+  - uid: 12849
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -29.5,-7.5
       parent: 2
       type: Transform
 - proto: TableCarpet
@@ -71204,22 +71610,10 @@ entities:
     - pos: -17.5,-8.5
       parent: 2
       type: Transform
-  - uid: 3605
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -38.5,-3.5
-      parent: 2
-      type: Transform
   - uid: 3702
     components:
     - rot: 3.141592653589793 rad
       pos: -38.5,-4.5
-      parent: 2
-      type: Transform
-  - uid: 3704
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -38.5,-2.5
       parent: 2
       type: Transform
   - uid: 3879
@@ -71367,6 +71761,12 @@ entities:
       pos: 16.5,-12.5
       parent: 2
       type: Transform
+  - uid: 11012
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -38.5,-3.5
+      parent: 2
+      type: Transform
   - uid: 11267
     components:
     - rot: 1.5707963267948966 rad
@@ -71394,9 +71794,38 @@ entities:
     - pos: 17.5,-3.5
       parent: 2
       type: Transform
+  - uid: 12782
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -38.5,-2.5
+      parent: 2
+      type: Transform
   - uid: 12817
     components:
     - pos: -15.5,-19.5
+      parent: 2
+      type: Transform
+  - uid: 12855
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 17.5,11.5
+      parent: 2
+      type: Transform
+  - uid: 12856
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 20.5,13.5
+      parent: 2
+      type: Transform
+  - uid: 12861
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 20.5,14.5
+      parent: 2
+      type: Transform
+  - uid: 12867
+    components:
+    - pos: 19.5,14.5
       parent: 2
       type: Transform
 - proto: TargetDarts
@@ -84993,14 +85422,6 @@ entities:
     - pos: 2.5,-9.5
       parent: 2
       type: Transform
-  - uid: 2634
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: 3.141592653589793 rad
-      pos: 17.5,10.5
-      parent: 2
-      type: Transform
   - uid: 2637
     components:
     - flags: PvsPriority
@@ -85009,28 +85430,12 @@ entities:
       pos: 17.5,15.5
       parent: 2
       type: Transform
-  - uid: 2648
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: 3.141592653589793 rad
-      pos: 18.5,10.5
-      parent: 2
-      type: Transform
   - uid: 2681
     components:
     - flags: PvsPriority
       type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 4.5,29.5
-      parent: 2
-      type: Transform
-  - uid: 2684
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: 3.141592653589793 rad
-      pos: 19.5,10.5
       parent: 2
       type: Transform
   - uid: 2705
@@ -85701,6 +86106,13 @@ entities:
       type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 14.5,5.5
+      parent: 2
+      type: Transform
+  - uid: 3380
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: 17.5,14.5
       parent: 2
       type: Transform
   - uid: 3381
@@ -87825,6 +88237,14 @@ entities:
       pos: -35.5,17.5
       parent: 2
       type: Transform
+  - uid: 6796
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: 16.5,11.5
+      parent: 2
+      type: Transform
   - uid: 6928
     components:
     - flags: PvsPriority
@@ -88623,32 +89043,11 @@ entities:
     - pos: 13.5,12.5
       parent: 2
       type: Transform
-  - uid: 10997
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - pos: 14.5,12.5
-      parent: 2
-      type: Transform
   - uid: 10998
     components:
     - flags: PvsPriority
       type: MetaData
     - pos: 17.5,13.5
-      parent: 2
-      type: Transform
-  - uid: 10999
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - pos: 18.5,13.5
-      parent: 2
-      type: Transform
-  - uid: 11000
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - pos: 19.5,13.5
       parent: 2
       type: Transform
   - uid: 11001
@@ -88867,6 +89266,22 @@ entities:
     - flags: PvsPriority
       type: MetaData
     - pos: -54.5,5.5
+      parent: 2
+      type: Transform
+  - uid: 12787
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: 17.5,10.5
+      parent: 2
+      type: Transform
+  - uid: 12854
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: 16.5,12.5
       parent: 2
       type: Transform
 - proto: WallSolidRust
@@ -89724,6 +90139,12 @@ entities:
       pos: -28.5,-3.5
       parent: 2
       type: Transform
+  - uid: 3585
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 18.5,10.5
+      parent: 2
+      type: Transform
   - uid: 3602
     components:
     - rot: -1.5707963267948966 rad
@@ -89933,6 +90354,11 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: -35.5,8.5
+      parent: 2
+      type: Transform
+  - uid: 12783
+    components:
+    - pos: 19.5,10.5
       parent: 2
       type: Transform
 - proto: WindowDirectional


### PR DESCRIPTION
## About the PR
I don't know why the diff is so big, here is the changelog:

AME Core is now in line with upstream's mapping standards.
More Generators have been added around the map for roundstart power.
The SWAT crate in security has been replaced with one that doesn't start with shotguns.
Disposals now will drop its contents correctly onto the belt instead of into the far wall.
Department Head Cosmetic Dressers have been mapped.
The outer armory windoor is now security access instead of armory access.
The inner bridge airlock is now glass.
Engineering has an engidrobe (Finally).
New Warp Points/Map Beacons have been added, I tried to convert over as many as I could, but I might have missed some.
A clown/mime room has been added above theater, its not a large space, but they can now fill out important documents.

## Why / Balance
Map Maintainer Moment.

Changelog:
Ferrous has received another pass over, all feedback from 1/12/23 and before has been adressed.
