### PR TITLE
Box Prisoner Role + Map Prototype Touch Ups

### DIFF
--- a/Resources/Prototypes/Maps/aspid.yml
+++ b/Resources/Prototypes/Maps/aspid.yml
@@ -33,26 +33,26 @@
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 2, 2 ]
-            SeniorEngineer: [ 1, 1 ]
+            SeniorEngineer: [ 1, 1 ] #CD Role
             StationEngineer: [ 2, 3 ]
             TechnicalAssistant: [ 4, 4 ]
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
-            SeniorPhysician: [ 1, 1 ]
+            SeniorPhysician: [ 1, 1 ] #CD Role
             Paramedic: [ 1, 1 ]
             Chemist: [ 1, 2 ]
             MedicalDoctor: [ 3, 3 ]
             MedicalIntern: [ 4, 4 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            SeniorResearcher: [ 1, 1 ]
+            SeniorResearcher: [ 1, 1 ] #CD Role
             Scientist: [ 3, 4 ]
             ResearchAssistant: [ 4, 4 ]
             Borg: [ 2, 2 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SeniorOfficer: [ 1, 1 ]
+            SeniorOfficer: [ 1, 1 ] #CD Role
             Detective: [ 1, 1 ]
             SecurityOfficer: [ 3, 4 ]
             SecurityCadet: [ 4, 4 ]
@@ -66,5 +66,4 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             #misc
-            Prisoner: [ 1, 1 ]
-            
+            Prisoner: [ 1, 1 ] #CD Role

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -31,27 +31,27 @@
             ServiceWorker: [ 2, 2 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
-            SeniorEngineer: [ 1, 1 ]
+            SeniorEngineer: [ 1, 1 ] #CD Role
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 3, 3 ]
             TechnicalAssistant: [ 4, 4 ]
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
-            SeniorPhysician: [ 1, 1 ]
+            SeniorPhysician: [ 1, 1 ] #CD Role
             Chemist: [ 2, 3 ]
             MedicalDoctor: [ 3, 3 ]
             Paramedic: [ 1, 1 ]
             MedicalIntern: [ 4, 4 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            SeniorResearcher: [ 1, 1 ]        
+            SeniorResearcher: [ 1, 1 ] #CD Role       
             Scientist: [ 4, 4 ]
             ResearchAssistant: [ 4, 4 ] 
             Borg: [ 2, 2 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SeniorOfficer: [ 1, 1 ]
+            SeniorOfficer: [ 1, 1 ] #CD Role
             SecurityOfficer: [ 3, 3 ]
             Detective: [ 1, 1 ]
             SecurityCadet: [ 4, 4 ]
@@ -66,5 +66,5 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             Reporter: [ 2, 2 ]
-            #wildcard
-            Prisoner: [ 1, 1 ]
+            #misc
+            Prisoner: [ 1, 1 ] #CD Role

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -30,13 +30,13 @@
             ServiceWorker: [ 2, 2 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
-            SeniorEngineer: [ 1, 1 ]
+            SeniorEngineer: [ 1, 1 ] #CD Role
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 4 ]
             TechnicalAssistant: [ 4, 4 ]
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
-            SeniorPhysician: [ 1, 1 ]
+            SeniorPhysician: [ 1, 1 ] #CD Role
             Chemist: [ 2, 3 ]
             MedicalDoctor: [ 3, 3 ]
             Paramedic: [ 1, 1 ]
@@ -44,14 +44,14 @@
             Psychologist: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            SeniorResearcher: [ 1, 1 ]        
+            SeniorResearcher: [ 1, 1 ] #CD Role      
             Scientist: [ 4, 4 ]
             ResearchAssistant: [ 4, 4 ] 
             Borg: [ 2, 2 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SeniorOfficer: [ 1, 1 ]
+            SeniorOfficer: [ 1, 1 ] #CD Role
             SecurityOfficer: [ 4, 4 ]
             Detective: [ 1, 1 ]
             SecurityCadet: [ 4, 4 ]
@@ -65,4 +65,5 @@
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            
+            #misc
+            Prisoner: [ 1, 1 ] #CD Role

--- a/Resources/Prototypes/_CD/Maps/ferrous.yml
+++ b/Resources/Prototypes/_CD/Maps/ferrous.yml
@@ -28,7 +28,6 @@
             Detective: [ 1, 1 ]
             SecurityOfficer: [ 2, 3 ]
             SecurityCadet: [ 2, 3 ]
-            Prisoner: [ 1, 1 ] #CD Role
             #Service
             Bartender: [ 1, 2 ]
             Botanist: [ 2, 3 ]
@@ -67,3 +66,5 @@
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 2 ]
+            #misc
+            Prisoner: [ 1, 1 ] #CD Role


### PR DESCRIPTION
## About the PR
Adds the prisoner role to Box.
Standardizes map files we've changed.

## Why / Balance
Box is the only 40 pop map that properly supports a fun prisoner environment (it has a proper meeting room).
It was confusing to look at all the different styles so I just fixed that.