### PR TITLE
Update Map Attributions To Include Ferrous

### DIFF
--- a/Resources/map_attributions.txt
+++ b/Resources/map_attributions.txt
@@ -49,3 +49,8 @@
 - files: ["core.yml"]
   authors: Ubaser
 
+#CD Maps
+#These are located in Maps/_CD
+
+- files: ["ferrous.yml"]
+  authors: PurusitinAshes


### PR DESCRIPTION
## About the PR
Things were hidden and I didn't realize the file existed, it now includes Ferrous in the list under a new category. Rest of the PR template has been deleted because this doesn't change anything else.
