### PR TITLE
More Role Timers

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -3,6 +3,9 @@
   name: job-name-atmostech
   description: job-description-atmostech
   playTimeTracker: JobAtmosphericTechnician
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 7200 #2 hrs
   startingGear: AtmosphericTechnicianGear
   icon: "JobIconAtmosphericTechnician"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -3,6 +3,9 @@
   name: job-name-engineer
   description: job-description-engineer
   playTimeTracker: JobStationEngineer
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 7200 #2 hrs
   startingGear: StationEngineerGear
   icon: "JobIconStationEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -3,6 +3,9 @@
   name: job-name-technical-assistant
   description: job-description-technical-assistant
   playTimeTracker: JobTechnicalAssistant
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 7200 #2 hrs
   startingGear: TechnicalAssistantGear
   icon: "JobIconTechnicalAssistant"
   supervisors: job-supervisors-engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -3,6 +3,9 @@
   name: job-name-chemist
   description: job-description-chemist
   playTimeTracker: JobChemist
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 7200 #2 hrs
   startingGear: ChemistGear
   icon: "JobIconChemist"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -3,6 +3,9 @@
   name: job-name-borg
   description: job-description-borg
   playTimeTracker: JobBorg
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 7200 #2 hrs
   canBeAntag: false
   icon: JobIconBorg
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/_CD/Roles/Jobs/Engineering/senior_engineer.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Engineering/senior_engineer.yml
@@ -3,6 +3,9 @@
   name: job-name-senior-engineer
   description: job-description-senior-engineer
   playTimeTracker: JobSeniorEngineer
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 7200 #2 hrs
   startingGear: SeniorEngineerGear
   icon: "JobIconSeniorEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/_CD/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Medical/senior_physician.yml
@@ -3,6 +3,9 @@
   name: job-name-senior-physician
   description: job-description-senior-physician
   playTimeTracker: JobSeniorPhysician
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 7200 #2 hrs
   startingGear: SeniorPhysicianGear
   icon: "JobIconSeniorPhysician"
   supervisors: job-supervisors-cmo


### PR DESCRIPTION
## About the PR
Adds a two hour overall game time role timer for all engineering, chemistry (including SP), and borg jobs.

## Why / Balance
Admin consensus.

## Media
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/110078045/5a88b049-fcab-4e39-ad03-c180d5c43563)

**Changelog**
All engineering jobs, chemistry, senior physician, and borgs, now have two hour overall role timers.