### PR TITLE
Nerf frezon and trit prices.

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -1,4 +1,4 @@
-﻿- type: gas
+- type: gas
   id: 0
   name: gases-oxygen
   specificHeat: 20
@@ -50,7 +50,7 @@
   gasOverlayState: tritium
   color: 13FF4B
   reagent: Tritium
-  pricePerMole: 2.5
+  pricePerMole: 1.2 # CD: Frezon Nerf
 
 - type: gas
   id: 5
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 3
+  pricePerMole: 1.5 # CD: Frezon Nerf


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This is an experimental change to hopefully make cargo have less money. It
would also provide more reason for atmos to optimize frezon setups. Trit was
also nerfed because if it was not, it would have sold for more than frezon.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

See the [discussion on discord](https://discord.com/channels/1163352113162768436/1163713936231764059/1245234514318589953)

TLDR: Atmos can produce enough cash for cargo to buy luxury hardsuits for the
entire station in around 4 hours.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Aquif, Ridiue
- tweak: Selling freezon and tritium got massively nerfed. This is an experimental change and will be reverted if it does not improve gameplay.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
