### PR TITLE
change trash bag storage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -32,7 +32,7 @@
     slots: [belt]
     sprite: Objects/Specific/Janitorial/trashbag.rsi
   - type: Item
-    size: 125
+    size: 10 
 
 - type: entity
   name: trash bag


### PR DESCRIPTION
Jank mobile webedit
To allow people to put it on belts and generally carry it around easier. Not that worried about trash arbitrage. 