### PR TITLE
Make the height textbox into a slider.

### DIFF
--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml
@@ -66,12 +66,13 @@
                                     <Control HorizontalExpand="True"/>
                                     <LineEdit Name="CAgeEdit" MinSize="40 0" HorizontalAlignment="Right" />
                                 </BoxContainer>
-                                <!-- Height -->
+                                <!-- CD Height -->
                                 <BoxContainer HorizontalExpand="True">
                                     <Label Text="{Loc 'humanoid-profile-editor-height-label'}" />
-                                    <Label Name="CHeightLabel" Text="1" />
-                                    <Button Name="CHeightReset" Text="{Loc 'humanoid-profile-editor-reset-height-button'}"/>
-                                    <LineEdit HorizontalAlignment="Right" HorizontalExpand="True" Name="CHeight" MinSize="40 0" Text="1.0" />
+                                    <Control HorizontalExpand="True" />
+                                    <Slider Name="CDHeightSlider" HorizontalAlignment="Right" SetWidth="300" MinValue="0.0" MaxValue="1.0"/>
+                                    <LineEdit HorizontalAlignment="Right" Name="CHeight" MinSize="60 0" Text="1.0" />
+                                    <Button Name="CHeightReset" Text="{Loc 'humanoid-profile-editor-reset-height-button'}" HorizontalAlignment="Right"/>
                                 </BoxContainer>
                                 <!-- Sex -->
                                 <BoxContainer HorizontalExpand="True">

--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -203,8 +203,7 @@ namespace Content.Client.Preferences.UI
 
             #endregion Species
 
-            #region Height
-
+            #region CDHeight
 
             _heightPicker.OnTextChanged += args =>
             {
@@ -212,25 +211,32 @@ namespace Content.Client.Preferences.UI
                     return;
 
                 var prototype = _prototypeManager.Index<SpeciesPrototype>(Profile.Species);
+                newHeight = MathF.Round(Math.Clamp(newHeight, prototype.MinHeight, prototype.MaxHeight), 2);
 
-                if (newHeight < prototype.MinHeight)
-                    newHeight = prototype.MinHeight;
+                // The percentage between the start and end numbers, aka "inverse lerp"
+                var sliderPercent = (newHeight - prototype.MinHeight) /
+                                    (prototype.MaxHeight - prototype.MinHeight);
+                CDHeightSlider.Value = sliderPercent;
 
-                if (newHeight > prototype.MaxHeight)
-                    newHeight = prototype.MaxHeight;
-
-                CHeightLabel.Text = MathF.Round(newHeight, 2).ToString("G");
-                SetProfileHeight(MathF.Round(newHeight, 2));
+                SetProfileHeight(newHeight);
             };
 
             CHeightReset.OnPressed += _ =>
             {
-                _heightPicker.Text = _defaultHeight.ToString(CultureInfo.InvariantCulture);
-                CHeightLabel.Text = _defaultHeight.ToString(CultureInfo.InvariantCulture);
-                SetProfileHeight(_defaultHeight);
+                _heightPicker.SetText(_defaultHeight.ToString(CultureInfo.InvariantCulture), true);
             };
 
-            #endregion Height
+            CDHeightSlider.OnValueChanged += _ =>
+            {
+                if (Profile is null)
+                    return;
+                var prototype = _prototypeManager.Index<SpeciesPrototype>(Profile.Species);
+                var newHeight = MathF.Round(MathHelper.Lerp(prototype.MinHeight, prototype.MaxHeight, CDHeightSlider.Value), 2);
+                _heightPicker.Text = newHeight.ToString(CultureInfo.InvariantCulture);
+                SetProfileHeight(newHeight);
+            };
+
+            #endregion CDHeight
 
             #region Skin
 
@@ -1070,8 +1076,11 @@ namespace Content.Client.Preferences.UI
             if (species != null)
                 _defaultHeight = species.DefaultHeight;
 
-            _heightPicker.Text = Profile.Height.ToString();
-            CHeightLabel.Text = Profile.Height.ToString();
+            var prototype = _prototypeManager.Index<SpeciesPrototype>(Profile.Species);
+            var sliderPercent = (Profile.Height - prototype.MinHeight) /
+                                (prototype.MaxHeight - prototype.MinHeight);
+            CDHeightSlider.Value = sliderPercent;
+            _heightPicker.Text = Profile.Height.ToString(CultureInfo.InvariantCulture);
         }
 
         private void UpdateSpawnPriorityControls()

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -193,7 +193,8 @@ namespace Content.Shared.Preferences
             {
                 sex = random.Pick(speciesPrototype.Sexes);
                 age = random.Next(speciesPrototype.MinAge, speciesPrototype.OldAge); // people don't look and keep making 119 year old characters with zero rp, cap it at middle aged
-                height = random.NextFloat(speciesPrototype.MinHeight, speciesPrototype.MaxHeight);
+                // CD: We only permit 2 decimals of precision for height in the editor, so we should enforce that here
+                height = MathF.Round(random.NextFloat(speciesPrototype.MinHeight, speciesPrototype.MaxHeight), 2);
             }
 
             var gender = sex == Sex.Male ? Gender.Male : Gender.Female;

--- a/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
@@ -1,5 +1,5 @@
 humanoid-profile-editor-randomize-everything-button = Randomize everything
-humanoid-profile-editor-reset-height-button = Reset Height
+humanoid-profile-editor-reset-height-button = Reset
 humanoid-profile-editor-name-label = Name:
 humanoid-profile-editor-name-random-button = Randomize
 humanoid-profile-editor-appearance-tab = Appearance


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Makes the height box into a slider

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The previous UI listed the height multiple times and had the reset button in a weird spot, in the process of fixing that I decided to turn it into a slider.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Because the max/min height depends on the prototype, we need to lerp between them so the slider ranges between 0.0 and 1.0. 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/57052305/040ae67e-b96f-4908-9a27-54b67a52e2ea)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
-->
:cl: Aquif
- tweak: The height box is now a slider

