### PR TITLE
Ferrous Updates (V1.04 I think)

### DIFF
--- a/Resources/Maps/_CD/ferrous.yml
+++ b/Resources/Maps/_CD/ferrous.yml
@@ -7112,7 +7112,7 @@ entities:
             0: 3276
           0,-10:
             0: 4369
-            5: 25088
+            5: 60960
           0,-9:
             0: 29457
             5: 36078
@@ -7408,7 +7408,9 @@ entities:
           -13,-6:
             0: 13056
           1,-9:
-            5: 12288
+            5: 12561
+          1,-10:
+            5: 4352
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -10869,6 +10871,72 @@ entities:
       pos: 35.5,-16.5
       parent: 2
       type: Transform
+- proto: AlwaysPoweredWallLight
+  entities:
+  - uid: 463
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-41.5
+      parent: 2
+      type: Transform
+  - uid: 472
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-38.5
+      parent: 2
+      type: Transform
+  - uid: 721
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: -9.5,-41.5
+      parent: 2
+      type: Transform
+  - uid: 4947
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-41.5
+      parent: 2
+      type: Transform
+  - uid: 11690
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,-41.5
+      parent: 2
+      type: Transform
+  - uid: 11750
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: -13.5,-41.5
+      parent: 2
+      type: Transform
+  - uid: 11766
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: -12.5,-38.5
+      parent: 2
+      type: Transform
+  - uid: 11959
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: -11.5,-41.5
+      parent: 2
+      type: Transform
 - proto: AmeController
   entities:
   - uid: 3814
@@ -11646,6 +11714,26 @@ entities:
   - uid: 262
     components:
     - pos: 21.5,-17.5
+      parent: 2
+      type: Transform
+- proto: AtmosFixPlasmaMarker
+  entities:
+  - uid: 12910
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -13.5,-42.5
+      parent: 2
+      type: Transform
+  - uid: 12911
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -13.5,-41.5
+      parent: 2
+      type: Transform
+  - uid: 12912
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -13.5,-40.5
       parent: 2
       type: Transform
 - proto: Autolathe
@@ -62284,27 +62372,11 @@ entities:
     - type: InsideEntityStorage
 - proto: Poweredlight
   entities:
-  - uid: 463
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: -7.5,-41.5
-      parent: 2
-      type: Transform
   - uid: 471
     components:
     - flags: PvsPriority
       type: MetaData
     - pos: -8.5,-29.5
-      parent: 2
-      type: Transform
-  - uid: 472
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: -3.5,-41.5
       parent: 2
       type: Transform
   - uid: 473
@@ -62336,14 +62408,6 @@ entities:
       type: MetaData
     - rot: -1.5707963267948966 rad
       pos: 46.5,0.5
-      parent: 2
-      type: Transform
-  - uid: 721
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: -11.5,-41.5
       parent: 2
       type: Transform
   - uid: 771
@@ -62465,14 +62529,6 @@ entities:
       type: MetaData
     - rot: 1.5707963267948966 rad
       pos: 29.5,-0.5
-      parent: 2
-      type: Transform
-  - uid: 4947
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: -9.5,-41.5
       parent: 2
       type: Transform
   - uid: 5079
@@ -64092,43 +64148,11 @@ entities:
     - pos: -15.5,-31.5
       parent: 2
       type: Transform
-  - uid: 11690
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: -5.5,-41.5
-      parent: 2
-      type: Transform
-  - uid: 11750
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: 3.141592653589793 rad
-      pos: -12.5,-38.5
-      parent: 2
-      type: Transform
   - uid: 11759
     components:
     - flags: PvsPriority
       type: MetaData
     - pos: -0.5,-29.5
-      parent: 2
-      type: Transform
-  - uid: 11766
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: 3.141592653589793 rad
-      pos: -6.5,-38.5
-      parent: 2
-      type: Transform
-  - uid: 11959
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: -13.5,-41.5
       parent: 2
       type: Transform
   - uid: 12151

--- a/Resources/Maps/_CD/ferrous.yml
+++ b/Resources/Maps/_CD/ferrous.yml
@@ -119,7 +119,7 @@ entities:
           version: 6
         -1,-2:
           ind: -1,-2
