### PR TITLE
CD Loadouts Patch

### DIFF
--- a/Resources/Locale/en-US/_CD/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_CD/preferences/loadout-groups.ftl
@@ -1,0 +1,24 @@
+# Civilian
+loadout-group-private-investigator-backpack = Private Investigator backpack
+loadout-group-private-investigator-outerclothing = Private Investigator outer clothing
+loadout-group-private-investigator-gloves = Private Investigator gloves
+loadout-group-private-investigator-shoes = Private Investigator shoes
+loadout-group-private-investigator-glasses = Private Investigator glasses
+
+# Engineering
+loadout-group-senior-engineer-jumpsuit = Senior Engineer jumpsuit
+
+# Science
+loadout-group-senior-researcher-jumpsuit = Senior Researcher jumpsuit
+loadout-group-senior-researcher-outerclothing = Senior Researcher outer clothing
+
+# Security
+loadout-group-senior-officer-jumpsuit = Senior Officer jumpsuit
+
+# Medical
+loadout-group-senior-physician-head = Senior Physician head
+loadout-group-senior-physician-jumpsuit = Senior Physician jumpsuit
+loadout-group-senior-physician-outerclothing = Senior Physician outer clothing
+
+# Wildcards
+loadout-group-prisoner-jumpsuit = Prisoner jumpsuit

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -20,12 +20,12 @@
 
 # Head
 
-- type: loadout
-  id: SeniorPhysicianBeret
-  equipment: SeniorPhysicianBeret
-  # effects:
-  # - !type:GroupLoadoutEffect (Disabling requirements for beret)
-  #   proto: SeniorPhysician
+# - type: loadout (CD: Disabling senior clothing)
+  # id: SeniorPhysicianBeret
+  # equipment: SeniorPhysicianBeret
+  # # effects:
+  # # - !type:GroupLoadoutEffect
+  # #   proto: SeniorPhysician
 
 - type: startingGear
   id: SeniorPhysicianBeret

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -27,10 +27,10 @@
   # # - !type:GroupLoadoutEffect
   # #   proto: SeniorPhysician
 
-- type: startingGear
-  id: SeniorPhysicianBeret
-  equipment:
-    head: ClothingHeadHatBeretSeniorPhysician
+# - type: startingGear
+  # id: SeniorPhysicianBeret
+  # equipment:
+    # head: ClothingHeadHatBeretSeniorPhysician
 
 - type: loadout
   id: MedicalBeret

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1014,7 +1014,7 @@
   minLimit: 0
   loadouts:
   - MedicalBeret
