### PR TITLE
Make Quick Threads Restock-able

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -135,6 +135,7 @@
     - ViroDrobeInventory
     - WinterDrobeInventory
     - CuraDrobeInventory
+    - QuickThreadsInventory #CD Inventory
   - type: Sprite
     layers:
     - state: base


### PR DESCRIPTION
## About the PR
Adds the Quick Threads to the wardrobe restock crate.

## Why / Balance
Should have some way to restock it. (Mostly because I like to keep it stocked as Central Command)