### PR TITLE
Updates all species' marking limits to be more lenient.

### DIFF
--- a/Resources/Prototypes/Species/arachnid.yml
+++ b/Resources/Prototypes/Species/arachnid.yml
@@ -64,10 +64,10 @@
       points: 3
       required: false
     Legs:
-      points: 2
+      points: 6
       required: false
     Arms:
-      points: 2
+      points: 6
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/Species/arachnid.yml
+++ b/Resources/Prototypes/Species/arachnid.yml
@@ -44,7 +44,7 @@
   onlyWhitelisted: true
   points:
     Hair:
-      points: 0
+      points: 1
       required: false
     FacialHair:
       points: 0
@@ -61,7 +61,7 @@
       required: true
       defaultMarkings: [ ArachnidCheliceraeDownwards ]
     Chest:
-      points: 1
+      points: 3
       required: false
     Legs:
       points: 2

--- a/Resources/Prototypes/Species/diona.yml
+++ b/Resources/Prototypes/Species/diona.yml
@@ -35,7 +35,7 @@
   onlyWhitelisted: true
   points:
     Head:
-      points: 2
+      points: 3
       required: false
     HeadTop:
       points: 2

--- a/Resources/Prototypes/Species/diona.yml
+++ b/Resources/Prototypes/Species/diona.yml
@@ -38,13 +38,13 @@
       points: 2
       required: false
     HeadTop:
-      points: 1
+      points: 2
       required: false
     HeadSide:
-      points: 1
+      points: 2
       required: false
     Chest:
-      points: 1
+      points: 2
       required: false
     Legs:
       points: 2

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -42,7 +42,7 @@
   onlyWhitelisted: true
   points:
     Hair:
-      points: 0
+      points: 1
       required: false
     FacialHair:
       points: 0
@@ -65,13 +65,13 @@
       points: 1
       required: false
     Chest:
-      points: 1
+      points: 2
       required: false
     Legs:
-      points: 2
+      points: 5
       required: false
     Arms:
-      points: 2
+      points: 5
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -68,10 +68,10 @@
       points: 2
       required: false
     Legs:
-      points: 5
+      points: 6
       required: false
     Arms:
-      points: 5
+      points: 6
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -62,7 +62,7 @@
       points: 1
       required: false
     Head:
-      points: 1
+      points: 3
       required: false
     Chest:
       points: 2

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -51,19 +51,19 @@
       required: true
       defaultMarkings: [ LizardSnoutRound ]
     HeadTop:
-      points: 2
+      points: 3
       required: false
     HeadSide:
       points: 1
       required: false
     Chest:
-      points: 1
+      points: 3
       required: false
     Legs:
-      points: 2
+      points: 3
       required: false
     Arms:
-      points: 2
+      points: 3
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -60,10 +60,10 @@
       points: 3
       required: false
     Legs:
-      points: 3
+      points: 6
       required: false
     Arms:
-      points: 3
+      points: 6
       required: false
 
 - type: humanoidBaseSprite


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
All species have an updated marking limit to accommodate for markings that can be used in synergy to create more unique and personalized characters. Different types of markings (ie skin markings vs. gauze) have been taken into account as well. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
My lizzer was prevented from having both wings and underbelly, so I decided to take a look at every species. Since this is HRP and whitelist only, I believe we can give more trust to our players not to abuse it to create some horrendous monster.

# Changes:

### Arachnid
- Chest now has 3 points (previously 1): Several chest markings can make a nice synergy with one another.

- Arms & Legs now have 6 points each (previously 2): Allows use of skin markings and gauze for each leg.

Example Arachnid:
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/125095677/70ec4e99-f4d8-49cf-b04f-77efdd66b54f)
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/125095677/a7669677-2534-450a-9ae0-c1a3f8d10f7b)
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/125095677/02ddaa9a-05be-44e5-9086-2f9eb2326f95)

### Diona
- Head now has 3 points (previously 2) : Better synergy.

- Head (Top) now has 2 points (previously 1): Better synergy.

- Head (Side) now has 2 points (previously 1): Better synergy.

- Chest now has 2 points (previously 1): Better synergy.

Example Diona:
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/125095677/97b3433e-cf46-4005-9fcf-0c2952479309)
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/125095677/738b72e2-c247-43e0-837b-0e191ed16bb8)
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/125095677/2fe57260-391f-495f-a05e-9e1bb0d9c798)

### Moth
- Head now has 3 points (previously 1): Better synergy & allows use of gauze and markings.

- Chest now has 2 points (previously 1): Better synergy.

- Arms & Legs now have 6 points each (previously 2): Allows use of skin markings and gauze for each leg.

Example Moth:
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/125095677/2e65ea57-ff44-406a-bbc0-9c327efb897a)
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/125095677/a1de41ca-65cd-4cb7-b0d2-321fede9d921)
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/125095677/9956fe79-25c3-4a52-b7ee-6d8f69c1b8f7)

### Reptilian
- Head (Top) now has 2 points (previously 1): Better synergy.

- Chest now has 3 points (previously 1): Allows use of skin markings, draconic wings, and gauze simultaneously.

- Arms & Legs now have 6 points each (previously 2): Allows use of skin markings and gauze for each leg.

Example Lizzer:
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/125095677/24225b96-6ed2-4bd5-a8ea-165453c23f6b)
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/125095677/a821620b-1d3b-4a0a-820d-4cb0d2332a55)
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/125095677/abf578b2-c7cd-466b-a704-2af89b42bfe6)

## Notes
- Dwarves were not changed due to them being a squished human
- Slimes were not changed due to their complete neglect of having any markings (they had enough for every marking available to them)

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: All species' markings are more lenient with their points.