-          tiles: eQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAACgAAAAAAeQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAACgAAAAAABwAAAAAAWQAAAAABeQAAAAAAWQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAADWQAAAAABWQAAAAAAWQAAAAABeQAAAAAAaAAAAAAAeQAAAAAAagAAAAAAeQAAAAAABwAAAAAAWQAAAAADeQAAAAAAWQAAAAACWQAAAAABWQAAAAABWQAAAAACWQAAAAAAWQAAAAABWQAAAAADWQAAAAADWQAAAAAAeQAAAAAAagAAAAACagAAAAACeQAAAAAABwAAAAAAWQAAAAABeQAAAAAAWQAAAAABWQAAAAADWQAAAAADWQAAAAACWQAAAAAAWQAAAAABWQAAAAADWQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAADeQAAAAAAWQAAAAACWQAAAAADeQAAAAAAeQAAAAAAagAAAAACaQAAAAAAaQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAABWQAAAAADWQAAAAACWQAAAAACWQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAAAWQAAAAACWQAAAAACWQAAAAADWQAAAAAAWQAAAAACeQAAAAAAWQAAAAADWQAAAAABWQAAAAADeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACeQAAAAAAWQAAAAABWQAAAAACWQAAAAABWQAAAAABWQAAAAACeQAAAAAAWQAAAAAAWQAAAAADWQAAAAAAeQAAAAAAaQAAAAAAagAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAABeQAAAAAAeQAAAAAAWQAAAAABWQAAAAABeQAAAAAAeQAAAAAAagAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAEwAAAAADHQAAAAADeQAAAAAAWQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAADWQAAAAABWQAAAAACWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaQAAAAAAEwAAAAAFdgAAAAAAeQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAADeQAAAAAAWQAAAAACWQAAAAADWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAACHQAAAAAAeQAAAAAAWQAAAAABWQAAAAACWQAAAAACWQAAAAAAWQAAAAADeQAAAAAAWQAAAAADWQAAAAABeQAAAAAAagAAAAACeQAAAAAAeQAAAAAAaQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAACWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAagAAAAACeQAAAAAAeQAAAAAAeQAAAAAA
+          tiles: eQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAACgAAAAAABwAAAAAAWQAAAAABeQAAAAAAWQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAADWQAAAAABWQAAAAAAWQAAAAABeQAAAAAAaAAAAAAAeQAAAAAAagAAAAAAeQAAAAAABwAAAAAAWQAAAAADeQAAAAAAWQAAAAACWQAAAAABWQAAAAABWQAAAAACWQAAAAAAWQAAAAABWQAAAAADWQAAAAADWQAAAAAAeQAAAAAAagAAAAACagAAAAACeQAAAAAABwAAAAAAWQAAAAABeQAAAAAAWQAAAAABWQAAAAADWQAAAAADWQAAAAACWQAAAAAAWQAAAAABWQAAAAADWQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAADeQAAAAAAWQAAAAACWQAAAAADeQAAAAAAeQAAAAAAagAAAAACaQAAAAAAaQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAABWQAAAAADWQAAAAACWQAAAAACWQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAAAWQAAAAACWQAAAAACWQAAAAADWQAAAAAAWQAAAAACeQAAAAAAWQAAAAADWQAAAAABWQAAAAADeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACeQAAAAAAWQAAAAABWQAAAAACWQAAAAABWQAAAAABWQAAAAACeQAAAAAAWQAAAAAAWQAAAAADWQAAAAAAeQAAAAAAaQAAAAAAagAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAABeQAAAAAAeQAAAAAAWQAAAAABWQAAAAABeQAAAAAAeQAAAAAAagAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAEwAAAAADHQAAAAADeQAAAAAAWQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAADWQAAAAABWQAAAAACWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaQAAAAAAEwAAAAAFdgAAAAAAeQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAADeQAAAAAAWQAAAAACWQAAAAADWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAACHQAAAAAAeQAAAAAAWQAAAAABWQAAAAACWQAAAAACWQAAAAAAWQAAAAADeQAAAAAAWQAAAAADWQAAAAABeQAAAAAAagAAAAACeQAAAAAAeQAAAAAAaQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAACWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAagAAAAACeQAAAAAAeQAAAAAAeQAAAAAA
           version: 6
         0,-2:
           ind: 0,-2
