### PR TITLE
Make recorders portable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_wind.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_wind.yml
@@ -122,7 +122,7 @@
     sprite: Objects/Fun/Instruments/recorder.rsi
     state: icon
   - type: Item
-    size: 24
+    size: 5
     sprite: Objects/Fun/Instruments/recorder.rsi
   - type: Tag
     tags:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changes the size of recorders from 24 to 5.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I am a recorder player. It does not take *24 bag storage* to fit this stupid fucking instrument in your bag.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: rain
- fix: Fixed an evil curse with recorders causing them to become the least portable instrument ever
