### PR TITLE
Skeleton Rules

### DIFF
--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -146,8 +146,11 @@ ghost-role-information-skeleton-pirate-description = Cause chaos and loot the st
 ghost-role-information-skeleton-biker-name = Skeleton Biker
 ghost-role-information-skeleton-biker-description = Ride around on your sweet ride.
 
+#CD changes below
 ghost-role-information-closet-skeleton-name = Closet Skeleton
-ghost-role-information-closet-skeleton-description = Wreak havoc! You are a primordial force with no allegiance. Live happily with the crew or wage sweet skeletal war.
+ghost-role-information-closet-skeleton-description = You are a primordial force with no allegiance. Follow your skeletal whims.
+ghost-role-information-closet-skeleton-rules = All rules apply. [color=red]THIS MEANS YOU ARE STILL SUBJECT TO SELF ANTAG RULES, AHELP FOR PERMISSION TO DO CRIMES.[/color]
+#CD changes above
 
 ghost-role-information-onestar-mecha-name = Onestar Mecha
 ghost-role-information-onestar-mecha-description = You are an experimental mecha created by who-knows-what, all you know is that you have weapons and you detect fleshy moving targets nearby...

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -44,6 +44,7 @@
   - type: GhostRole
     name: ghost-role-information-closet-skeleton-name
     description: ghost-role-information-closet-skeleton-description
+    rules: ghost-role-information-closet-skeleton-rules #CD change
   - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [LimitedPassengerGear]


### PR DESCRIPTION
## About the PR
Replaces closet skeleton rules to imply they are covered by self-antag rules.

## Why / Balance
Admin consensus.

## Media
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/110078045/62373f2e-9899-4211-9bec-096fa5240229)

**Changelog**
We usually don't do rule change alerts, but I believe this one is substantial enough to warrant. Skeletons are now held to the same antag standards as any crew, meaning they should ahelp for permission before committing crimes.