@@ -187,7 +187,7 @@ entities:
           version: 6
         -1,-3:
           ind: -1,-3
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAHBwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAEBwAAAAAABwAAAAAEAAAAAAAAAAAAAAAABwAAAAAEBwAAAAAABwAAAAADBwAAAAAFBwAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAHBwAAAAAABwAAAAAABwAAAAAFBwAAAAAABwAAAAAKBwAAAAAABwAAAAAABwAAAAAABwAAAAAAeAAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAFBwAAAAAABwAAAAAABwAAAAAJBwAAAAAABwAAAAAIBwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAegAAAAAABwAAAAAABwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAegAAAAAABwAAAAAABwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAegAAAAAAAAAAAAAABwAAAAAEeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAABwAAAAAABwAAAAAABwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAABBwAAAAAABwAAAAAABwAAAAAGBwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAEBwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAACgAAAAAABwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAACgAAAAAABwAAAAAHeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAACgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAHBwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAEBwAAAAAABwAAAAAEAAAAAAAAAAAAAAAABwAAAAAEBwAAAAAABwAAAAADBwAAAAAFBwAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAHBwAAAAAABwAAAAAABwAAAAAFBwAAAAAABwAAAAAKBwAAAAAABwAAAAAABwAAAAAABwAAAAAAeAAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAFBwAAAAAABwAAAAAABwAAAAAJBwAAAAAABwAAAAAIBwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAegAAAAAABwAAAAAABwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAegAAAAAABwAAAAAABwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAegAAAAAAAAAAAAAABwAAAAAEeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAABwAAAAAABwAAAAAABwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAABBwAAAAAABwAAAAAABwAAAAAGBwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAEBwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAACgAAAAAABwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAACgAAAAAABwAAAAAHeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAA
           version: 6
         -2,-3:
           ind: -2,-3
@@ -227,7 +227,7 @@ entities:
           version: 6
         0,-3:
           ind: 0,-3
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAABwAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAABwAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAJBwAAAAAABwAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAABwAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAAeQAAAAAAeQAAAAAAeQAAAAAABwAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAJBwAAAAAABwAAAAAA
           version: 6
         -5,-1:
           ind: -5,-1
@@ -10310,16 +10310,6 @@ entities:
       pos: 16.5,-15.5
       parent: 2
       type: Transform
-- proto: AirlockServiceLocked
-  entities:
-  - uid: 12789
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: 1.5707963267948966 rad
-      pos: 20.5,10.5
-      parent: 2
-      type: Transform
 - proto: AirlockShuttle
   entities:
   - uid: 12215
@@ -10334,6 +10324,15 @@ entities:
     - flags: PvsPriority
       type: MetaData
     - pos: -53.5,-21.5
+      parent: 2
+      type: Transform
+- proto: AirlockTheatreLocked
+  entities:
+  - uid: 720
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: 20.5,10.5
       parent: 2
       type: Transform
 - proto: AirlockVirologyGlassLocked
@@ -15672,6 +15671,16 @@ entities:
     - pos: -28.5,-29.5
       parent: 2
       type: Transform
+  - uid: 5559
+    components:
+    - pos: 1.5,-29.5
+      parent: 2
+      type: Transform
+  - uid: 5784
+    components:
+    - pos: 0.5,-29.5
+      parent: 2
+      type: Transform
   - uid: 5786
     components:
     - pos: -63.5,12.5
@@ -19387,6 +19396,11 @@ entities:
     - pos: 44.5,-14.5
       parent: 2
       type: Transform
+  - uid: 11760
+    components:
+    - pos: 2.5,-30.5
+      parent: 2
+      type: Transform
   - uid: 11960
     components:
     - pos: 44.5,-15.5
@@ -21877,6 +21891,21 @@ entities:
     - pos: -68.5,10.5
       parent: 2
       type: Transform
+  - uid: 12719
+    components:
+    - pos: 1.5,-30.5
+      parent: 2
+      type: Transform
+  - uid: 12721
+    components:
+    - pos: -1.5,-29.5
+      parent: 2
+      type: Transform
+  - uid: 12724
+    components:
+    - pos: -0.5,-29.5
+      parent: 2
+      type: Transform
   - uid: 12739
     components:
     - pos: 18.5,-4.5
@@ -21932,34 +21961,49 @@ entities:
     - pos: -2.5,-29.5
       parent: 2
       type: Transform
-  - uid: 12800
+  - uid: 12877
     components:
-    - pos: -2.5,-30.5
+    - pos: 2.5,-31.5
       parent: 2
       type: Transform
-  - uid: 12802
+  - uid: 12878
     components:
-    - pos: -1.5,-30.5
+    - pos: 2.5,-32.5
       parent: 2
       type: Transform
