### PR TITLE
Make records console reset button clear search bar

### DIFF
--- a/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
+++ b/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
@@ -74,6 +74,7 @@ public sealed partial class CharacterRecordViewer : FancyWindow
         RecordFiltersReset.OnPressed += _ =>
         {
             OnFiltersChanged?.Invoke(StationRecordFilterType.Name, null);
+            RecordFiltersValue.Clear();
         };
 
         RecordFiltersValue.OnTextEntered += text =>


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It was annoying me that it did not clear the search bar upon pressing reset. Also, this is a desync technically because the search field is cleared server side.

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
 Not required
