### PR TITLE
Whitelist vulp emotes to vulpkin

### DIFF
--- a/Resources/Prototypes/_CD/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_CD/Entities/Mobs/Species/vulpkanin.yml
@@ -20,6 +20,7 @@
   - type: Speech
     speechSounds: Vulpkanin
     speechVerb: Vulpkanin
+    allowedEmotes: [ 'Bark', 'Snarl', 'Whine', 'Howl', 'Growl' ]
   # - type: TypingIndicator # If you wish to add a typing indicator, go to Textures/_CD/Effects/speech.rsi and uncomment this.
   #   proto: vulpkanin
   - type: Vocal

--- a/Resources/Prototypes/_CD/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_CD/Voice/speech_emotes.yml
@@ -3,6 +3,13 @@
   id: Bark
   name: chat-emote-name-bark
   category: Vocal
+  available: false
+  whitelist:
+    components:
+    - Vocal
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [barks.]
   chatTriggers:
     - bark
@@ -19,6 +26,13 @@
   id: Snarl
   name: chat-emote-name-snarl
   category: Vocal
+  available: false
+  whitelist:
+    components:
+    - Vocal
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [snarls.]
   chatTriggers:
     - snarl
@@ -35,6 +49,13 @@
   id: Whine
   name: chat-emote-name-whine
   category: Vocal
+  available: false
+  whitelist:
+    components:
+    - Vocal
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [whines.]
   chatTriggers:
     - whine
@@ -51,6 +72,13 @@
   id: Howl
   name: chat-emote-name-howl
   category: Vocal
+  available: false
+  whitelist:
+    components:
+    - Vocal
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [howls.]
   chatTriggers:
     - howl
@@ -66,6 +94,13 @@
   id: Growl
   name: chat-emote-name-growl
   category: Vocal
+  available: false
+  whitelist:
+    components:
+    - Vocal
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [growls.]
   chatTriggers:
     - growl


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title. The vulp emote wheel is still a bit too crowded. However, I will leave
that for someone else to fix.

**Changelog**

:cl: Aquif
- fix: Vulpkin emotes can no longer be used by non-Vulpkin.
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