-  - uid: 12803
+  - uid: 12879
     components:
-    - pos: -0.5,-30.5
+    - pos: 2.5,-33.5
       parent: 2
       type: Transform
-  - uid: 12804
+  - uid: 12880
     components:
-    - pos: 0.5,-30.5
+    - pos: 2.5,-34.5
       parent: 2
       type: Transform
-  - uid: 12805
+  - uid: 12881
     components:
-    - pos: 0.5,-31.5
+    - pos: 1.5,-34.5
       parent: 2
       type: Transform
-  - uid: 12806
+  - uid: 12882
     components:
-    - pos: 0.5,-32.5
+    - pos: 1.5,-35.5
+      parent: 2
+      type: Transform
+  - uid: 12883
+    components:
+    - pos: 0.5,-35.5
+      parent: 2
+      type: Transform
+  - uid: 12884
+    components:
+    - pos: -0.5,-35.5
+      parent: 2
+      type: Transform
+  - uid: 12885
+    components:
+    - pos: -1.5,-35.5
       parent: 2
       type: Transform
 - proto: CableHV
@@ -22682,6 +22726,11 @@ entities:
   - uid: 4515
     components:
     - pos: -20.5,-28.5
+      parent: 2
+      type: Transform
+  - uid: 4549
+    components:
+    - pos: -16.5,-35.5
       parent: 2
       type: Transform
   - uid: 4552
@@ -24559,6 +24608,17 @@ entities:
     - pos: -3.5,-32.5
       parent: 2
       type: Transform
+- proto: CableHVStack1
+  entities:
+  - uid: 12888
+    components:
+    - pos: 6.5590897,34.75779
+      parent: 2
+      type: Transform
+    - count: 22
+      type: Stack
+    - size: 22
+      type: Item
 - proto: CableMV
   entities:
   - uid: 11
@@ -31131,6 +31191,12 @@ entities:
       pos: -28.5,-24.5
       parent: 2
       type: Transform
+  - uid: 12800
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -15.5,43.5
+      parent: 2
+      type: Transform
   - uid: 12810
     components:
     - pos: -8.5,14.5
@@ -31469,6 +31535,12 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: 44.402092,-9.48119
+      parent: 2
+      type: Transform
+  - uid: 11757
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -14.508305,42.609886
       parent: 2
       type: Transform
 - proto: ChurchOrganInstrument
@@ -40545,6 +40617,14 @@ entities:
       type: Transform
     - joinedGrid: 2
       type: AtmosDevice
+  - uid: 4135
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -13.5,-40.5
+      parent: 2
+      type: Transform
+    - joinedGrid: 2
+      type: AtmosDevice
   - uid: 4512
     components:
     - rot: 3.141592653589793 rad
@@ -40577,18 +40657,18 @@ entities:
       type: Transform
     - joinedGrid: 2
       type: AtmosDevice
-  - uid: 4519
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -13.5,-40.5
-      parent: 2
-      type: Transform
-    - joinedGrid: 2
-      type: AtmosDevice
   - uid: 4520
     components:
     - rot: 3.141592653589793 rad
       pos: -3.5,-40.5
+      parent: 2
+      type: Transform
+    - joinedGrid: 2
+      type: AtmosDevice
+  - uid: 4530
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -17.5,-40.5
       parent: 2
       type: Transform
     - joinedGrid: 2
@@ -56566,14 +56646,6 @@ entities:
       type: AtmosDevice
     - color: '#0055CCFF'
       type: AtmosPipeColor
-  - uid: 10334
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -17.5,-40.5
-      parent: 2
-      type: Transform
-    - joinedGrid: 2
-      type: AtmosDevice
   - uid: 10903
     components:
     - rot: 3.141592653589793 rad
@@ -59433,22 +59505,19 @@ entities:
       pos: -59.5,-9.5
       parent: 2
       type: Transform
-  - uid: 11757
+  - uid: 11749
     components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,-31.5
+    - pos: 3.5,-33.5
       parent: 2
       type: Transform
-  - uid: 11759
+  - uid: 11752
     components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,-32.5
+    - pos: 3.5,-32.5
       parent: 2
       type: Transform
-  - uid: 11765
+  - uid: 11753
     components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,-33.5
+    - pos: 3.5,-31.5
       parent: 2
       type: Transform
   - uid: 11852
