### PR TITLE
Sync medkits with upstream

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -6,14 +6,10 @@
   components:
   - type: StorageFill
     contents:
-      - id: HandheldHealthAnalyzer
       - id: Brutepack
-        amount: 2
       - id: Ointment
-        amount: 2
       - id: Gauze
-      - id: PillTricordrazine
-        amount: 5
+      - id: PillCanisterTricordrazine
       # see https://github.com/tgstation/blob/master/code/game/objects/items/storage/firstaid.dm for example contents
 
 - type: entity
@@ -23,15 +19,10 @@
   components:
   - type: StorageFill
     contents:
-      - id: RegenerativeMesh
-        amount: 2
       - id: Ointment
         amount: 2
-      - id: SyringeSigynate
-      - id: PillKelotane
-        amount: 5
-      - id: PillDermaline
-        amount: 5
+      - id: PillCanisterKelotane
+      - id: PillCanisterDermaline
 
 - type: entity
   id: MedkitBruteFilled
@@ -40,17 +31,10 @@
   components:
   - type: StorageFill
     contents:
-      - id: MedicatedSuture
       - id: Brutepack
       - id: Gauze
-      - id: Bloodpack
-      - id: SyringeTranexamicAcid
-      - id: PillIron
-        amount: 3
-      - id: PillBicaridine
-        amount: 3
-      - id: PillCopper
-        amount: 3
+      - id: PillCanisterIron
+      - id: PillCanisterCopper
 
 - type: entity
   id: MedkitToxinFilled
@@ -62,10 +46,8 @@
       - id: SyringeIpecac
       - id: SyringeEthylredoxrazine
       - id: AntiPoisonMedipen
-      - id: PillDylovene
-        amount: 5
-      - id: PillCharcoal
-        amount: 3
+      - id: PillCanisterDylovene
+      - id: PillCanisterCharcoal
 
 - type: entity
   id: MedkitOxygenFilled
@@ -78,8 +60,7 @@
       - id: EmergencyOxygenTankFilled
       - id: EmergencyMedipen
       - id: SyringeInaprovaline
-      - id: PillDexalin
-        amount: 7
+      - id: PillCanisterDexalin
 
 - type: entity
   id: MedkitRadiationFilled
@@ -88,14 +69,10 @@
   components:
   - type: StorageFill
     contents:
-      - id: GeigerCounter
       - id: SyringePhalanximine
       - id: RadAutoInjector
-        amount: 1
       - id: EmergencyMedipen
-        amount: 1
-      - id: PillHyronalin
-        amount: 5
+      - id: PillCanisterHyronalin
 
 - type: entity
   id: MedkitAdvancedFilled
@@ -105,9 +82,7 @@
   - type: StorageFill
     contents:
       - id: MedicatedSuture
-        amount: 2
       - id: RegenerativeMesh
-        amount: 2
       - id: Bloodpack
         amount: 2
 
@@ -118,15 +93,11 @@
   components:
   - type: StorageFill
     contents:
-      - id: HandheldHealthAnalyzer
       - id: MedicatedSuture
       - id: RegenerativeMesh
       - id: SyringeEphedrine
-      - id: SyringeSaline
       - id: BruteAutoInjector
       - id: BurnAutoInjector
-      - id: EmergencyMedipen
-      - id: Bloodpack
 
 - type: entity
   id: StimkitFilled


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Medkits are currently missing pills. This fixes the issue and bring them inline
with the balance upstream. The only thing that is a bit weird is that the pill
canisters are not full. This is also the case upstream, so I don't think it is
a bit deal

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Obvious bug

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
```sh
cp /home/$USER/src/wizden/Resources/Prototypes/Entities/Specific/Medical/healing.yml .
```

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Medkits are no longer lacking pills
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
