### PR TITLE
Add log probe to private investigator starting gear

### DIFF
--- a/Resources/Prototypes/_CD/Catalog/Fills/Backpacks/StarterGear/startergear.yml
+++ b/Resources/Prototypes/_CD/Catalog/Fills/Backpacks/StarterGear/startergear.yml
@@ -9,6 +9,7 @@
       - id: ForensicScanner
       - id: ForensicPad
         amount: 3
+      - id: LogProbeCartridge
 
 - type: entity
   noSpawn: true
@@ -21,6 +22,7 @@
       - id: ForensicScanner
       - id: ForensicPad
         amount: 3
+      - id: LogProbeCartridge
 
 - type: entity
   noSpawn: true
@@ -33,3 +35,4 @@
       - id: ForensicScanner
       - id: ForensicPad
         amount: 3
+      - id: LogProbeCartridge


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR adds the Log Probe Cartridge to the private investigators starting gear.

**Changelog**
Simyon: Private investigators now start with a log probe cartridge