@@ -61200,6 +61269,12 @@ entities:
     - pos: 26.5,-5.5
       parent: 2
       type: Transform
+  - uid: 12889
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 55.5,25.5
+      parent: 2
+      type: Transform
 - proto: MaintenanceWeaponSpawner
   entities:
   - uid: 1546
@@ -61245,6 +61320,18 @@ entities:
   - uid: 11553
     components:
     - pos: 23.5,-2.5
+      parent: 2
+      type: Transform
+  - uid: 12805
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 53.5,27.5
+      parent: 2
+      type: Transform
+  - uid: 12806
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 52.5,30.5
       parent: 2
       type: Transform
 - proto: MaterialCloth
@@ -61550,9 +61637,9 @@ entities:
       type: AtmosDevice
 - proto: NitrousOxideCanister
   entities:
-  - uid: 4553
+  - uid: 11751
     components:
-    - pos: -11.5,-29.5
+    - pos: -10.5,-29.5
       parent: 2
       type: Transform
     - joinedGrid: 2
@@ -61900,9 +61987,27 @@ entities:
       type: Transform
 - proto: PlasmaCanister
   entities:
+  - uid: 4519
+    components:
+    - pos: -13.5,-41.5
+      parent: 2
+      type: Transform
+    - releaseValve: True
+      type: GasCanister
+    - locked: False
+      type: Lock
+    - joinedGrid: 2
+      type: AtmosDevice
   - uid: 5553
     components:
     - pos: -12.5,-29.5
+      parent: 2
+      type: Transform
+    - joinedGrid: 2
+      type: AtmosDevice
+  - uid: 12802
+    components:
+    - pos: -12.5,-30.5
       parent: 2
       type: Transform
     - joinedGrid: 2
@@ -62346,6 +62451,14 @@ entities:
     - pos: -30.5,8.5
       parent: 2
       type: Transform
+  - uid: 4535
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-35.5
+      parent: 2
+      type: Transform
   - uid: 4727
     components:
     - flags: PvsPriority
@@ -62381,14 +62494,6 @@ entities:
     - flags: PvsPriority
       type: MetaData
     - pos: -58.5,0.5
-      parent: 2
-      type: Transform
-  - uid: 5785
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: 3.141592653589793 rad
-      pos: -0.5,-34.5
       parent: 2
       type: Transform
   - uid: 6274
@@ -62930,6 +63035,14 @@ entities:
       type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -21.5,-32.5
+      parent: 2
+      type: Transform
+  - uid: 10334
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-34.5
       parent: 2
       type: Transform
   - uid: 10352
@@ -63477,13 +63590,6 @@ entities:
     - pos: 28.5,8.5
       parent: 2
       type: Transform
-  - uid: 10844
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - pos: -0.5,-30.5
-      parent: 2
-      type: Transform
   - uid: 10880
     components:
     - flags: PvsPriority
@@ -64002,6 +64108,13 @@ entities:
       pos: -12.5,-38.5
       parent: 2
       type: Transform
+  - uid: 11759
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - pos: -0.5,-29.5
+      parent: 2
+      type: Transform
   - uid: 11766
     components:
     - flags: PvsPriority
@@ -64039,6 +64152,14 @@ entities:
       type: MetaData
     - rot: 1.5707963267948966 rad
       pos: -54.5,-19.5
+      parent: 2
+      type: Transform
+  - uid: 12725
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-30.5
       parent: 2
       type: Transform
   - uid: 12793
@@ -66925,22 +67046,10 @@ entities:
       pos: -58.5,-4.5
       parent: 2
       type: Transform
-  - uid: 11741
+  - uid: 11765
     components:
     - rot: 3.141592653589793 rad
-      pos: 2.5,-32.5
-      parent: 2
-      type: Transform
-  - uid: 11742
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,-31.5
-      parent: 2
-      type: Transform
-  - uid: 11762
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 2.5,-33.5
+      pos: 3.5,-31.5
       parent: 2
       type: Transform
   - uid: 12211
@@ -66952,6 +67061,18 @@ entities:
   - uid: 12213
     components:
     - pos: -55.5,-19.5
+      parent: 2
+      type: Transform
+  - uid: 12717
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-32.5
+      parent: 2
+      type: Transform
+  - uid: 12718
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-33.5
       parent: 2
       type: Transform
 - proto: ReinforcedWindowDiagonal
@@ -67104,10 +67225,10 @@ entities:
       type: Transform
 - proto: SheetSteel
   entities:
