### PR TITLE
Synth Trait

### DIFF
--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -74,12 +74,12 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
 
         // CD Change - Go through everyone with the SynthComponent and inform them a storm is happening.
         var synthQuery = EntityQueryEnumerator<SynthComponent>();
-        while (synthQuery.MoveNext(out var ent))
+        while (synthQuery.MoveNext(out var ent, out var synthComp))
         {
-            if (RobustRandom.Prob(0.7f))
+            if (RobustRandom.Prob(synthComp.AlertChance))
                 continue;
 
-            if (!TryComp<ActorComponent>(uid, out var actor))
+            if (!TryComp<ActorComponent>(ent, out var actor))
                 continue;
 
             var msg = Loc.GetString("station-event-ion-storm-synth");

--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -1,3 +1,4 @@
+using Content.Server._CD.Traits;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Silicons.Laws;
 using Content.Server.Station.Components;
@@ -12,6 +13,10 @@ using Content.Shared.Silicons.Laws;
 using Content.Shared.Silicons.Laws.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+// Used in CD's System
+using Content.Server.Chat.Managers;
+using Content.Shared.Chat;
+using Robust.Shared.Player;
 
 namespace Content.Server.StationEvents.Events;
 
@@ -20,6 +25,7 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly SiliconLawSystem _siliconLaw = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!; // Used for CD's System
 
     // funny
     [ValidatePrototypeId<DatasetPrototype>]
@@ -65,6 +71,22 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
 
         if (!TryGetRandomStation(out var chosenStation))
             return;
+
+        // CD Change - Go through everyone with the SynthComponent and inform them a storm is happening.
+        var synthQuery = EntityQueryEnumerator<SynthComponent>();
+        while (synthQuery.MoveNext(out var ent))
+        {
+            if (RobustRandom.Prob(0.7f))
+                continue;
+
+            if (!TryComp<ActorComponent>(uid, out var actor))
+                continue;
+
+            var msg = Loc.GetString("station-event-ion-storm-synth");
+            var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", msg));
+            _chatManager.ChatMessageToOne(ChatChannel.Server, msg, wrappedMessage, default, false, actor.PlayerSession.Channel, colorOverride: Color.Yellow);
+        }
+        // End of CD change
 
         var query = EntityQueryEnumerator<SiliconLawBoundComponent, TransformComponent, IonStormTargetComponent>();
         while (query.MoveNext(out var ent, out var lawBound, out var xform, out var target))

--- a/Content.Server/_CD/Traits/SynthComponent.cs
+++ b/Content.Server/_CD/Traits/SynthComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Server._CD.Traits;
+
+/// <summary>
+/// Set players' blood to coolant, and is used to notify them of ion storms
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(SynthSystem))]
+public sealed partial class SynthComponent : Component
+{
+    /// <summary>
+    /// The blood reagent to give them.
+    /// </summary>
+    [DataField("newBloodReagent")]
+    public string NewBloodReagent = "SynthBlood";
+}

--- a/Content.Server/_CD/Traits/SynthComponent.cs
+++ b/Content.Server/_CD/Traits/SynthComponent.cs
@@ -1,16 +1,14 @@
-using Robust.Shared.GameStates;
-
 namespace Content.Server._CD.Traits;
 
 /// <summary>
 /// Set players' blood to coolant, and is used to notify them of ion storms
 /// </summary>
-[RegisterComponent, NetworkedComponent, Access(typeof(SynthSystem))]
+[RegisterComponent, Access(typeof(SynthSystem))]
 public sealed partial class SynthComponent : Component
 {
     /// <summary>
-    /// The blood reagent to give them.
+    /// The chance that the synth is alerted of an ion storm
     /// </summary>
-    [DataField("newBloodReagent")]
-    public string NewBloodReagent = "SynthBlood";
+    [DataField]
+    public float AlertChance = 0.3f;
 }

