### PR TITLE
Update Standard PI Spawn To Correct Icon

### DIFF
--- a/Resources/Prototypes/_CD/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/_CD/Entities/Markers/Spawners/jobs.yml
@@ -21,7 +21,7 @@
   - type: Sprite
     layers:
       - state: green
-      - state: prisoner
+      - state: detective
 
 # Standard Spawnpoints for Senior Roles
 - type: entity


### PR DESCRIPTION
## About the PR
The arrivals spawner was the correct icon, but the standard spawner was not. This makes both the same icon, the detective's icon. I might go through again and create a new icon for the PI specifically later, but for now this is good. (I did test this ingame, I just forgot to grab media, sorry. I can grab media if asked.)