### PR TITLE
Add option for admins to disable bwoink

### DIFF
--- a/Content.Client/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Client/Administration/Systems/BwoinkSystem.cs
@@ -19,11 +19,11 @@ namespace Content.Client.Administration.Systems
             OnBwoinkTextMessageRecieved?.Invoke(this, message);
         }
 
-        public void Send(NetUserId channelId, string text)
+        public void Send(NetUserId channelId, string text, bool playSound)
         {
             // Reuse the channel ID as the 'true sender'.
             // Server will ignore this and if someone makes it not ignore this (which is bad, allows impersonation!!!), that will help.
-            RaiseNetworkEvent(new BwoinkTextMessage(channelId, channelId, text));
+            RaiseNetworkEvent(new BwoinkTextMessage(channelId, channelId, text, playSound: playSound));
             SendInputTextUpdated(channelId, false);
         }
 

--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
@@ -7,6 +7,8 @@
             <BoxContainer Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="2">
                 <BoxContainer Access="Public" Name="BwoinkArea" VerticalExpand="True" />
                 <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
+                    <CheckBox Visible="True" Name="PlaySound" Access="Public" Text="{Loc 'admin-bwoink-play-sound'}" Pressed="True" />
+                    <Control HorizontalExpand="True" MinWidth="5" />
                     <Button Visible="True" Name="PopOut" Access="Public" Text="{Loc 'admin-logs-pop-out'}" StyleClasses="OpenBoth" HorizontalAlignment="Left" />
                     <Control HorizontalExpand="True" />
                     <Button Visible="False" Name="Bans" Text="{Loc 'admin-player-actions-bans'}" StyleClasses="OpenRight" />

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -407,18 +407,21 @@ namespace Content.Server.Administration.Systems
 
             if (senderAdmin is not null && senderAdmin.Flags == AdminFlags.Adminhelp) // Mentor. Not full admin. That's why it's colored differently.
             {
-                bwoinkText = $"[color=purple]{senderSession.Name}[/color]: {escapedText}";
+                bwoinkText = $"[color=purple]{senderSession.Name}[/color]";
             }
             else if (senderAdmin is not null && senderAdmin.HasFlag(AdminFlags.Adminhelp))
             {
-                bwoinkText = $"[color=red]{senderSession.Name}[/color]: {escapedText}";
+                bwoinkText = $"[color=red]{senderSession.Name}[/color]";
             }
             else
             {
-                bwoinkText = $"{senderSession.Name}: {escapedText}";
+                bwoinkText = $"{senderSession.Name}";
             }
 
-            var msg = new BwoinkTextMessage(message.UserId, senderSession.UserId, bwoinkText);
+            bwoinkText = (message.PlaySound ? "" : "(S) ") + bwoinkText + ": " + escapedText;
+
+            var playSound = senderAHelpAdmin && message.PlaySound;
+            var msg = new BwoinkTextMessage(message.UserId, senderSession.UserId, bwoinkText, playSound: playSound);
 
             LogBwoink(msg);
 
@@ -442,18 +445,20 @@ namespace Content.Server.Administration.Systems
                         // Doing the same thing as above, but with the override name. Theres probably a better way to do this.
                         if (senderAdmin is not null && senderAdmin.Flags == AdminFlags.Adminhelp) // Mentor. Not full admin. That's why it's colored differently.
                         {
-                            overrideMsgText = $"[color=purple]{_overrideClientName}[/color]: {escapedText}";
+                            overrideMsgText = $"[color=purple]{_overrideClientName}[/color]";
                         }
                         else if (senderAdmin is not null && senderAdmin.HasFlag(AdminFlags.Adminhelp))
                         {
-                            overrideMsgText = $"[color=red]{_overrideClientName}[/color]: {escapedText}";
+                            overrideMsgText = $"[color=red]{_overrideClientName}[/color]";
                         }
                         else
                         {
-                            overrideMsgText = $"{senderSession.Name}: {escapedText}"; // Not an admin, name is not overridden.
+                            overrideMsgText = $"{senderSession.Name}"; // Not an admin, name is not overridden.
                         }
 
-                        RaiseNetworkEvent(new BwoinkTextMessage(message.UserId, senderSession.UserId, overrideMsgText), session.Channel);
+                        overrideMsgText = (message.PlaySound ? "" : "(S) ") + overrideMsgText + ": " + escapedText;
+
+                        RaiseNetworkEvent(new BwoinkTextMessage(message.UserId, senderSession.UserId, overrideMsgText, playSound: playSound), session.Channel);
                     }
                     else
                         RaiseNetworkEvent(msg, session.Channel);

--- a/Content.Shared/Administration/SharedBwoinkSystem.cs
+++ b/Content.Shared/Administration/SharedBwoinkSystem.cs
@@ -38,12 +38,15 @@ namespace Content.Shared.Administration
             public NetUserId TrueSender { get; }
             public string Text { get; }
 
-            public BwoinkTextMessage(NetUserId userId, NetUserId trueSender, string text, DateTime? sentAt = default)
+            public bool PlaySound { get; }
+
+            public BwoinkTextMessage(NetUserId userId, NetUserId trueSender, string text, DateTime? sentAt = default, bool playSound = true)
             {
                 SentAt = sentAt ?? DateTime.Now;
                 UserId = userId;
                 TrueSender = trueSender;
                 Text = text;
+                PlaySound = playSound;
             }
         }
     }

--- a/Resources/Locale/en-US/_CD/admin/admin.ftl
+++ b/Resources/Locale/en-US/_CD/admin/admin.ftl
@@ -1,0 +1,1 @@
+admin-bwoink-play-sound = Bwoink?


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
In a vain attempt to get people to ahelp more, provide the possibility for admins to not play the bwoink sound.

(also, if any of the upstream people who stalk the repo want this. Let me know and I am happy to send a PR.)
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
See discord.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I am not very proud of this code, but can't really think of a better way of doing it. The bwoink message now has an additional field that can only be set by admins to disable the bwoink sound. This required a decent amount of spaghetti to wire it though everything.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![](https://cdn.discordapp.com/attachments/1163713936231764059/1204210988455567360/image.png?ex=65d3e7e0&is=65c172e0&hm=b265b73c256d8e439465712ecb8df6034402a08af1df3f18bc070e7d721c7dcd&)
(The first S being misaligned is because I reloaded code. The second and third S are how it really is.)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
The ahelp UI controller action and ahelp system Send method now have an additional parameter. They are not used outside of ahelp stuff so I doubt it is an issue. 

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl: Aquif
- add: Admins can now disable the bwoink sound if they don't want to scare players.

