### PR TITLE
Give the senior officers back their secglasses

### DIFF
--- a/Resources/Prototypes/_CD/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Security/senior_officer.yml
@@ -26,7 +26,7 @@
     jumpsuit: ClothingUniformJumpsuitSeniorOfficer
     back: ClothingBackpackSecurityFilled
     shoes: ClothingShoesBootsCombatFilled
-    eyes: ClothingEyesGlassesSunglasses
+    eyes: ClothingEyesGlassesSecurity
     head: ClothingHeadHatBeretSecurity
     outerClothing: ClothingOuterArmorBasic
     id: SeniorOfficerPDA


### PR DESCRIPTION
## About the PR
Role maintenence - Senior officers now roundstart with secglasses like the rest of the roles. Secglasses are now round start and SO just needed to be updated to match.

No CL
Its untested, so if something is broken let me know and I'll fix it.