-  - SeniorPhysicianBeret
+  # - SeniorPhysicianBeret
   - BlueSurgeryCap
   - GreenSurgeryCap
   - PurpleSurgeryCap

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Civilian/private_investigator.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Civilian/private_investigator.yml
@@ -1,0 +1,121 @@
+# Back
+- type: loadout
+  id: PrivateInvestigatorBackpack
+  equipment: PrivateInvestigatorBackpack
+
+- type: startingGear
+  id: PrivateInvestigatorBackpack
+  equipment:
+    back: ClothingBackpackPrivateInvestigatorFilled
+
+- type: loadout
+  id: PrivateInvestigatorSatchel
+  equipment: PrivateInvestigatorSatchel
+
+- type: startingGear
+  id: PrivateInvestigatorSatchel
+  equipment:
+    back: ClothingBackpackSatchelPrivateInvestigatorFilled
+
+- type: loadout
+  id: PrivateInvestigatorDuffel
+  equipment: PrivateInvestigatorDuffel
+
+- type: startingGear
+  id: PrivateInvestigatorDuffel
+  equipment:
+    back: ClothingBackpackDuffelPrivateInvestigatorFilled
+
+# Outerclothing
+- type: loadout
+  id: JensonCoat
+  equipment: JensonCoat
+
+- type: startingGear
+  id: JensonCoat
+  equipment:
+    outerClothing: ClothingOuterCoatJensen
+
+- type: loadout
+  id: InspectorCoat
+  equipment: InspectorCoat
+
+- type: startingGear
+  id: InspectorCoat
+  equipment:
+    outerClothing: ClothingOuterCoatInspector
+
+- type: loadout
+  id: TrenchCoat
+  equipment: TrenchCoat
+
+- type: startingGear
+  id: TrenchCoat
+  equipment:
+    outerClothing: ClothingOuterCoatTrench
+
+# Gloves
+- type: loadout
+  id: BlackGloves
+  equipment: BlackGloves
+
+- type: startingGear
+  id: BlackGloves
+  equipment:
+    gloves: ClothingHandsGlovesColorBlack
+
+# Shoes
+- type: loadout
+  id: Jackboots
+  equipment: Jackboots
+
+- type: startingGear
+  id: Jackboots
+  equipment:
+    shoes: ClothingShoesBootsJack
+
+- type: loadout
+  id: LaceupShoes
+  equipment: LaceupShoes
+
+- type: startingGear
+  id: LaceupShoes
+  equipment:
+    shoes: ClothingShoesBootsLaceup
+
+- type: loadout
+  id: LeatherShoes
+  equipment: LeatherShoes
+
+- type: startingGear
+  id: LeatherShoes
+  equipment:
+    shoes: ClothingShoesLeather
+
+# Glasses
+- type: loadout
+  id: Sunglasses
+  equipment: Sunglasses
+
+- type: startingGear
+  id: Sunglasses
+  equipment:
+    eyes: ClothingEyesGlassesSunglasses
+
+- type: loadout #Upstream merge will add a second glasses entry.
+  id: Glasses
+  equipment: Glasses
+
+- type: startingGear
+  id: Glasses
+  equipment:
+    eyes: ClothingEyesGlasses
+
+- type: loadout
+  id: Aviators
+  equipment: Aviators
+
+- type: startingGear
+  id: Aviators
+  equipment:
+    eyes: ClothingEyesGlassesAviator

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Engineering/senior_engineer.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Engineering/senior_engineer.yml
@@ -1,0 +1,18 @@
+# Jumpsuit
+- type: loadout
+  id: SeniorEngineerJumpsuit
+  equipment: SeniorEngineerJumpsuit
+
+- type: startingGear
+  id: SeniorEngineerJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSeniorEngineer
+
+- type: loadout
+  id: SeniorEngineerJumpskirt
+  equipment: SeniorEngineerJumpskirt
+
+- type: startingGear
+  id: SeniorEngineerJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtSeniorEngineer

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Medical/senior_physician.yml
@@ -1,0 +1,38 @@
+# Head
+- type: loadout
+  id: SeniorPhysicianBeret
+  equipment: SeniorPhysicianBeret
+
+- type: startingGear
+  id: SeniorPhysicianBeret
+  equipment:
+    head: ClothingHeadHatBeretSeniorPhysician
+
+# Jumpsuit
+- type: loadout
+  id: SeniorPhysicianJumpsuit
+  equipment: SeniorPhysicianJumpsuit
+
+- type: startingGear
+  id: SeniorPhysicianJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSeniorPhysician
+
+- type: loadout
+  id: SeniorPhysicianJumpskirt
+  equipment: SeniorPhysicianJumpskirt
+
+- type: startingGear
+  id: SeniorPhysicianJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtSeniorPhysician
+
+# OuterClothing
+- type: loadout 
+  id: SeniorPhysicianLabCoat
+  equipment: SeniorPhysicianLabCoat
+
+- type: startingGear
+  id: SeniorPhysicianLabCoat
+  equipment:
+    outerClothing: ClothingOuterCoatLabSeniorPhysician

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Science/senior_researcher.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Science/senior_researcher.yml
@@ -1,0 +1,28 @@
+# Jumpsuit
+- type: loadout
+  id: SeniorResearcherJumpsuit
+  equipment: SeniorResearcherJumpsuit
+
+- type: startingGear
+  id: SeniorResearcherJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSeniorResearcher
+
+- type: loadout
+  id: SeniorResearcherJumpskirt
+  equipment: SeniorResearcherJumpskirt
+
+- type: startingGear
+  id: SeniorResearcherJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtSeniorResearcher
+
+# OuterClothing
+- type: loadout
+  id: SeniorResearcherLabCoat
+  equipment: SeniorResearcherLabCoat
+
+- type: startingGear
+  id: SeniorResearcherLabCoat
+  equipment:
+    outerClothing: ClothingOuterCoatLabSeniorResearcher

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Security/senior_officer.yml
@@ -1,0 +1,18 @@
+# Jumpsuit
+- type: loadout
+  id: SeniorOfficerJumpsuit
+  equipment: SeniorOfficerJumpsuit
+
+- type: startingGear
+  id: SeniorOfficerJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSeniorOfficer
+
+- type: loadout
+  id: SeniorOfficerJumpskirt
+  equipment: SeniorOfficerJumpskirt
+
+- type: startingGear
+  id: SeniorOfficerJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtSeniorOfficer

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Wildcards/prisoner.yml
@@ -1,0 +1,18 @@
+# Jumpsuit
+- type: loadout
+  id: PrisonerJumpsuit
+  equipment: PrisonerJumpsuit
+
+- type: startingGear
+  id: PrisonerJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitPrisoner
+
+- type: loadout
+  id: PrisonerJumpskirt
+  equipment: PrisonerJumpskirt
+
+- type: startingGear
+  id: PrisonerJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtPrisoner

