### PR TITLE
Adjusted Oasis Roles

### DIFF
--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -31,11 +31,13 @@
             Zookeeper: [ 1, 1 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
+            SeniorEngineer: [ 1, 1 ] #CD role
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 5, 5 ]
             TechnicalAssistant: [ 4, 4 ]
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
+            SeniorPhysician: [ 1, 1 ] #CD role
             Chemist: [ 3, 3 ]
             MedicalDoctor: [ 6, 6 ]
             Paramedic: [ 2, 2 ]
@@ -43,16 +45,18 @@
             Psychologist: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
+            SeniorResearcher: [ 1, 1 ]  #CD role
             Scientist: [ 5, 5 ]
             ResearchAssistant: [ 6, 6 ]
             Borg: [ 2, 2 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 8, 8 ]
+            SeniorOfficer: [ 1, 1 ] #CD role
+            SecurityOfficer: [ 3, 3 ] #CD change to 3 from 8
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
-            Lawyer: [ 3, 3 ]
+            SecurityCadet: [ 2, 2 ] #CD change to 2 from 4
+            Lawyer: [ 2, 2 ] #CD change to 2 from 3
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]


### PR DESCRIPTION
## About the PR
Adds Senior Roles to Oasis.

And also adjusts the security roles;
- Security Officer: 8 -> 3
- Cadet: 4 -> 2
- Lawyer: 3 -> 2

## Why / Balance
Updating to match CD standards.