-  - uid: 4135
+  - uid: 2749
     components:
     - rot: -1.5707963267948966 rad
-      pos: 1.5284107,-32.721077
+      pos: 2.526245,-32.85125
       parent: 2
       type: Transform
   - uid: 7521
@@ -67115,15 +67236,15 @@ entities:
     - pos: -47.43872,-6.4903016
       parent: 2
       type: Transform
+  - uid: 10844
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.4663625,-32.350964
+      parent: 2
+      type: Transform
   - uid: 11332
     components:
     - pos: -11.361614,-25.474611
-      parent: 2
-      type: Transform
-  - uid: 12738
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 1.5179935,-32.418995
       parent: 2
       type: Transform
 - proto: SheetSteel10
@@ -67138,6 +67259,12 @@ entities:
     - pos: -24.145395,0.5584049
       parent: 2
       type: Transform
+  - uid: 5785
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.518446,-33.225964
+      parent: 2
+      type: Transform
   - uid: 11287
     components:
     - pos: -37.26236,32.5713
@@ -67146,12 +67273,6 @@ entities:
   - uid: 11331
     components:
     - pos: -11.611614,-25.927736
-      parent: 2
-      type: Transform
-  - uid: 12737
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 1.5339191,-33.24858
       parent: 2
       type: Transform
 - proto: ShipBattlemap
@@ -68898,13 +69019,6 @@ entities:
       type: Transform
     - joinedGrid: 2
       type: AtmosDevice
-  - uid: 5559
-    components:
-    - pos: -10.5,-29.5
-      parent: 2
-      type: Transform
-    - joinedGrid: 2
-      type: AtmosDevice
   - uid: 5560
     components:
     - pos: -9.5,-30.5
@@ -70541,16 +70655,6 @@ entities:
       pos: -32.5,9.5
       parent: 2
       type: Transform
-  - uid: 4530
-    components:
-    - pos: 1.5,-32.5
-      parent: 2
-      type: Transform
-  - uid: 5784
-    components:
-    - pos: 1.5,-33.5
-      parent: 2
-      type: Transform
   - uid: 5895
     components:
     - rot: 3.141592653589793 rad
@@ -71022,6 +71126,16 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: 45.5,3.5
+      parent: 2
+      type: Transform
+  - uid: 11741
+    components:
+    - pos: 2.5,-32.5
+      parent: 2
+      type: Transform
+  - uid: 11742
+    components:
+    - pos: 2.5,-33.5
       parent: 2
       type: Transform
   - uid: 12118
@@ -72176,7 +72290,7 @@ entities:
       type: Transform
   - uid: 8979
     components:
-    - pos: 6.505407,34.634743
+    - pos: 6.5509357,34.415333
       parent: 2
       type: Transform
   - uid: 12156
@@ -72225,11 +72339,6 @@ entities:
   - uid: 1601
     components:
     - pos: -14.5,43.5
-      parent: 2
-      type: Transform
-  - uid: 1603
-    components:
-    - pos: -14.5,42.5
       parent: 2
       type: Transform
   - uid: 3395
@@ -72759,9 +72868,9 @@ entities:
       type: Transform
 - proto: VendingMachineTankDispenserEngineering
   entities:
-  - uid: 12735
+  - uid: 4553
     components:
-    - pos: 1.5,-31.5
+    - pos: 2.5,-31.5
       parent: 2
       type: Transform
 - proto: VendingMachineTankDispenserEVA
@@ -77924,13 +78033,6 @@ entities:
     - pos: -17.5,-31.5
       parent: 2
       type: Transform
-  - uid: 4535
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - pos: -1.5,-35.5
-      parent: 2
-      type: Transform
   - uid: 4540
     components:
     - flags: PvsPriority
@@ -77943,13 +78045,6 @@ entities:
     - flags: PvsPriority
       type: MetaData
     - pos: -1.5,-37.5
-      parent: 2
-      type: Transform
-  - uid: 4549
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - pos: -1.5,-29.5
       parent: 2
       type: Transform
   - uid: 4550
@@ -79491,44 +79586,20 @@ entities:
       pos: -70.5,3.5
       parent: 2
       type: Transform
-  - uid: 11749
+  - uid: 11762
     components:
     - flags: PvsPriority
       type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: 2.5,-30.5
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-35.5
       parent: 2
       type: Transform
