### PR TITLE
Add prisoner join notification for security radio

### DIFF
--- a/Content.Server/_CD/Roles/NotifyDepartmentSpecial.cs
+++ b/Content.Server/_CD/Roles/NotifyDepartmentSpecial.cs
@@ -1,4 +1,5 @@
 using Content.Server.Radio.EntitySystems;
+using Content.Server.Station.Systems;
 using Content.Shared.Radio;
 using Content.Shared.Roles;
 using Robust.Shared.Prototypes;
@@ -20,7 +21,9 @@ public sealed partial class NotifyDepartmentSpecial : JobSpecial
         var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
         var radio = entMan.System<RadioSystem>();
         var channel = prototypeManager.Index<RadioChannelPrototype>(RadioChannelKey);
+        var stationSystem = entMan.System<StationSystem>();
+        var station = stationSystem.GetOwningStation(mob);
 
-        radio.SendRadioMessage(mob, Loc.GetString(NotifyTextKey), channel, mob);
+        radio.SendRadioMessage(station ?? mob, Loc.GetString(NotifyTextKey), channel, mob);
     }
 }

--- a/Content.Server/_CD/Roles/NotifyDepartmentSpecial.cs
+++ b/Content.Server/_CD/Roles/NotifyDepartmentSpecial.cs
@@ -1,0 +1,26 @@
+using Content.Server.Radio.EntitySystems;
+using Content.Shared.Radio;
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server._CD.Roles;
+
+public sealed partial class NotifyDepartmentSpecial : JobSpecial
+{
+    [DataField("notify_text", required: true)]
+    public string NotifyTextKey { get; private set; } = string.Empty;
+
+    [DataField("radio_channel", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<RadioChannelPrototype>))]
+    public string RadioChannelKey { get; private set; } = string.Empty;
+
+    public override void AfterEquip(EntityUid mob)
+    {
+        var entMan = IoCManager.Resolve<IEntityManager>();
+        var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
+        var radio = entMan.System<RadioSystem>();
+        var channel = prototypeManager.Index<RadioChannelPrototype>(RadioChannelKey);
+
+        radio.SendRadioMessage(mob, Loc.GetString(NotifyTextKey), channel, mob);
+    }
+}

--- a/Content.Server/_CD/Roles/NotifyDepartmentSpecial.cs
+++ b/Content.Server/_CD/Roles/NotifyDepartmentSpecial.cs
@@ -21,9 +21,12 @@ public sealed partial class NotifyDepartmentSpecial : JobSpecial
         var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
         var radio = entMan.System<RadioSystem>();
         var channel = prototypeManager.Index<RadioChannelPrototype>(RadioChannelKey);
-        var stationSystem = entMan.System<StationSystem>();
-        var station = stationSystem.GetOwningStation(mob);
+        var stationManager = entMan.System<StationSystem>();
 
-        radio.SendRadioMessage(station ?? mob, Loc.GetString(NotifyTextKey), channel, mob);
+        // Notify people on all stations.
+        foreach (var station in stationManager.GetStations())
+        {
+            radio.SendRadioMessage(station, Loc.GetString(NotifyTextKey), channel, mob);
+        }
     }
 }

--- a/Resources/Locale/en-US/_CD/job/job-description.ftl
+++ b/Resources/Locale/en-US/_CD/job/job-description.ftl
@@ -1,5 +1,6 @@
 
-job-description-prisoner = Sit in prison. Negogiate with the Warden. Serve parole. You are not an antagonist, and are bound to the same crime rules as any normal crew member. 
+job-description-prisoner = Sit in prison. Negogiate with the Warden. Serve parole. You are not an antagonist, and are bound to the same crime rules as any normal crew member.
+job-prisoner-sec-notify-text = Prisoner has been transferred to the arrivals terminal and requires transportation.
 
 # Senior Roles
 job-description-senior-engineer = Teach new engineers the basics of the station's engine, repairing, atmospherics and power.

--- a/Resources/Prototypes/_CD/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Wildcards/prisoner.yml
@@ -6,6 +6,10 @@
   startingGear: PrisonerGear
   icon: "JobIconPrisoner"
   supervisors: job-supervisors-security
+  special:
+  - !type:NotifyDepartmentSpecial
+    notify_text: job-prisoner-sec-notify-text
+    radio_channel: Security
 
 - type: startingGear
   id: PrisonerGear


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Implements https://github.com/cosmatic-drift-14/cosmatic-drift/issues/122

One possible issue is it looks like the prisoner is speaking over security radio, but this is applied before the shift assignment message so I doubt it would case too much confusion. I did this because the only entity that is readily available for JobSpecials is the character that is joining.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Add a new JobSpecial called NotifyDepartmentSpecial that notifies a radio channel with the given text upon the job joining. This is then added to the prisoner role.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![prisoner-join](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/57052305/0a9c6600-db6d-441b-b65e-68ee22d96b09)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl:
- add (aquif): A notification is now played over security radio when a prisoner is assigned to the shift.
