### PR TITLE
Add loadout for security glasses vs hud

### DIFF
--- a/Resources/Locale/en-US/_CD/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_CD/preferences/loadout-groups.ftl
@@ -14,6 +14,7 @@ loadout-group-senior-researcher-outerclothing = Senior Researcher outer clothing
 
 # Security
 loadout-group-senior-officer-jumpsuit = Senior Officer jumpsuit
+loadout-group-security-glasses-or-hud = Security Glasses
 
 # Medical
 loadout-group-senior-physician-head = Senior Physician head

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -242,6 +242,7 @@
   - SecurityBelt
   - HeadofSecurityOuterClothing
   - SecurityShoes
+  - SecurityGlassesOrHud # CD Addition
   - Trinkets
 
 - type: roleLoadout
@@ -253,6 +254,7 @@
   - SecurityBelt
   - WardenOuterClothing
   - SecurityShoes
+  - SecurityGlassesOrHud # CD Addition
   - Trinkets
 
 - type: roleLoadout
@@ -265,6 +267,7 @@
   - SecurityShoes
   - SecurityPDA
   - SecurityBelt
+  - SecurityGlassesOrHud # CD Addition
   - Trinkets
 
 - type: roleLoadout
@@ -276,6 +279,7 @@
   - DetectiveBackpack
   - DetectiveOuterClothing
   - SecurityShoes
+  - SecurityGlassesOrHud # CD Addition
   - Trinkets
 
 - type: roleLoadout
@@ -283,6 +287,7 @@
   groups:
   - SecurityCadetJumpsuit
   - SecurityBackpack
+  - SecurityGlassesOrHud # CD Addition
   - Trinkets
 
 # Medical

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Security/security_officer.yml
@@ -1,0 +1,17 @@
+- type: loadout
+  id: EyesGlassesSecurity
+  equipment: EyesGlassesSecurity
+
+- type: startingGear
+  id: EyesGlassesSecurity
+  equipment:
+    eyes: ClothingEyesGlassesSecurity
+
+- type: loadout
+  id: EyesHudSecurity
+  equipment: EyesHudSecurity
+
+- type: startingGear
+  id: EyesHudSecurity
+  equipment:
+    eyes: ClothingEyesHudSecurity

--- a/Resources/Prototypes/_CD/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_CD/Loadouts/loadout_groups.yml
@@ -91,6 +91,13 @@
   - SecurityJumpsuitGrey
   - SecurityJumpskirtGrey
 
+- type: loadoutGroup
+  id: SecurityGlassesOrHud
+  name: loadout-group-security-glasses-or-hud
+  loadouts:
+  - EyesGlassesSecurity
+  - EyesHudSecurity
+
 # Medical
 - type: loadoutGroup
   id: SeniorPhysicianHead

--- a/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
@@ -45,6 +45,7 @@
   - SecurityOuterClothing
   - SecurityShoes
   - SecurityBelt
+  - SecurityGlassesOrHud
   - Trinkets
 
 # Medical


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Add the ability for security to chose between sechuds and sec glasses in the loadout editor.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It was annoying me this was not the case.

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Aquif
- add: Security can now select sechuds via loadouts.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