--- a/Resources/Prototypes/_CD/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_CD/Loadouts/loadout_groups.yml
@@ -1,0 +1,134 @@
+# Civilian
+- type: loadoutGroup
+  id: PrivateInvestigatorBackpack
+  name: loadout-group-private-investigator-backpack
+  loadouts:
+  - PrivateInvestigatorBackpack
+  - PrivateInvestigatorSatchel
+  - PrivateInvestigatorDuffel
+
+- type: loadoutGroup
+  id: PrivateInvestigatorOuterClothing
+  name: loadout-group-private-investigator-outerclothing
+  minLimit: 0
+  loadouts:
+  - JensonCoat
+  - BartenderVest
+  - InspectorCoat
+  - TrenchCoat
+
+- type: loadoutGroup
+  id: PrivateInvestigatorGloves
+  name: loadout-group-private-investigator-gloves
+  minLimit: 0
+  loadouts:
+  - BlackGloves
+  - LatexGloves
+
+- type: loadoutGroup
+  id: PrivateInvestigatorShoes
+  name: loadout-group-private-investigator-shoes
+  loadouts:
+  - Jackboots
+  - BlackShoes
+  - LaceupShoes
+  - BrownShoes
+  - LeatherShoes
+
+- type: loadoutGroup
+  id: PrivateInvestigatorGlasses
+  name: loadout-group-private-investigator-glasses
+  minLimit: 0
+  loadouts:
+  - Sunglasses
+  - Glasses
+  - Aviators
+
+# Engineering
+- type: loadoutGroup
+  id: SeniorEngineerJumpsuit
+  name: loadout-group-senior-engineer-jumpsuit
+  loadouts:
+  - SeniorEngineerJumpsuit
+  - SeniorEngineerJumpskirt
+  - StationEngineerJumpsuit
+  - StationEngineerJumpskirt
+  - StationEngineerHazardsuit
+
+# Science
+- type: loadoutGroup
+  id: SeniorResearcherJumpsuit
+  name: loadout-group-senior-researcher-jumpsuit
+  loadouts:
+  - SeniorResearcherJumpsuit
+  - SeniorResearcherJumpskirt
+  - ScientistJumpsuit
+  - ScientistJumpskirt
+  - RoboticistJumpsuit
+  - RoboticistJumpskirt
+
+- type: loadoutGroup
+  id: SeniorResearcherOuterClothing
+  name: loadout-group-senior-researcher-outerclothing
+  minLimit: 0
+  loadouts:
+  - SeniorResearcherLabCoat
+  - RegularLabCoat
+  - ScienceLabCoat
+  - ScienceWintercoat
+  - RoboticistLabCoat
+  - RoboticistWintercoat
+
+# Security
+- type: loadoutGroup
+  id: SeniorOfficerJumpsuit
+  name: loadout-group-senior-officer-jumpsuit
+  loadouts:
+  - SeniorOfficerJumpsuit
+  - SeniorOfficerJumpskirt
+  - SecurityJumpsuit
+  - SecurityJumpskirt
+  - SecurityJumpsuitGrey
+  - SecurityJumpskirtGrey
+
+# Medical
+- type: loadoutGroup
+  id: SeniorPhysicianHead
+  name: loadout-group-senior-physician-head
+  minLimit: 0
+  loadouts:
+  - SeniorPhysicianBeret
+  - MedicalBeret
+  - BlueSurgeryCap
+  - GreenSurgeryCap
+  - PurpleSurgeryCap
+  - NurseHat
+
+- type: loadoutGroup
+  id: SeniorPhysicianJumpsuit
+  name: loadout-group-senior-physician-jumpsuit
+  loadouts:
+  - SeniorPhysicianJumpsuit
+  - SeniorPhysicianJumpskirt
+  - MedicalDoctorJumpsuit
+  - MedicalDoctorJumpskirt
+  - MedicalBlueScrubs
+  - MedicalGreenScrubs
+  - MedicalPurpleScrubs
+
+- type: loadoutGroup
+  id: SeniorPhysicianOuterClothing
+  name: loadout-group-senior-physician-outerclothing
+  minLimit: 0
+  loadouts:
+  - SeniorPhysicianLabCoat
+  - RegularLabCoat
+  - MedicalDoctorWintercoat
+
+# Wildcards
+- type: loadoutGroup
+  id: PrisonerJumpsuit
+  name: loadout-group-prisoner-jumpsuit
+  loadouts:
+  - PrisonerJumpsuit
+  - PrisonerJumpskirt

