### PR TITLE
Obtainable Stylized Maid Set

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefdrobe.yml
@@ -11,3 +11,4 @@
     ClothingHeadHatChef: 2
     ClothingShoesColorBlack: 2
     ClothingBeltChef: 2
+    ClothingBeltHalfApron: 2 #CD Clothing

--- a/Resources/Prototypes/_CD/Catalog/VendingMachines/Inventories/quickthreads.yml
+++ b/Resources/Prototypes/_CD/Catalog/VendingMachines/Inventories/quickthreads.yml
@@ -26,6 +26,7 @@
     ClothingUniformJumpsuitPajamaBlue: 2
     ClothingUniformJumpsuitPajamaRed: 2
     ClothingUniformJumpsuitBoilersuitNTNavy: 2
+    ClothingUniformJumpskirtStylizedMaid: 2
     ClothingOuterApronBar: 2
     ClothingOuterApronChef: 2
     ClothingOuterApronBotanist: 2
@@ -36,6 +37,7 @@
     ClothingOuterHoodieGrey: 2
     ClothingOuterCoatInspector: 2
     ClothingOuterCoatJensen: 3
+    ClothingBeltHalfApron: 2
     ClothingOuterVest: 2
     ClothingShoesChef: 2
     ClothingShoesBootsJack: 3
@@ -44,6 +46,7 @@
     ClothingShoesBootsSalvage: 3
     ClothingShoesTourist: 2
     ClothingShoesBootsWork: 3
+    ClothingShoesLuxuryHeelBoots: 3
     ClothingHeadHatFedoraBrown: 2
     ClothingHeadHatFlowerCrown: 2
     ClothingHeadHatFedoraGrey: 2


### PR DESCRIPTION
## About the PR
Adds all the Stylized Maid from #116 to the Quick Threads inventory, two of everything but the shoes which have three.
Adds just the half apron to the chef vend because I thought it fit enough in a kitchen setting (see the literal reason why half apron exists) and that someone might be able to get it to look nice.

## Why / Balance
I'm tired of people having to ahelp about it, and it should be obtainable in the first place.