### PR TITLE
Replace SecGlasses From Cosmetic Lockers

### DIFF
--- a/Resources/Prototypes/_CD/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_CD/Catalog/Fills/Lockers/heads.yml
@@ -127,7 +127,7 @@
       - id: CigarGoldCase
         prob: 0.50
       - id: ClothingBeltSecurityWebbing
-      - id: ClothingEyesGlassesSecurity
+      - id: ClothingEyesGlassesSunglasses
       - id: ClothingEyesHudSecurity
       - id: ClothingHeadHatBeretHoS
       - id: ClothingHeadHatHoshat

--- a/Resources/Prototypes/_CD/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_CD/Catalog/Fills/Lockers/security.yml
@@ -10,7 +10,7 @@
       - id: ClothingHeadHatBeretWarden
       - id: ClothingBeltSecurityFilled
       - id: Flash
-      - id: ClothingEyesGlassesSecurity
+      - id: ClothingEyesGlassesSunglasses
       - id: ClothingShoesBootsJack
       - id: ClothingOuterCoatWarden
       - id: ClothingOuterWinterWarden


### PR DESCRIPTION
## About the PR
Replaces the security glasses in the HoS and Warden cosmetic lockers with sunglasses

## Why / Balance
To fit with Upstream balance.