### PR TITLE
add sunglasses to quickthreads

### DIFF
--- a/Resources/Prototypes/_CD/Catalog/VendingMachines/Inventories/quickthreads.yml
+++ b/Resources/Prototypes/_CD/Catalog/VendingMachines/Inventories/quickthreads.yml
@@ -61,5 +61,6 @@
     ClothingHandsGlovesColorWhite: 2
     ClothingNeckTieDet: 2
     ClothingNeckTieRed: 2
+    ClothingEyesGlassesSunglasses: 2
     ClothingEyesGlassesAviator: 4
     BoxPridePins: 2


### PR DESCRIPTION
i did in it quickthreads to prevent conflicts with namespace or something.

why did i do it? well you see it is because someone wanted them.

there are now 2