--- a/Content.Server/_CD/Traits/SynthSystem.cs
+++ b/Content.Server/_CD/Traits/SynthSystem.cs
@@ -1,0 +1,19 @@
+using Content.Server.Body.Systems;
+
+namespace Content.Server._CD.Traits;
+
+public sealed class SynthSystem : EntitySystem
+{
+    [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<SynthComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(EntityUid uid, SynthComponent component, ComponentStartup args)
+    {
+        //Give them synth blood. Ion storm notif is handled in that system
+        _bloodstream.ChangeBloodReagent(uid, component.NewBloodReagent);
+    }
+}

--- a/Content.Server/_CD/Traits/SynthSystem.cs
+++ b/Content.Server/_CD/Traits/SynthSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Body.Systems;
+using Content.Shared.Chat.TypingIndicator;
 
 namespace Content.Server._CD.Traits;
 
@@ -8,12 +9,20 @@ public sealed class SynthSystem : EntitySystem
 
     public override void Initialize()
     {
+        base.Initialize();
+
         SubscribeLocalEvent<SynthComponent, ComponentStartup>(OnStartup);
     }
 
     private void OnStartup(EntityUid uid, SynthComponent component, ComponentStartup args)
     {
-        //Give them synth blood. Ion storm notif is handled in that system
-        _bloodstream.ChangeBloodReagent(uid, component.NewBloodReagent);
+        if (TryComp<TypingIndicatorComponent>(uid, out var indicator))
+        {
+            indicator.Prototype = "robot";
+            Dirty(uid, indicator);
+        }
+
+        // Give them synth blood. Ion storm notif is handled in that system
+        _bloodstream.ChangeBloodReagent(uid, "SynthBlood");
     }
 }

--- a/Content.Shared/Chat/TypingIndicator/TypingIndicatorComponent.cs
+++ b/Content.Shared/Chat/TypingIndicator/TypingIndicatorComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Chat.TypingIndicator;
@@ -7,14 +7,13 @@ namespace Content.Shared.Chat.TypingIndicator;
 ///     Show typing indicator icon when player typing text in chat box.
 ///     Added automatically when player poses entity.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
-[Access(typeof(SharedTypingIndicatorSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class TypingIndicatorComponent : Component
 {
     /// <summary>
     ///     Prototype id that store all visual info about typing indicator.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("proto", customTypeSerializer: typeof(PrototypeIdSerializer<TypingIndicatorPrototype>))]
+    [DataField("proto", customTypeSerializer: typeof(PrototypeIdSerializer<TypingIndicatorPrototype>)), AutoNetworkedField]
     public string Prototype = SharedTypingIndicatorSystem.InitialIndicatorId;
 }

--- a/Resources/Locale/en-US/_CD/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/_CD/reagents/meta/biological.ftl
@@ -1,0 +1,2 @@
+reagent-name-synth-blood = synth blood
+reagent-desc-synth-blood = Not quite coolant, not quite blue powerade.

--- a/Resources/Locale/en-US/_CD/station/events.ftl
+++ b/Resources/Locale/en-US/_CD/station/events.ftl
@@ -1,0 +1,1 @@
+﻿station-event-ion-storm-synth = You detect an Ion Storm. Your internal systems may be tampered with or damaged as a result. 

--- a/Resources/Locale/en-US/_CD/traits/traits.ftl
+++ b/Resources/Locale/en-US/_CD/traits/traits.ftl
@@ -1,0 +1,2 @@
+trait-synth-name = Synthetic
+trait-synth-desc = You are a biomechanical construct, who bleeds coolant and is notified of ongoing Ion Storms.

--- a/Resources/Prototypes/_CD/Reagents/biological.yml
+++ b/Resources/Prototypes/_CD/Reagents/biological.yml
@@ -1,0 +1,23 @@
+- type: reagent
+  id: SynthBlood
+  name: reagent-name-synth-blood
+  group: Biological
+  desc: reagent-desc-synth-blood
+  flavor: metallic
+  color: "#00b8f5"
+  recognizable: true
+  physicalDesc: reagent-physical-desc-reflective
+  slippery: false
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 1.5
+        conditions:
+          - !type:OrganType
+            type: Human
+            shouldHave: false
+  footstepSound:
+    collection: FootstepBlood
+    params:
+      volume: 6

--- a/Resources/Prototypes/_CD/Traits/traits.yml
+++ b/Resources/Prototypes/_CD/Traits/traits.yml
@@ -1,6 +1,6 @@
 ﻿- type: trait
   id: Synthetic
-  name: trait-lightweight-name
-  description: trait-lightweight-desc
+  name: trait-synth-name
+  description: trait-synth-desc
   components:
     - type: Synth

--- a/Resources/Prototypes/_CD/Traits/traits.yml
+++ b/Resources/Prototypes/_CD/Traits/traits.yml
@@ -1,0 +1,6 @@
+﻿- type: trait
+  id: Synthetic
+  name: trait-lightweight-name
+  description: trait-lightweight-desc
+  components:
+    - type: Synth


### PR DESCRIPTION
had to fuck with upstream code for this but *surely* it's fine.
Currently:
gives synth blood instead of whatever blood you had before
changes typing indicator to robor
30% chance of being alerted of an ion storm when one happens