### PR TITLE
Nerf chance of reveanant

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -114,9 +114,9 @@
   noSpawn: true
   components:
   - type: StationEvent
-    weight: 2
+    weight: 1
     duration: 1
-    earliestStart: 45
+    earliestStart: 135
     minimumPlayers: 20
   - type: RandomSpawnRule
     prototype: MobRevenant


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Lowers the weight and the chance that Revenants will spawn and increases the minimum time.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
As discussed in discord they show up a bit too frequently and often dominate a
round. This makes them rarer and because they can only show up later in the
round they will be less of an issue if they show up.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Aquif
- tweak: Revenants should spawn less frequently.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
