### PR TITLE
Security QoL Rules

### DIFF
--- a/Resources/ServerInfo/Rules.txt
+++ b/Resources/ServerInfo/Rules.txt
@@ -40,7 +40,7 @@ Game admins have the final say on all rules, game issues, and punishments. We re
 [bullet] Try your best not to negatively affect absent or SSD players. Stealing, killing, and griefing these players is disallowed, however, things such as moving a player to a safe area or security performing a search acceptable.[/color]
 
 [color=#e6e6e6][color=#3bff72][bold]3.2 -[/bold][/color] Do not commit major crimes without admin approval. We are a server that permits crime in the effort to further RP story lines, however it must be kept non-intensive if you're doing it without the guidance of an admin.[color=#c4c4c4]
-[bullet] As a rule of thumb, if it harms anyone other than yourself, causes a public or work location to be unusable or unsafe, or involves the theft of irreplaceable gear such as command gear, you should ahelp. If you are unsure if what you're about to do is a minor or major crime, always ahelp.
+[bullet] As a rule of thumb, if it significantly harms anyone other than yourself, causes a public or work location to be unusable or unsafe, or involves the theft of irreplaceable gear such as command gear, you should ahelp. If you are unsure if what you're about to do is a minor or major crime, always ahelp.
 [bullet] After you are caught and punished in-characterly, you are expected not to do the same crime again that round without an admin's approval.
 [bullet] The arrivals station, arrivals shuttle, and end round Central Command station are entirely off-limits; do not grief, attack others, or do any antagonistic acts in these locations under any circumstance, even as an antagonist.[/color]
 

--- a/Resources/ServerInfo/Rules.txt
+++ b/Resources/ServerInfo/Rules.txt
@@ -35,22 +35,25 @@ Game admins have the final say on all rules, game issues, and punishments. We re
 [color=#e6e6e6]General rules and common practice. The "bare-minimum" expectations that you should be following.[/color]
 
 [color=#e6e6e6][color=#3bff72][bold]3.1 -[/bold][/color] Do not be a huge dick and try not to over-escalate. You are playing a roleplaying game with other real people. Do not go out of your way to ruin the experience of other players, and do not grief.[/color][color=#c4c4c4]
-[bullet] Doing antagonistic actions without being an antagonist is commonly called "self-antagging."
-[bullet] Due to the nature of an HRP server, some leeway will be granted in terms of minor self-antagging. This means roleplaying out minor crimes, as long as they are not taken over the top and do not become uninteresting. Try not to commit the same crimes repeatedly, especially after in-character punishment. Generally, you should always ahelp to ask for permission to do things such as these.
-[bullet] The arrivals station is entirely off-limits; do not grief, attack others, or do any antagonistic acts on the terminal under any circumstance (this also applies to antagonists).
-[bullet] Try to avoid permanently killing or "round-removing" other players. While this is acceptable if it is in pursuit of an antagonistic objective, it is generally frowned upon and should be avoided if possible.
+[bullet] Killing yourself while in security custody is considered being a dick, as they have little way to stop you without depriving you of your basic rights. If you wish to commit suicide while arrested ask to do so in ahelp.
+[bullet] Try to avoid permanently killing or "round-removing" other players. While this is acceptable if it is in pursuit of a direct antagonistic kill objective, it is generally frowned upon and should be avoided if possible.
 [bullet] Try your best not to negatively affect absent or SSD players. Stealing, killing, and griefing these players is disallowed, however, things such as moving a player to a safe area or security performing a search acceptable.[/color]
 
-[color=#e6e6e6][color=#3bff72][bold]3.2 -[/bold][/color] You are playing a high-roleplay server; speak and act like a human being. While playing in this server, you will be held to a higher standard of roleplay. With this being the case, you are expected to actively engage in roleplay when it comes up.[/color][color=#c4c4c4]
+[color=#e6e6e6][color=#3bff72][bold]3.2 -[/bold][/color] Do not commit major crimes without admin approval. We are a server that permits crime in the effort to further RP story lines, however it must be kept non-intensive if you're doing it without the guidance of an admin.[color=#c4c4c4]
+[bullet] As a rule of thumb, if it harms anyone other than yourself, causes a public or work location to be unusable or unsafe, or involves the theft of irreplaceable gear such as command gear, you should ahelp. If you are unsure if what you're about to do is a minor or major crime, always ahelp.
+[bullet] After you are caught and punished in-characterly, you are expected not to do the same crime again that round without an admin's approval.
+[bullet] The arrivals station, arrivals shuttle, and end round Central Command station are entirely off-limits; do not grief, attack others, or do any antagonistic acts in these locations under any circumstance, even as an antagonist.[/color]
+
+[color=#e6e6e6][color=#3bff72][bold]3.3 -[/bold][/color] You are playing a high-roleplay server; speak and act like a human being. While playing in this server, you will be held to a higher standard of roleplay. With this being the case, you are expected to actively engage in roleplay when it comes up.[/color][color=#c4c4c4]
 [bullet] Do not use text speech such as "omg," "idk," "wtf," or "lol."
 [bullet] Referring to gamey terms like "admins" or "RNG" is disallowed.
 [bullet] Do not abuse emotes to bypass chat filters. Emotes should represent actions that your character could actually perform. Emotes should have effort put into them; this means that you should not be typing things such as "John Doe motions with his hands to signal syndicate agents west of you."
 [bullet] Do not respond to events in a highly unbelievable manner, stick to how your character would react.[/color]
 
-[color=#e6e6e6][color=#3bff72][bold]3.3 -[/bold][/color] Do not disconnect, ghost, suicide, or otherwise intentionally permanently remove yourself from the round as an important role or while facing in-character punishment such as jail time without ahelping beforehand. You do not need to wait for a response, however, failure to notify admins will result in consequences.[/color][color=#c4c4c4]
+[color=#e6e6e6][color=#3bff72][bold]3.4 -[/bold][/color] Do not disconnect, ghost, suicide, or otherwise intentionally permanently remove yourself from the round as an important role or while facing in-character punishment such as jail time without ahelping beforehand. You do not need to wait for a response, however, failure to notify admins will result in consequences.[/color][color=#c4c4c4]
 [bullet] This does not apply to cryo.[/color]
 
-[color=#e6e6e6][color=#3bff72][bold]3.4 -[/bold][/color] Your character name should be believable and realistic.[/color][color=#c4c4c4]
+[color=#e6e6e6][color=#3bff72][bold]3.5 -[/bold][/color] Your character name should be believable and realistic.[/color][color=#c4c4c4]
 [bullet] Your name must only contain basic English letters and accented characters.
 [bullet] Your character name should not mimic popular real-life or fictional people, even if it is a "clever" plays on them, such as "White Walter."
 [bullet] Your character's name should not be phonetic word plays, such as "Mike Oxlong" or "Ben Dover."
@@ -65,26 +68,31 @@ Game admins have the final say on all rules, game issues, and punishments. We re
 [bullet] The concept of "playing to win" is commonly referred to as "powergaming."
 [bullet] Standard Operating Procedure (SOP) dictates how areas should be locked down and what gear should be held and/or equipped during any given circumstance. Minor things such as getting a crowbar on round-start is fine, however, seeking out weapons is not.[/color]
 
-[color=#e6e6e6][color=#59ffe1][bold]4.2 -[/bold][/color] Because this is an HRP server, you should avoid abandoning your job for no good reason. You can focus on and off of work, or ask the Head of Personnel to clock you out if you plan to be away for quite some time. Don't spend the entire round away from your job while on duty and your department needs you.[/color]
+[color=#e6e6e6][color=#59ffe1][bold]4.2 -[/bold][/color] Do not overly crowd an RP situation. This is mostly designed around security and people following others into departments. We do not expect you to be absolutely always cautious about this rule, nor do we intend to enforce it with a heavy hand, but please just be mindful of it, as it can seriously detract from others' RP.[color=#c4c4c4]
+[bullet] If security is dealing with a situation, be respectful of their operation, do not needlessly intervene or chime in verbally as a third party, basically you should only be stepping in if you're taking the full side of the suspect and intend to act as an accomplice.
+[bullet] Medical and similar departments get roughly the same protections, do not follow a patient/involved person into a location such as the medical bay unless you have good reason to, for example you having information on their condition that you are going to give or an officer making an arrest.
+[bullet] In short do not barge into situations you do not belong in and force yourself into it. Treat it like a real security or medical emergency; discuss things on the sides quietly, but do not intervene.[/color]
 
-[color=#e6e6e6][color=#59ffe1][bold]4.3 -[/bold][/color] This server uses a New Life rule. You may not remember any events that may have happened while you were in an unconscious or dead state. You may not retain any knowledge that you have learned whilst you were a ghost.[/color][color=#c4c4c4]
+[color=#e6e6e6][color=#59ffe1][bold]4.3 -[/bold][/color] Because this is an HRP server, you should avoid abandoning your job for no good reason. You can focus on and off of work, or ask the Head of Personnel to clock you out if you plan to be away for quite some time. Don't spend the entire round away from your job while on duty and your department needs you.[/color]
+
+[color=#e6e6e6][color=#59ffe1][bold]4.4 -[/bold][/color] This server uses a New Life rule. You may not remember any events that may have happened while you were in an unconscious or dead state. You may not retain any knowledge that you have learned whilst you were a ghost.[/color][color=#c4c4c4]
 [bullet] If you enter a dead state and get defibbed back to life you forget all the events that led up to your death. (This is the basic type of memory loss for anything else that is not specified)
 [bullet] If you enter a dead state and get cloned back to life you forget all the events since the beginning of the shift.
 [bullet] Respawning as a new character eliminates all memory of everything that may have happened previously in that shift.[/color]
 
-[color=#e6e6e6][color=#59ffe1][bold]4.4 -[/bold][/color] Full continuity of your character and events that happen to them is to be expected. All rounds are canonical unless stated otherwise by an admin.[/color][color=#c4c4c4]
+[color=#e6e6e6][color=#59ffe1][bold]4.5 -[/bold][/color] Full continuity of your character and events that happen to them is to be expected. All rounds are canonical unless stated otherwise by an admin.[/color][color=#c4c4c4]
 [bullet] You are allowed to recall past shifts in any manner unless it violates the New Life rule.
 [bullet] Punishments you receive will be enforced and carried out in-character throughout rounds. If your character gets demoted, you are expected to stay out of that job until a reasonable amount of time has passed or you are rehired again in-game.
 [bullet] Your characters should generally hold no more than two departmental jobs and a service side job in-character. You may swap departments from time to time so long as it doesn't happen constantly or consistently.
 [bullet] Permanent death is not required, as there is an off-site DNA storages available for all crewmembers.[/color]
 
-[color=#e6e6e6][color=#59ffe1][bold]4.5 -[/bold][/color] Stay within your job, reasonable knowledge, and abilities.[/color][color=#c4c4c4]
+[color=#e6e6e6][color=#59ffe1][bold]4.6 -[/bold][/color] Stay within your job, reasonable knowledge, and abilities.[/color][color=#c4c4c4]
 [bullet] Do not use knowledge that you have learned out-of-character while you are in-character. This is referred to as "metagaming."
 [bullet] Unless your character has a past in a particular line of work, they should not know how to do jobs outside of their own.
 [bullet] Do not do the jobs of other people for them, only play the role you signed up for. If you want to work a different job, ask the Head of Personnel for a job change. Exceptions can be made for if no active staff exist for a department.
 [bullet] Basic crew should not be knowledgeable on most non-NT technology and items unless they've experienced it in-character. Security and command may have some leeway within reason.[/color]
 
-[color=#e6e6e6][color=#59ffe1][bold]4.6 -[/bold][/color] Command and security are expected to be competent, to be lawful, and to follow procedure.[/color][color=#c4c4c4]
+[color=#e6e6e6][color=#59ffe1][bold]4.7 -[/bold][/color] Command and security are expected to be competent, to be lawful, and to follow procedure.[/color][color=#c4c4c4]
 [bullet] Neither roles should be grossly incompetent at their job or in their judgment. You are held to higher standards and should be able to be depended upon. Be a role-model for your department.
 [bullet] You cannot take direct, unchallengeable orders from people other than your job superiors.
 [bullet] You should not knowingly break the law as either command or security.


### PR DESCRIPTION
## About the PR
- Splits the "dick be a dick" rule in half, now having a separate rule for crime rules.
- Adds a section about not being allowed to kill yourself while in security custody without ahelping.
- Introduces a small rule of thumb going over what we consider a minor crime opposed to a major crime.
- Clarifies that the Arrivals Shuttle and end of round Central Command station are not places to commit crime.
---
- Adds a new, "don't crowd RP situations" rule designed to protect things like security and medical from being swamped with people barging into their work.

## Why / Balance
Admin consensus.

## Media
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/110078045/f5598c62-6b76-48ef-89b0-cfa7652bf5c8)
---
![image](https://github.com/cosmatic-drift-14/cosmatic-drift/assets/110078045/700d36e9-bc38-44a6-809a-2028b581e987)

**Changelog**
_[This is either a progress report done by you, or announcement done by me, you decide Lank.]_
Security have gotten a few Quality of Life changes in the form of rules. 
If you'd like to read in full, go to the PR itself or read new rules 3.1, 3.2, and 4.2. To summarize the new changes;
- People in security custody are no longer allowed to kill themselves without approval from an admin.
- Minor crimes have been roughly defined as things that **_don't_** harm anyone other than yourself, cause a location to be unsafe or unusable, or include the theft of irreplaceable items.
- The arrival shuttle itself and end of round CentComm are now protected against grief and crimes.
- People are no longer allowed to suddenly step in and intervene with security (some times medical or other departments depending on context) RP situations if they have no justifiable reason to be doing so.