### PR TITLE
Adjust Unknown Shuttle Events

### DIFF
--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -43,20 +43,20 @@
   - type: LoadMapRule
     preloadedGrid: DisasterEvacPod
 
-- type: entity
-  id: UnknownShuttleHonki
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-    weight: 2
-    reoccurrenceDelay: 30
-    duration: 1
-  - type: LoadMapRule
-    preloadedGrid: Honki
+# - type: entity
+#   id: UnknownShuttleHonki
+#   parent: BaseGameRule
+#   noSpawn: true
+#   components:
+#   - type: StationEvent
+#     startAnnouncement: station-event-unknown-shuttle-incoming
+#     startAudio:
+#       path: /Audio/Announcements/attention.ogg
+#     weight: 2
+#     reoccurrenceDelay: 30
+#     duration: 1
+#   - type: LoadMapRule
+#     preloadedGrid: Honki
 
 - type: entity
   id: UnknownShuttleSyndieEvacPod
@@ -67,7 +67,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    weight: 2
+    weight: 1 #CD change from 2 to 1, if it happens too much we can flat out disable it.
     reoccurrenceDelay: 30
     duration: 1
   - type: LoadMapRule


### PR DESCRIPTION
## About the PR
Disables the clown shuttle.
Changes the syndicate evac shuttle to weight 1 from weight 2.

## Why / Balance
Clowns are insanely chaotic.
Syndicate forces can be stressful for security, but still good for RP as they're not geared to kill.