-  - uid: 11751
+  - uid: 11767
     components:
     - flags: PvsPriority
       type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,-29.5
-      parent: 2
-      type: Transform
-  - uid: 11752
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,-29.5
-      parent: 2
-      type: Transform
-  - uid: 11753
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,-30.5
-      parent: 2
-      type: Transform
-  - uid: 11760
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,-29.5
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-34.5
       parent: 2
       type: Transform
   - uid: 11854
@@ -79544,6 +79615,14 @@ entities:
     - flags: PvsPriority
       type: MetaData
     - pos: -59.5,-11.5
+      parent: 2
+      type: Transform
+  - uid: 12057
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-35.5
       parent: 2
       type: Transform
   - uid: 12158
@@ -79583,44 +79662,92 @@ entities:
       pos: -52.5,-21.5
       parent: 2
       type: Transform
-  - uid: 12717
+  - uid: 12726
     components:
     - flags: PvsPriority
       type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,-35.5
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-29.5
       parent: 2
       type: Transform
-  - uid: 12718
+  - uid: 12727
     components:
     - flags: PvsPriority
       type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: 0.5,-35.5
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-30.5
       parent: 2
       type: Transform
-  - uid: 12719
+  - uid: 12728
     components:
     - flags: PvsPriority
       type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,-35.5
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-28.5
       parent: 2
       type: Transform
-  - uid: 12720
+  - uid: 12735
     components:
     - flags: PvsPriority
       type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: 1.5,-34.5
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-29.5
       parent: 2
       type: Transform
-  - uid: 12721
+  - uid: 12737
     components:
     - flags: PvsPriority
       type: MetaData
-    - rot: -1.5707963267948966 rad
-      pos: 2.5,-34.5
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-28.5
+      parent: 2
+      type: Transform
+  - uid: 12738
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-28.5
+      parent: 2
+      type: Transform
+  - uid: 12789
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-28.5
+      parent: 2
+      type: Transform
+  - uid: 12873
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-36.5
+      parent: 2
+      type: Transform
+  - uid: 12874
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-36.5
+      parent: 2
+      type: Transform
+  - uid: 12875
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-36.5
+      parent: 2
+      type: Transform
+  - uid: 12876
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-36.5
       parent: 2
       type: Transform
 - proto: WallRock
@@ -79640,11 +79767,12 @@ entities:
     - pos: 3.5,35.5
       parent: 2
       type: Transform
-  - uid: 720
+  - uid: 1603
     components:
     - flags: PvsPriority
       type: MetaData
-    - pos: 3.5,-29.5
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-30.5
       parent: 2
       type: Transform
   - uid: 2472
@@ -79673,6 +79801,30 @@ entities:
     - flags: PvsPriority
       type: MetaData
     - pos: 36.5,-27.5
+      parent: 2
+      type: Transform
+  - uid: 2746
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-36.5
+      parent: 2
+      type: Transform
+  - uid: 2747
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-36.5
+      parent: 2
+      type: Transform
+  - uid: 2748
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-35.5
       parent: 2
       type: Transform
   - uid: 2769
@@ -81567,13 +81719,6 @@ entities:
     - pos: 3.5,-28.5
       parent: 2
       type: Transform
-  - uid: 11767
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - pos: 3.5,-30.5
-      parent: 2
-      type: Transform
   - uid: 11773
     components:
     - flags: PvsPriority
@@ -82570,6 +82715,14 @@ entities:
     - pos: -40.5,-24.5
       parent: 2
       type: Transform
+  - uid: 12720
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-37.5
+      parent: 2
+      type: Transform
   - uid: 12722
     components:
     - flags: PvsPriority
@@ -82584,25 +82737,188 @@ entities:
     - pos: 3.5,-27.5
       parent: 2
       type: Transform
-  - uid: 12724
+  - uid: 12852
     components:
     - flags: PvsPriority
       type: MetaData
-    - pos: 2.5,-28.5
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-34.5
       parent: 2
       type: Transform
-  - uid: 12725
+  - uid: 12886
     components:
     - flags: PvsPriority
       type: MetaData
-    - pos: 2.5,-29.5
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-37.5
       parent: 2
       type: Transform
-  - uid: 12726
+  - uid: 12887
     components:
     - flags: PvsPriority
       type: MetaData
