### PR TITLE
Stowaway trait

### DIFF
--- a/Content.Server/Spawners/Components/ContainerSpawnPointComponent.cs
+++ b/Content.Server/Spawners/Components/ContainerSpawnPointComponent.cs
@@ -1,4 +1,5 @@
 using Content.Server.Spawners.EntitySystems;
+using Content.Shared.Whitelist;
 
 namespace Content.Server.Spawners.Components;
 
@@ -21,6 +22,12 @@ public sealed partial class ContainerSpawnPointComponent : Component, ISpawnPoin
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public string? Job;
+
+    /// <summary>
+    /// Only entities with this component will be spawned
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Whitelist = null;
 
     /// <summary>
     /// The type of spawn point

--- a/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
@@ -67,6 +67,9 @@ public sealed class ContainerSpawnPointSystem : EntitySystem
             if (!_container.TryGetContainer(uid, spawnPoint.ContainerId, out var container, manager))
                 continue;
 
+            if (spawnPoint.Whitelist != null && !spawnPoint.Whitelist.IsValid(args.SpawnResult.Value))
+                continue; // This specific entity doesn't fit with the SpawnPoint's filter
+
             if (!_container.Insert(args.SpawnResult.Value, container, containerXform: xform))
                 continue;
 

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -8,6 +8,7 @@ using Content.Server.PDA;
 using Content.Server.Shuttles.Systems;
 using Content.Server.Spawners.EntitySystems;
 using Content.Server.Station.Components;
+using Content.Server.Traits;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.CCVar;
@@ -48,6 +49,7 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
     [Dependency] private readonly SharedAccessSystem _accessSystem = default!;
     [Dependency] private readonly IdentitySystem _identity = default!;
     [Dependency] private readonly MetaDataSystem _metaSystem = default!;
+    [Dependency] private readonly TraitSystem _traitSystem = default!;
 
     [Dependency] private readonly ArrivalsSystem _arrivalsSystem = default!;
     [Dependency] private readonly ContainerSpawnPointSystem _containerSpawnPointSystem = default!;
@@ -233,6 +235,7 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
             {
                 AddComp<DetailExaminableComponent>(entity.Value).Content = profile.FlavorText;
             }
+            _traitSystem.TryAddTraits(entity.Value, profile);
         }
 
         DoJobSpecials(job, entity.Value);

--- a/Content.Server/_CD/Stowaway/StowawayComponent.cs
+++ b/Content.Server/_CD/Stowaway/StowawayComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Server._CD.Stowaway;
+
+/// <summary>
+/// Marks an entity as a stowaway. This means they will be parented to a random crate/closet on the station.
+/// </summary>
+[RegisterComponent]
+public sealed partial class StowawayComponent : Component
+{
+
+}

--- a/Resources/Locale/en-US/_CD/traits/traits.ftl
+++ b/Resources/Locale/en-US/_CD/traits/traits.ftl
@@ -1,2 +1,5 @@
 trait-synth-name = Synthetic
 trait-synth-desc = You are a biomechanical construct, who bleeds coolant and is notified of ongoing Ion Storms.
+
+trait-stowaway-name = Stowaway
+trait-stowaway-desc = You are not employed at NT. You instead, spawn hiding in a random closet/crate.

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -96,6 +96,11 @@
   id: ClosetSteelBase
   parent: ClosetBase
   components:
+  - type: ContainerSpawnPoint
+    containerId: entity_storage
+    whitelist:
+      components:
+      - Stowaway
   - type: Construction
     graph: ClosetSteel
     node: done

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -33,6 +33,11 @@
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
+    - type: ContainerSpawnPoint
+      containerId: entity_storage
+      whitelist:
+        components:
+        - Stowaway
     - type: Damageable
       damageContainer: Box
     - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -81,6 +81,11 @@
     containers:
       entity_storage: !type:Container
       paper_label: !type:ContainerSlot
+  - type: ContainerSpawnPoint
+    containerId: entity_storage
+    whitelist:
+      components:
+      - Stowaway
   - type: ItemSlots
   - type: StaticPrice
     price: 50

--- a/Resources/Prototypes/_CD/Traits/traits.yml
+++ b/Resources/Prototypes/_CD/Traits/traits.yml
@@ -3,4 +3,11 @@
   name: trait-synth-name
   description: trait-synth-desc
   components:
-    - type: Synth
+  - type: Synth
+
+- type: trait
+  id: Stowaway
+  name: trait-stowaway-name
+  description: trait-stowaway-desc
+  components:
+  - type: Stowaway


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Adds the "stowaway" trait, which removes anything within a players PDA slot, alongside spawning them inside of a closet/crate.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

I thought it would be cool.

## Technical/breaking details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Makes the PlayerSpawningEvent of TraitSystem public, and instead spawns the traits **on** player spawn instead of after (after as in once a spawn has been picked).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/cosmatic-drift-14/cosmatic-drift/assets/67359748/b3f74e92-9ea0-4fc9-9d02-cca85ef8f7ae

Please do your best to ignore the music in the video.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: The Stowaway trait has been added. It will spawn you in a random unmarked crate/closet without your PDA.
