### PR TITLE
Map Pop Fixes

### DIFF
--- a/Resources/Prototypes/Maps/atlas.yml
+++ b/Resources/Prototypes/Maps/atlas.yml
@@ -2,8 +2,8 @@
   id: Atlas
   mapName: Atlas
   mapPath: /Maps/atlas.yml
-  minPlayers: 0
-  maxPlayers: 15
+  minPlayers: 0 #CD change
+  maxPlayers: 15 #CD change
   stations:
     Atlas:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -2,8 +2,8 @@
   id: Bagel
   mapName: 'Bagel Station'
   mapPath: /Maps/bagel.yml
-  minPlayers: 25
-  maxPlayers: 55
+  minPlayers: 25 #CD change
+  maxPlayers: 55 #CD change
   stations:
     Bagel:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -2,7 +2,7 @@
   id: Box
   mapName: 'Box Station'
   mapPath: /Maps/box.yml
-  minPlayers: 35
+  minPlayers: 35 #CD
   stations:
     Boxstation:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -2,8 +2,8 @@
   id: Cluster
   mapName: 'Cluster'
   mapPath: /Maps/cluster.yml
-  minPlayers: 5
-  maxPlayers: 25
+  minPlayers: 5 #CD change
+  maxPlayers: 25 #CD change
   stations:
     Cluster:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -2,8 +2,8 @@
   id: Core
   mapName: 'Core'
   mapPath: /Maps/core.yml
-  minPlayers: 25
-  maxPlayers: 35
+  minPlayers: 25 #CD change
+  maxPlayers: 35 #CD change
   stations:
     Core:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -2,8 +2,8 @@
   id: Marathon
   mapName: 'Marathon Station'
   mapPath: /Maps/marathon.yml
-  minPlayers: 35
-  maxPlayers: 70
+  minPlayers: 25 #CD change
+  maxPlayers: 55 #CD change
   stations:
     Marathon:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -2,7 +2,7 @@
   id: Meta
   mapName: 'Meta Station'
   mapPath: /Maps/meta.yml
-  minPlayers: 35
+  minPlayers: 35 #CD change
   stations:
     Meta:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -2,7 +2,7 @@
   id: Oasis
   mapName: 'Oasis'
   mapPath: /Maps/oasis.yml
-  minPlayers: 70
+  minPlayers: 35 #CD change
   stations:
     Oasis:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -2,8 +2,8 @@
   id: Omega
   mapName: 'Omega'
   mapPath: /Maps/omega.yml
-  minPlayers: 5
-  maxPlayers: 25
+  minPlayers: 5 #CD change
+  maxPlayers: 25 #CD change
   stations:
     Omega:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/origin.yml
+++ b/Resources/Prototypes/Maps/origin.yml
@@ -2,7 +2,7 @@
   id: Origin
   mapName: 'Origin'
   mapPath: /Maps/origin.yml
-  minPlayers: 45
+  minPlayers: 45 #CD change
   stations:
     Origin:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -3,7 +3,7 @@
   mapName: 'Packed'
   mapPath: /Maps/packed.yml
   minPlayers: 5
-  maxPlayers: 40
+  maxPlayers: 25 #CD change
   stations:
     Packed:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -3,7 +3,7 @@
   mapName: 'Reach'
   mapPath: /Maps/reach.yml
   minPlayers: 0
-  maxPlayers: 7
+  maxPlayers: 5 #CD change
   stations:
     Reach:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -3,7 +3,7 @@
   mapName: 'Saltern'
   mapPath: /Maps/saltern.yml
   minPlayers: 0
-  maxPlayers: 15
+  maxPlayers: 15 #CD change
   fallback: true
   stations:
     Saltern:


### PR DESCRIPTION
## About the PR
Changes Oasis to 35 minimum players, akin to Meta and Box.
Fixes Reach, Packed, and Marathon prototypes that were edited by an Upstream merge.
Labels all map prototype changes with CD markers.

## Why / Balance
Oasis looks about Box sized.
The rest are just fixes.