-    - pos: 1.5,-28.5
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-37.5
+      parent: 2
+      type: Transform
+  - uid: 12890
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -11.5,47.5
+      parent: 2
+      type: Transform
+  - uid: 12891
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -11.5,48.5
+      parent: 2
+      type: Transform
+  - uid: 12892
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -10.5,48.5
+      parent: 2
+      type: Transform
+  - uid: 12893
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -10.5,47.5
+      parent: 2
+      type: Transform
+  - uid: 12894
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,47.5
+      parent: 2
+      type: Transform
+  - uid: 12895
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,48.5
+      parent: 2
+      type: Transform
+  - uid: 12896
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,47.5
+      parent: 2
+      type: Transform
+  - uid: 12897
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,46.5
+      parent: 2
+      type: Transform
+  - uid: 12898
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,46.5
+      parent: 2
+      type: Transform
+  - uid: 12899
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,47.5
+      parent: 2
+      type: Transform
+  - uid: 12900
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,46.5
+      parent: 2
+      type: Transform
+  - uid: 12901
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,46.5
+      parent: 2
+      type: Transform
+  - uid: 12902
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,45.5
+      parent: 2
+      type: Transform
+  - uid: 12903
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,46.5
+      parent: 2
+      type: Transform
+  - uid: 12904
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,44.5
+      parent: 2
+      type: Transform
+  - uid: 12905
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,47.5
+      parent: 2
+      type: Transform
+  - uid: 12906
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,48.5
+      parent: 2
+      type: Transform
+  - uid: 12907
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,48.5
+      parent: 2
+      type: Transform
+  - uid: 12908
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -9.5,49.5
+      parent: 2
+      type: Transform
+  - uid: 12909
+    components:
+    - flags: PvsPriority
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -10.5,49.5
       parent: 2
       type: Transform
 - proto: WallRockArtifactFragment
@@ -82969,20 +83285,6 @@ entities:
       type: Transform
 - proto: WallRockUranium
   entities:
-  - uid: 12727
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - pos: 0.5,-28.5
-      parent: 2
-      type: Transform
-  - uid: 12728
-    components:
-    - flags: PvsPriority
-      type: MetaData
-    - pos: -0.5,-28.5
-      parent: 2
-      type: Transform
   - uid: 12729
     components:
     - flags: PvsPriority
@@ -89465,15 +89767,6 @@ entities:
     - pos: -1.5,7.5
       parent: 2
       type: Transform
-- proto: WarpPoint
-  entities:
-  - uid: 12057
-    components:
-    - pos: 53.5,29.5
-      parent: 2
-      type: Transform
-    - location: Abandonded AI Sat
-      type: WarpPoint
 - proto: WarpPointBombing
   entities:
   - uid: 12038
@@ -89595,7 +89888,7 @@ entities:
   entities:
   - uid: 5556
     components:
-    - pos: -12.5,-30.5
+    - pos: -11.5,-29.5
       parent: 2
       type: Transform
     - joinedGrid: 2
@@ -90505,28 +90798,6 @@ entities:
       pos: 24.5,23.5
       parent: 2
       type: Transform
-  - uid: 2746
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 20.5,32.5
-      parent: 2
-      type: Transform
-  - uid: 2747
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 22.5,32.5
-      parent: 2
-      type: Transform
-  - uid: 2748
-    components:
-    - pos: 17.5,31.5
-      parent: 2
-      type: Transform
-  - uid: 2749
-    components:
-    - pos: 25.5,31.5
-      parent: 2
-      type: Transform
   - uid: 10399
     components:
     - rot: 1.5707963267948966 rad
@@ -90566,6 +90837,18 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: 56.5,29.5
+      parent: 2
+      type: Transform
+  - uid: 12803
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 25.5,30.5
+      parent: 2
+      type: Transform
+  - uid: 12804
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 17.5,30.5
       parent: 2
       type: Transform
 - proto: WoodDoor


### PR DESCRIPTION
## About the PR
Clown/Mime room is now theater access.
Atmos has been given another plasma tank, bringing their count to two.
The burn chamber for atmos is now both passive vents.
North Solars has been given some HV Cables to start with.
The TEG area has been expanded to allow for more breathability.
Perma now has some more games to play to pass the time if two prisoners are being held.

## Why / Balance
Most of these changes make atmos's life easier. Its no fun having 30 mins of the round without power. The alternative is we give more AME fuel/parts, which I'd rather not do. The TEG is significantly easier to set up now.

**Very Optional Changelog**

tweak: Ferrous has received yet another pass over, its version is now 1.04.