### PR TITLE
Double SMES capacity 

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -32,7 +32,7 @@
     - type: Appearance
     - type: Battery
       startingCharge: 0
-      maxCharge: 8000000
+      maxCharge: 16000000
     - type: ExaminableBattery
     - type: NodeContainer
       examinable: true
@@ -95,11 +95,11 @@
 - type: entity
   parent: BaseSMES
   id: SMESBasic
-  suffix: Basic, 8MW
+  suffix: Basic, 8MW # CD: 16MW
   components:
   - type: Battery
-    maxCharge: 8000000
-    startingCharge: 8000000
+    maxCharge: 16000000
+    startingCharge: 16000000
 
 - type: entity
   parent: SMESBasic

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -32,7 +32,7 @@
     - type: Appearance
     - type: Battery
       startingCharge: 0
-      maxCharge: 16000000
+      maxCharge: 16000000 # CD: Buffed from 8MW
     - type: ExaminableBattery
     - type: NodeContainer
       examinable: true
@@ -95,7 +95,7 @@
 - type: entity
   parent: BaseSMES
   id: SMESBasic
-  suffix: Basic, 8MW # CD: 16MW
+  suffix: Basic, 16MW # CD: Buffed from 16MW
   components:
   - type: Battery
     maxCharge: 16000000


### PR DESCRIPTION
Jank mobile webedit 2
Necessary for our arrivals system to prevent power from running out roundstart. Also better to prevent constant blackouts. 