### PR TITLE
Hopefully mix the missing records issue.

### DIFF
--- a/Content.Server/_CD/Records/CharacterRecordsSystem.cs
+++ b/Content.Server/_CD/Records/CharacterRecordsSystem.cs
@@ -36,13 +36,10 @@ public sealed class CharacterRecordsSystem : EntitySystem
             AddComp<CharacterRecordsComponent>(args.Station);
 
         var profile = args.Profile;
-        var broken = false;
         if (profile.CDCharacterRecords == null)
         {
-            // FIXME: I have no clue what is the root cause of this issue. If you see a player with this, tell them to make some (small) change to their records and resave them.
-            // Right now we apply a baindaid fix of giving them default records.
-            Log.Error($"Null records in CharacterRecordsSystem::OnPlayerSpawn for character {args.Profile.Name} played by {args.Player.Name}. Assuming default records.");
-            broken = true;
+            Log.Error($"Null records in CharacterRecordsSystem::OnPlayerSpawn for character {args.Profile.Name} played by {args.Player.Name}.");
+            return;
         }
         if (string.IsNullOrEmpty(args.JobId))
         {
@@ -61,7 +58,7 @@ public sealed class CharacterRecordsSystem : EntitySystem
         TryComp<DnaComponent>(player, out var dnaComponent);
 
         var records = new FullCharacterRecords(
-            characterRecords: !broken ? new CharacterRecords(profile.CDCharacterRecords!) : CharacterRecords.DefaultRecords(),
+            characterRecords: new CharacterRecords(profile.CDCharacterRecords),
             stationRecordsKey: FindStationRecordsKey(player),
             name: profile.Name,
             age: profile.Age,

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -218,7 +218,7 @@ namespace Content.Shared.Preferences
                 new Dictionary<string, JobPriority>
                 {
                     {SharedGameTicker.FallbackOverflowJob, JobPriority.High},
-                }, PreferenceUnavailableMode.StayInLobby, new List<string>(), new List<string>(), new Dictionary<string, RoleLoadout>(), null);
+                }, PreferenceUnavailableMode.StayInLobby, new List<string>(), new List<string>(), new Dictionary<string, RoleLoadout>(), CharacterRecords.DefaultRecords());
         }
 
         public string Name { get; private set; }

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -539,8 +539,15 @@ namespace Content.Shared.Preferences
             _traitPreferences.Clear();
             _traitPreferences.AddRange(traits);
 
-            CDCharacterRecords?.EnsureValid();
-            
+            if (CDCharacterRecords == null)
+            {
+                CDCharacterRecords = CharacterRecords.DefaultRecords();
+            }
+            else
+            {
+                CDCharacterRecords!.EnsureValid();
+            }
+
             // Checks prototypes exist for all loadouts and dump / set to default if not.
             var toRemove = new ValueList<string>();
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Add some additional logging statements to the event handler that initializes records.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Somehow, profiles get passed to the character records system that don't have records. I think that after this PR all possibilities for this case have been closed. The commit message for 1aca376bbfd2685cf7eeadeea154d142f3850e16 has more info.

:cl: Aquif
- fix: Hopefully fix the issue causing character records to not show up in game for some characters. Please let aquif know if the issue still persists. 

