### PR TITLE
New Map Pops

### DIFF
--- a/Resources/Prototypes/Maps/aspid.yml
+++ b/Resources/Prototypes/Maps/aspid.yml
@@ -3,7 +3,7 @@
   mapName: 'NCS Aspid'
   mapPath: /Maps/aspid.yml
   minPlayers: 25
-  maxPlayers: 55
+  maxPlayers: 45
   stations:
     Aspid:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/atlas.yml
+++ b/Resources/Prototypes/Maps/atlas.yml
@@ -2,7 +2,7 @@
   id: Atlas
   mapName: Atlas
   mapPath: /Maps/atlas.yml
-  minPlayers: 5
+  minPlayers: 0
   maxPlayers: 15
   stations:
     Atlas:

--- a/Resources/Prototypes/Maps/atlas.yml
+++ b/Resources/Prototypes/Maps/atlas.yml
@@ -3,7 +3,7 @@
   mapName: Atlas
   mapPath: /Maps/atlas.yml
   minPlayers: 5
-  maxPlayers: 20
+  maxPlayers: 15
   stations:
     Atlas:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -2,8 +2,8 @@
   id: Bagel
   mapName: 'Bagel Station'
   mapPath: /Maps/bagel.yml
-  minPlayers: 40
-  maxPlayers: 76
+  minPlayers: 25
+  maxPlayers: 55
   stations:
     Bagel:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -2,7 +2,7 @@
   id: Box
   mapName: 'Box Station'
   mapPath: /Maps/box.yml
-  minPlayers: 50
+  minPlayers: 35
   stations:
     Boxstation:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -2,8 +2,8 @@
   id: Cluster
   mapName: 'Cluster'
   mapPath: /Maps/cluster.yml
-  minPlayers: 10
-  maxPlayers: 35
+  minPlayers: 5
+  maxPlayers: 25
   stations:
     Cluster:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -2,8 +2,8 @@
   id: Core
   mapName: 'Core'
   mapPath: /Maps/core.yml
-  minPlayers: 30
-  maxPlayers: 60
+  minPlayers: 25
+  maxPlayers: 35
   stations:
     Core:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -2,7 +2,7 @@
   id: Fland
   mapName: 'Fland Installation'
   mapPath: /Maps/fland.yml
-  minPlayers: 70
+  minPlayers: 55
   stations:
     Fland:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -2,7 +2,7 @@
   id: Fland
   mapName: 'Fland Installation'
   mapPath: /Maps/fland.yml
-  minPlayers: 55
+  minPlayers: 70
   stations:
     Fland:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/gemini.yml
+++ b/Resources/Prototypes/Maps/gemini.yml
@@ -2,7 +2,7 @@
   id: Gemini
   mapName: 'Gemini'
   mapPath: /Maps/gemini.yml
-  minPlayers: 35
+  minPlayers: 45
   stations:
     Gemini:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -2,8 +2,8 @@
   id: Marathon
   mapName: 'Marathon Station'
   mapPath: /Maps/marathon.yml
-  minPlayers: 35
-  maxPlayers: 70
+  minPlayers: 25
+  maxPlayers: 55
   stations:
     Marathon:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -2,7 +2,7 @@
   id: Meta
   mapName: 'Meta Station'
   mapPath: /Maps/meta.yml
-  minPlayers: 50
+  minPlayers: 45
   stations:
     Meta:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -2,7 +2,7 @@
   id: Meta
   mapName: 'Meta Station'
   mapPath: /Maps/meta.yml
-  minPlayers: 45
+  minPlayers: 35
   stations:
     Meta:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -2,8 +2,8 @@
   id: Omega
   mapName: 'Omega'
   mapPath: /Maps/omega.yml
-  minPlayers: 10
-  maxPlayers: 35
+  minPlayers: 5
+  maxPlayers: 25
   stations:
     Omega:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/origin.yml
+++ b/Resources/Prototypes/Maps/origin.yml
@@ -2,7 +2,7 @@
   id: Origin
   mapName: 'Origin'
   mapPath: /Maps/origin.yml
-  minPlayers: 50
+  minPlayers: 45
   stations:
     Origin:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -2,8 +2,8 @@
   id: Packed
   mapName: 'Packed'
   mapPath: /Maps/packed.yml
-  minPlayers: 5
-  maxPlayers: 40
+  minPlayers: 0
+  maxPlayers: 25
   stations:
     Packed:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -2,7 +2,7 @@
   id: Packed
   mapName: 'Packed'
   mapPath: /Maps/packed.yml
-  minPlayers: 0
+  minPlayers: 5
   maxPlayers: 25
   stations:
     Packed:

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -3,7 +3,7 @@
   mapName: 'Reach'
   mapPath: /Maps/reach.yml
   minPlayers: 0
-  maxPlayers: 7
+  maxPlayers: 5
   stations:
     Reach:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -3,7 +3,7 @@
   mapName: 'Saltern'
   mapPath: /Maps/saltern.yml
   minPlayers: 0
-  maxPlayers: 35
+  maxPlayers: 15
   fallback: true
   stations:
     Saltern:

--- a/Resources/Prototypes/_CD/Maps/ferrous.yml
+++ b/Resources/Prototypes/_CD/Maps/ferrous.yml
@@ -3,7 +3,7 @@
   mapName: 'Ferrous'
   mapPath: /Maps/_CD/ferrous.yml
   minPlayers: 15
-  maxPlayers: 45
+  maxPlayers: 35
   stations:
     Ferrous:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_CD/Maps/ferrous.yml
+++ b/Resources/Prototypes/_CD/Maps/ferrous.yml
@@ -2,7 +2,8 @@
   id: Ferrous
   mapName: 'Ferrous'
   mapPath: /Maps/_CD/ferrous.yml
-  minPlayers: 20
+  minPlayers: 15
+  maxPlayers: 45
   stations:
     Ferrous:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
## About the PR
Redoes all the map vote populations.
Should be something like this:

Fland: (Unused)
Gemini: 45+
Origin: 45+
Box: 35+
Meta: 35+
Bagel: 25 - 55
Marathon: 25 - 55
Aspid: 25 - 45
Core: 25 - 35
Ferrous: 15 - 35
Cluster: 5 - 25
Omega: 5 - 25
Packed: 5 - 25
Atlas: 0 - 15
Saltern: 0 - 15
Reach: 0 - 5

## Why / Balance
To make it so admins don't have to constantly run custom votes.
The numbers are slightly arbitrarily picked, but based off of my original list I was doing for map votes. We can play it by touch from here on out doing adjustments when we need.