### PR TITLE
Add galoshes to JaniDrobe

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
@@ -4,7 +4,7 @@
     ClothingUniformJumpsuitJanitor: 2
     ClothingUniformJumpskirtJanitor: 2
     ClothingHandsGlovesJanitor: 2
-    ClothingShoesGaloshes: 2
+    ClothingShoesGaloshes: 2 #Cosmatic Drift Change
     ClothingShoesColorBlack: 2
     ClothingHeadHatPurplesoft: 2
     ClothingBeltJanitor: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
@@ -4,6 +4,7 @@
     ClothingUniformJumpsuitJanitor: 2
     ClothingUniformJumpskirtJanitor: 2
     ClothingHandsGlovesJanitor: 2
+    ClothingShoesGaloshes: 2
     ClothingShoesColorBlack: 2
     ClothingHeadHatPurplesoft: 2
     ClothingBeltJanitor: 2


### PR DESCRIPTION
## About the PR
This adds 2 pairs of galoshes to the JaniDrobe

## Why / Balance
This is so that when the janitor slots are filled and the HOP hires another janitor or two, they can get boots so they don't have to worry about slipping on puddles.

**Changelog**
:cl:
- tweak: Added 2 galoshes to JaniDrobe

