### PR TITLE
Fix list inv desync upon inserting stackables

### DIFF
--- a/Content.Server/Item/ItemSystem.cs
+++ b/Content.Server/Item/ItemSystem.cs
@@ -19,6 +19,5 @@ public sealed class ItemSystem : SharedItemSystem
             return;
 
         _storage.RecalculateStorageUsed(container.Owner, storage);
-        _storage.UpdateUI(container.Owner, storage);
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes a desync upon inserting a stack into a container that already had a stack of the same item type. 

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
UpdateUI was only being called server side which has no body. We move the call to Shared so it also gets called on the client.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
I don't think media is needed, but I could record before and after videos upon request.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aquif
- fix: Inserting stackables into an inventory that already contained items of the same type updates the inventory viewer 