### PR TITLE
Increase ore bag capacity

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -14,9 +14,9 @@
     slots:
     - belt
   - type: Item
-    size: 176
+    size: 241
   - type: Storage
-    capacity: 175
+    capacity: 240
     quickInsert: true
     areaInsert: true
     whitelist:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Ore bags can fit four stacks of ore now.
It's a webedit, but it should work, right? :clueless:

## Why / Balance
Salvaging with the previous ore bag capacity was kind of painful - 175 was only enough room for slightly under three stacks. Now it should be less painful.

## Technical details
This changes two numbers - it sets the capacity to 240, and the size to 241, in line with the old capacity and size (175 and 176 respectively).

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Shouldn't break anything, I'd hope.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Ore bags can now fit considerably more ore.