### PR TITLE
20 Character Slots

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -177,7 +177,7 @@ namespace Content.Shared.CCVar
         ///     Controls the maximum number of character slots a player is allowed to have.
         /// </summary>
         public static readonly CVarDef<int>
-            GameMaxCharacterSlots = CVarDef.Create("game.maxcharacterslots", 10, CVar.ARCHIVE | CVar.SERVERONLY);
+            GameMaxCharacterSlots = CVarDef.Create("game.maxcharacterslots", 20, CVar.ARCHIVE | CVar.SERVERONLY); /// CD change to 20 from 10.
 
         /// <summary>
         ///     Controls the game map prototype to load. SS14 stores these prototypes in Prototypes/Maps.


### PR DESCRIPTION
## About the PR
Changes the cvar default to 20 instead of 10.

## Why / Balance
To make the database cry. And also because it could be nice for players who have an excess of characters, shouldn't be used by the majority of people though.