--- a/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
@@ -1,0 +1,68 @@
+# Civilian
+- type: roleLoadout
+  id: JobPrivateInvestigator
+  groups: #Using Detective groups is probably a bad idea, but it's easier this way.
+  - DetectiveHead
+  - DetectiveJumpsuit
+  - PrivateInvestigatorBackpack
+  - PrivateInvestigatorOuterClothing
+  - PrivateInvestigatorGloves
+  - PrivateInvestigatorShoes
+  - PrivateInvestigatorGlasses
+  - Trinkets
+
+# Engineering
+- type: roleLoadout
+  id: JobSeniorEngineer
+  groups:
+  - StationEngineerHead
+  - SeniorEngineerJumpsuit
+  - StationEngineerBackpack
+  - StationEngineerOuterClothing
+  - StationEngineerShoes
+  - Trinkets
+
+# Science
+- type: roleLoadout
+  id: JobSeniorResearcher
+  groups:
+  - ScientistHead
+  - ScientistNeck
+  - SeniorResearcherJumpsuit
+  - ScientistBackpack
+  - SeniorResearcherOuterClothing
+  - ScientistGloves
+  - ScientistShoes
+  - Trinkets
+
+# Security
+- type: roleLoadout
+  id: JobSeniorOfficer
+  groups:
+  - SecurityHead
+  - SeniorOfficerJumpsuit
+  - SecurityBackpack
+  - SecurityOuterClothing
+  - SecurityShoes
+  - SecurityBelt
+  - Trinkets
+
+# Medical
+- type: roleLoadout
+  id: JobSeniorPhysician
+  groups:
+  - SeniorPhysicianHead
+  - MedicalMask
+  - SeniorPhysicianJumpsuit
+  - MedicalGloves
+  - MedicalBackpack
+  - SeniorPhysicianOuterClothing
+  - MedicalShoes
+  - Trinkets
+
+# Wildcards
+- type: roleLoadout
+  id: JobPrisoner
+  groups:
+  - PrisonerJumpsuit
+  - Trinkets

--- a/Resources/Prototypes/_CD/Roles/Jobs/Civilian/private_investigator.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Civilian/private_investigator.yml
@@ -13,11 +13,5 @@
 - type: startingGear
   id: PrivateInvestigatorGear
   equipment:
-    jumpsuit: ClothingUniformJumpsuitDetectiveGrey # Technically a detective outfit but only in ID
-    back: ClothingBackpackPrivateInvestigatorFilled
-    shoes: ClothingShoesBootsJack
-    eyes: ClothingEyesGlassesSunglasses # They keep these
-    head: ClothingHeadHatFedoraGrey
     id: PrivateInvestigatorPDA
     ears: ClothingHeadsetService
-    gloves: ClothingHandsGlovesColorBlack

--- a/Resources/Prototypes/_CD/Roles/Jobs/Engineering/senior_engineer.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Engineering/senior_engineer.yml
@@ -18,10 +18,6 @@
 - type: startingGear
   id: SeniorEngineerGear
   equipment:
-    head: ClothingHeadHatBeretEngineering
-    jumpsuit: ClothingUniformJumpsuitSeniorEngineer
-    back: ClothingBackpackEngineeringFilled
-    shoes: ClothingShoesBootsWork
     id: SeniorEngineerPDA
     eyes: ClothingEyesGlassesMeson
     belt: ClothingBeltUtilityEngineering

--- a/Resources/Prototypes/_CD/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Medical/senior_physician.yml
@@ -17,11 +17,6 @@
 - type: startingGear
   id: SeniorPhysicianGear
   equipment:
-    head: ClothingHeadHatBeretSeniorPhysician
-    jumpsuit: ClothingUniformJumpsuitSeniorPhysician
-    back: ClothingBackpackMedicalFilled
-    shoes: ClothingShoesColorBlack
-    outerClothing: ClothingOuterCoatLabSeniorPhysician
     id: SeniorPhysicianPDA
     ears: ClothingHeadsetMedical
     belt: ClothingBeltMedicalFilled

--- a/Resources/Prototypes/_CD/Roles/Jobs/Science/senior_researcher.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Science/senior_researcher.yml
@@ -13,10 +13,5 @@
 - type: startingGear
   id: SeniorResearcherGear
   equipment:
-    head: ClothingHeadHatBeretRND
-    jumpsuit: ClothingUniformJumpsuitSeniorResearcher
-    back: ClothingBackpackScienceFilled
-    shoes: ClothingShoesColorBlack
-    outerClothing: ClothingOuterCoatLabSeniorResearcher
     id: SeniorResearcherPDA
     ears: ClothingHeadsetScience

--- a/Resources/Prototypes/_CD/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Security/senior_officer.yml
@@ -23,13 +23,7 @@
 - type: startingGear
   id: SeniorOfficerGear
   equipment:
-    jumpsuit: ClothingUniformJumpsuitSeniorOfficer
-    back: ClothingBackpackSecurityFilled
-    shoes: ClothingShoesBootsCombatFilled
     eyes: ClothingEyesGlassesSecurity
-    head: ClothingHeadHatBeretSecurity
-    outerClothing: ClothingOuterArmorBasic
     id: SeniorOfficerPDA
     ears: ClothingHeadsetSecurity
-    belt: ClothingBeltSecurityFilled
     pocket1: WeaponPistolMk58

--- a/Resources/Prototypes/_CD/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Wildcards/prisoner.yml
@@ -14,7 +14,6 @@
 - type: startingGear
   id: PrisonerGear
   equipment:
-    jumpsuit: ClothingUniformJumpsuitPrisoner
     shoes: ClothingShoesColorBlack
     id: PrisonerPDA
     ears: ClothingHeadsetGrey


### PR DESCRIPTION
## About the PR
Patches all the senior, PI, and prisoner roles to have loadouts. (Primarily just their jumpsuit choice due to that being rolled into loadouts.)

Normal medical doctors don't get access to the physician beret anymore.
I also gave PI a grab bag of items that seemed to fit their theme in their loadout, but apart from that touched basically nothing else.

## Why / Balance
Mostly just because not being able to pick between bags or jumpsuit/skirt choice sucks.

**Changelog**
CD roles (seniors, private investigator, and prisoner) now have loadouts.