### PR TITLE
Partially revert "Makes machine parts stackable, removes unused field in stack prototypes (#28434)"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: BaseStockPart
   name: stock part
   parent: BaseItem
@@ -29,6 +29,7 @@
         - CapacitorStockPart
     - type: Stack
       stackType: Capacitor
+      itemSize: 1
 
 - type: entity
   id: MicroManipulatorStockPart
@@ -44,6 +45,7 @@
       rating: 1
     - type: Stack
       stackType: MicroManipulator
+      itemSize: 1
 
 - type: entity
   id: MatterBinStockPart
@@ -59,3 +61,4 @@
       rating: 1
     - type: Stack
       stackType: MatterBin
+      itemSize: 1

--- a/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
@@ -29,7 +29,6 @@
         - CapacitorStockPart
     - type: Stack
       stackType: Capacitor
-      itemSize: 1
 
 - type: entity
   id: MicroManipulatorStockPart
@@ -45,7 +44,6 @@
       rating: 1
     - type: Stack
       stackType: MicroManipulator
-      itemSize: 1
 
 - type: entity
   id: MatterBinStockPart
@@ -61,4 +59,3 @@
       rating: 1
     - type: Stack
       stackType: MatterBin
-      itemSize: 1

--- a/Resources/Prototypes/Entities/Objects/Tools/fulton.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/fulton.yml
@@ -7,6 +7,7 @@
     state: extraction_pack
   spawn: Fulton1
   maxCount: 10
+  itemSize: 2
 
 # Entities
 - type: entity

--- a/Resources/Prototypes/Stacks/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Stacks/Materials/Sheets/glass.yml
@@ -4,6 +4,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/glass.rsi, state: glass }
   spawn: SheetGlass1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: ReinforcedGlass
@@ -11,6 +12,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/glass.rsi, state: rglass }
   spawn: SheetRGlass1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: PlasmaGlass
@@ -18,6 +20,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/glass.rsi, state: pglass }
   spawn: SheetPGlass1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: ReinforcedPlasmaGlass
@@ -25,6 +28,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/glass.rsi, state: rpglass }
   spawn: SheetRPGlass1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: UraniumGlass
@@ -32,6 +36,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/glass.rsi, state: uglass }
   spawn: SheetUGlass1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: ReinforcedUraniumGlass
@@ -39,6 +44,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/glass.rsi, state: ruglass }
   spawn: SheetRUGlass1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: ClockworkGlass
@@ -46,3 +52,4 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/glass.rsi, state: cglass }
   spawn: SheetClockworkGlass1
   maxCount: 30
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Stacks/Materials/Sheets/metal.yml
@@ -4,6 +4,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/metal.rsi, state: steel }
   spawn: SheetSteel1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Plasteel
@@ -11,6 +12,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/metal.rsi, state: plasteel }
   spawn: SheetPlasteel1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Brass
@@ -18,3 +20,4 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/metal.rsi, state: brass }
   spawn: SheetBrass1
   maxCount: 30
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Stacks/Materials/Sheets/other.yml
@@ -4,6 +4,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/other.rsi, state: paper }
   spawn: SheetPaper1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Plasma
@@ -11,6 +12,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/other.rsi, state: plasma }
   spawn: SheetPlasma1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Plastic
@@ -18,6 +20,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/other.rsi, state: plastic }
   spawn: SheetPlastic1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Uranium
@@ -25,3 +28,4 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/other.rsi, state: uranium }
   spawn: SheetUranium1
   maxCount: 30
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/Materials/crystals.yml
+++ b/Resources/Prototypes/Stacks/Materials/crystals.yml
@@ -3,3 +3,4 @@
   name: telecrystal
   icon: Objects/Specific/Syndicate/telecrystal.rsi
   spawn: Telecrystal1
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/Materials/ingots.yml
+++ b/Resources/Prototypes/Stacks/Materials/ingots.yml
@@ -4,6 +4,7 @@
   icon: { sprite: "/Textures/Objects/Materials/ingots.rsi", state: gold }
   spawn: IngotGold1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Silver
@@ -11,3 +12,4 @@
   icon: { sprite: "/Textures/Objects/Materials/ingots.rsi", state: silver }
   spawn: IngotSilver1
   maxCount: 30
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/Materials/materials.yml
+++ b/Resources/Prototypes/Stacks/Materials/materials.yml
@@ -4,6 +4,7 @@
   icon: { sprite: /Textures/Objects/Misc/monkeycube.rsi, state: cube }
   spawn: MaterialBiomass1
   maxCount: 100
+  itemSize: 1
 
 - type: stack
   id: WoodPlank
@@ -11,6 +12,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: wood }
   spawn: MaterialWoodPlank1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Cardboard
@@ -18,6 +20,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: cardboard }
   spawn: MaterialCardboard1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Cloth
@@ -25,6 +28,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: cloth }
   spawn: MaterialCloth1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Durathread
@@ -32,6 +36,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: durathread }
   spawn: MaterialDurathread1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Diamond
@@ -39,6 +44,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: diamond }
   spawn: MaterialDiamond1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: Cotton
@@ -46,6 +52,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: cotton }
   spawn: MaterialCotton1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Pyrotton
@@ -53,6 +60,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: pyrotton }
   spawn: MaterialPyrotton1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Bananium
@@ -60,6 +68,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: bananium }
   spawn: MaterialBananium1
   maxCount: 10
+  itemSize: 2
 
 - type: stack
   id: MeatSheets
@@ -67,6 +76,7 @@
   icon: { sprite: /Textures/Objects/Materials/Sheets/meaterial.rsi, state: meat }
   spawn: MaterialSheetMeat1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: WebSilk
@@ -74,6 +84,7 @@
   icon: { sprite: /Textures/Objects/Materials/silk.rsi, state: icon }
   spawn: MaterialWebSilk1
   maxCount: 50
+  itemSize: 1
 
 - type: stack
   id: Bones
@@ -81,6 +92,7 @@
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: bones}
   spawn: MaterialBones1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: Gunpowder
@@ -88,3 +100,4 @@
   icon: { sprite: /Textures/Objects/Misc/reagent_fillings.rsi, state: powderpile }
   spawn: MaterialGunpowder
   maxCount: 60
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/Materials/ore.yml
+++ b/Resources/Prototypes/Stacks/Materials/ore.yml
@@ -4,6 +4,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: gold }
   spawn: GoldOre1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: SteelOre
@@ -11,6 +12,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: iron }
   spawn: SteelOre1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: PlasmaOre
@@ -18,6 +20,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: plasma }
   spawn: PlasmaOre1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: SilverOre
@@ -25,6 +28,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: silver }
   spawn: SilverOre1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: SpaceQuartz
@@ -32,6 +36,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: spacequartz }
   spawn: SpaceQuartz1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: UraniumOre
@@ -39,6 +44,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: uranium }
   spawn: UraniumOre1
   maxCount: 30
+  itemSize: 2
 
 
 - type: stack
@@ -47,6 +53,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: bananium }
   spawn: BananiumOre1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: Coal
@@ -54,6 +61,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: coal }
   spawn: Coal1
   maxCount: 30
+  itemSize: 2
 
 - type: stack
   id: SaltOre
@@ -61,3 +69,4 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: salt }
   spawn: Salt1
   maxCount: 30
+  itemSize: 2

--- a/Resources/Prototypes/Stacks/Materials/parts.yml
+++ b/Resources/Prototypes/Stacks/Materials/parts.yml
@@ -4,3 +4,4 @@
   icon: { sprite: /Textures/Objects/Materials/parts.rsi, state: rods }
   spawn: PartRodMetal1
   maxCount: 30
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/consumable_stacks.yml
+++ b/Resources/Prototypes/Stacks/consumable_stacks.yml
@@ -5,6 +5,7 @@
   name: pancake
   spawn: FoodBakedPancake
   maxCount: 3
+  itemSize: 1
 
 # Food Containers
 
@@ -14,6 +15,7 @@
   icon: { sprite: Objects/Consumable/Food/Baked/pizza.rsi, state: box }
   spawn: FoodBoxPizza
   maxCount: 30
+  itemSize: 10
 
 # Smokeables
 
@@ -23,6 +25,7 @@
   icon: { sprite: /Textures/Objects/Consumable/Smokeables/Cigarettes/paper.rsi, state: cigpaper }
   spawn: PaperRolling
   maxCount: 5
+  itemSize: 1
 
 - type: stack
   id: CigaretteFilter
@@ -30,6 +33,7 @@
   icon: { sprite: /Textures/Objects/Consumable/Smokeables/Cigarettes/paper.rsi, state: cigfilter }
   spawn: CigaretteFilter
   maxCount: 5
+  itemSize: 2
 
 - type: stack
   id: GroundTobacco
@@ -37,6 +41,7 @@
   icon: { sprite: /Textures/Objects/Misc/reagent_fillings.rsi, state: powderpile }
   spawn: GroundTobacco
   maxCount: 5
+  itemSize: 1
 
 - type: stack
   id: GroundCannabis
@@ -44,6 +49,7 @@
   icon: { sprite: /Textures/Objects/Misc/reagent_fillings.rsi, state: powderpile }
   spawn: GroundCannabis
   maxCount:
+  itemSize: 1
 
 - type: stack
   id: GroundCannabisRainbow
@@ -51,6 +57,7 @@
   icon: { sprite: /Textures/Objects/Specific/Hydroponics/rainbow_cannabis.rsi, state: powderpile_rainbow }
   spawn: GroundCannabisRainbow
   maxCount:
+  itemSize: 1
 
 - type: stack
   id: LeavesTobaccoDried
@@ -58,6 +65,7 @@
   icon: { sprite: /Textures/Objects/Specific/Hydroponics/tobacco.rsi, state: dried }
   spawn: LeavesTobaccoDried
   maxCount: 5
+  itemSize: 5
 
 - type: stack
   id: LeavesCannabisDried
@@ -65,9 +73,12 @@
   icon: { sprite: /Textures/Objects/Specific/Hydroponics/tobacco.rsi, state: dried }
   spawn: LeavesCannabisDried
   maxCount: 5
+  itemSize: 5
 
 - type: stack
   id: LeavesCannabisRainbowDried
   name: dried rainbow cannabis leaves
   icon: { sprite: /Textures/Objects/Specific/Hydroponics/rainbow_cannabis.rsi, state: dried }
   spawn: LeavesCannabisRainbowDried
+  maxCount: 5
+  itemSize: 5

--- a/Resources/Prototypes/Stacks/engineering_stacks.yml
+++ b/Resources/Prototypes/Stacks/engineering_stacks.yml
@@ -4,9 +4,11 @@
   name: inflatable wall
   spawn: InflatableWallStack1
   maxCount: 10
+  itemSize: 1
 
 - type: stack
   id: InflatableDoor
   name: inflatable door
   spawn: InflatableDoorStack1
   maxCount: 4
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/floor_tile_stacks.yml
+++ b/Resources/Prototypes/Stacks/floor_tile_stacks.yml
@@ -3,402 +3,469 @@
   name: steel tile
   spawn: FloorTileItemSteel
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileMetalDiamond
   name: steel tile
   spawn: FloorTileItemMetalDiamond
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileWood
   name: wood floor
   spawn: FloorTileItemWood
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileWhite
   name: white tile
   spawn: FloorTileItemWhite
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileDark
   name: dark tile
   spawn: FloorTileItemDark
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileTechmaint
   name: techmaint floor
   spawn: FloorTileItemTechmaint
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileFreezer
   name: freezer tile
   spawn: FloorTileItemFreezer
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileShowroom
   name: showroom tile
   spawn: FloorTileItemShowroom
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileGCircuit
   name: green-circuit floor
   spawn: FloorTileItemGCircuit
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileGold
   name: gold floor
   spawn: FloorTileItemGold
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileReinforced
   name: reinforced tile
   spawn: FloorTileItemReinforced
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileMono
   name: mono tile
   spawn: FloorTileItemMono
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileBrassFilled
   name: filled brass plate
   spawn: FloorTileItemBrassFilled
   maxCount: 30
-
+  itemSize: 5
+  
 - type: stack
   id: FloorTileBrassReebe
   name: smooth brass plate
   spawn: FloorTileItemBrassReebe
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileLino
   name: linoleum floor
   spawn: FloorTileItemLino
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileHydro
   name: hydro tile
   spawn: FloorTileItemHydro
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileLime
   name: lime tile
   spawn: FloorTileItemLime
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileDirty
   name: dirty tile
   spawn: FloorTileItemDirty
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackShuttleWhite
   name: white shuttle tile
   spawn: FloorTileItemShuttleWhite
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackShuttleBlue
   name: blue shuttle tile
   spawn: FloorTileItemShuttleBlue
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackShuttleOrange
   name: orange shuttle tile
   spawn: FloorTileItemShuttleOrange
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackShuttlePurple
   name: purple shuttle tile
   spawn: FloorTileItemShuttlePurple
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackShuttleRed
   name: red shuttle tile
   spawn: FloorTileItemShuttleRed
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackShuttleGrey
   name: grey shuttle tile
   spawn: FloorTileItemShuttleGrey
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackShuttleBlack
   name: black shuttle tile
   spawn: FloorTileItemShuttleBlack
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackEighties
   name: eighties floor tile
   spawn: FloorTileItemEighties
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackArcadeBlue
   name: blue arcade tile
   spawn: FloorTileItemArcadeBlue
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackArcadeBlue2
   name: blue arcade tile
   spawn: FloorTileItemArcadeBlue2
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackArcadeRed
   name: red arcade tile
   spawn: FloorTileItemArcadeRed
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetRed
   name: red carpet tile
   spawn: FloorCarpetItemRed
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetBlack
   name: block carpet tile
   spawn: FloorCarpetItemBlack
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetBlue
   name: blue carpet tile
   spawn: FloorCarpetItemBlue
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetGreen
   name: green carpet tile
   spawn: FloorCarpetItemGreen
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetOrange
   name: orange carpet tile
   spawn: FloorCarpetItemOrange
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetSkyBlue
   name: skyblue carpet tile
   spawn: FloorCarpetItemSkyBlue
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetPurple
   name: purple carpet tile
   spawn: FloorCarpetItemPurple
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetPink
   name: pink carpet tile
   spawn: FloorCarpetItemPink
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetCyan
   name: cyan carpet tile
   spawn: FloorCarpetItemCyan
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorCarpetWhite
   name: white carpet tile
   spawn: FloorCarpetItemWhite
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackCarpetClown
   name: clown carpet tile
   spawn: FloorTileItemCarpetClown
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackCarpetOffice
   name: office carpet tile
   spawn: FloorTileItemCarpetOffice
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackBoxing
   name: boxing ring tile
   spawn: FloorTileItemBoxing
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileStackGym
   name: gym floor tile
   spawn: FloorTileItemGym
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileElevatorShaft
   name: elevator shaft tile
   spawn: FloorTileItemElevatorShaft
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileRockVault
   name: rock vault tile
   spawn: FloorTileItemRockVault
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileBlue
   name: blue floor tile
   spawn: FloorTileItemBlue
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileMining
   name: mining floor tile
   spawn: FloorTileItemMining
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileMiningDark
   name: dark mining floor tile
   spawn: FloorTileItemMiningDark
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileMiningLight
   name: light mining floor tile
   spawn: FloorTileItemMiningLight
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileBar
   name: item bar floor tile
   spawn: FloorTileItemBar
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileClown
   name: clown floor tile
   spawn: FloorTileItemClown
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileMime
   name: mime floor tile
   spawn: FloorTileItemMime
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileKitchen
   name: kitchen floor tile
   spawn: FloorTileItemKitchen
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileLaundry
   name: laundry floor tile
   spawn: FloorTileItemLaundry
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileConcrete
   name: concrete tile
   spawn: FloorTileItemGrayConcrete
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileGrayConcrete
   name: gray concrete tile
   spawn: FloorTileItemLaundry
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileOldConcrete
   name: old concrete tile
   spawn: FloorTileItemOldConcrete
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileSilver
   name: silver floor tile
   spawn: FloorTileItemSilver
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileBCircuit
   name: bcircuit floor tile
   spawn: FloorTileItemBCircuit
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileGrass
   name: grass floor tile
   spawn: FloorTileItemGrass
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileGrassJungle
   name: grass jungle floor tile
   spawn: FloorTileItemGrassJungle
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileSnow
   name: snow floor tile
   spawn: FloorTileItemSnow
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileWoodPattern
   name: wood pattern floor
   spawn: FloorTileItemWoodPattern
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileFlesh
   name: flesh floor
   spawn: FloorTileItemFlesh
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileSteelMaint
   name: steel maint floor
   spawn: FloorTileItemSteelMaint
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileGratingMaint
   name: grating maint floor
   spawn: FloorTileItemGratingMaint
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileWeb
   name: web tile
   spawn: FloorTileItemWeb
   maxCount: 30
+  itemSize: 5
 
 # Faux science tiles
 - type: stack
@@ -406,30 +473,35 @@
   name: astro-grass floor
   spawn: FloorTileItemAstroGrass
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileMowedAstroGrass
   name: mowed astro-grass floor
   spawn: FloorTileItemMowedAstroGrass
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileJungleAstroGrass
   name: jungle astro-grass floor
   spawn: FloorTileItemJungleAstroGrass
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileAstroIce
   name: astro-ice floor
   spawn: FloorTileItemAstroIce
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileAstroSnow
   name: astro-snow floor
   spawn: FloorTileItemAstroSnow
   maxCount: 30
+  itemSize: 5
 
 - type: stack
   id: FloorTileWoodLarge

--- a/Resources/Prototypes/Stacks/medical_stacks.yml
+++ b/Resources/Prototypes/Stacks/medical_stacks.yml
@@ -4,6 +4,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: ointment }
   spawn: Ointment
   maxCount: 10
+  itemSize: 1
 
 - type: stack
   id: AloeCream
@@ -11,6 +12,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Hydroponics/aloe.rsi", state: cream }
   spawn: AloeCream
   maxCount: 10
+  itemSize: 1
 
 - type: stack
   id: Gauze
@@ -18,6 +20,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: gauze }
   spawn: Gauze
   maxCount: 10
+  itemSize: 1
 
 - type: stack
   id: Brutepack
@@ -25,6 +28,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: gauze }
   spawn: Brutepack
   maxCount: 10
+  itemSize: 1
 
 - type: stack
   id: Bloodpack
@@ -32,6 +36,7 @@
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: bloodpack }
   spawn: Bloodpack
   maxCount: 10
+  itemSize: 1
 
 - type: stack
   id: MedicatedSuture
@@ -39,6 +44,7 @@
   icon: {sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: medicated-suture }
   spawn: MedicatedSuture
   maxCount: 10
+  itemSize: 1
 
 - type: stack
   id: RegenerativeMesh
@@ -46,4 +52,6 @@
   icon: {sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: regenerative-mesh}
   spawn: RegenerativeMesh
   maxCount: 10
+  itemSize: 1
+
 

--- a/Resources/Prototypes/Stacks/power_stacks.yml
+++ b/Resources/Prototypes/Stacks/power_stacks.yml
@@ -4,6 +4,7 @@
   icon: { sprite: "/Textures/Objects/Tools/cable-coils.rsi", state: coil-30 }
   spawn: CableApcStack1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: CableMV
@@ -11,6 +12,7 @@
   icon: { sprite: "/Textures/Objects/Tools/cable-coils.rsi", state: coilmv-30 }
   spawn: CableMVStack1
   maxCount: 30
+  itemSize: 1
 
 - type: stack
   id: CableHV
@@ -18,3 +20,4 @@
   icon: { sprite: "/Textures/Objects/Tools/cable-coils.rsi", state: coilhv-30 }
   spawn: CableHVStack1
   maxCount: 30
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/science_stacks.yml
+++ b/Resources/Prototypes/Stacks/science_stacks.yml
@@ -10,18 +10,18 @@
   name: capacitor
   spawn: CapacitorStockPart
   maxCount: 10
-  itemSize: 3
+  itemSize: 1
 
 - type: stack
   id: MicroManipulator
   name: micro manipulator
   spawn: MicroManipulatorStockPart
   maxCount: 10
-  itemSize: 3
+  itemSize: 1
 
 - type: stack
   id: MatterBin
   name: matter bin
   spawn: MatterBinStockPart
   maxCount: 10
-  itemSize: 3
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/science_stacks.yml
+++ b/Resources/Prototypes/Stacks/science_stacks.yml
@@ -1,6 +1,27 @@
-﻿- type: stack
+- type: stack
   id: ArtifactFragment
   name: artifact fragment
   spawn: ArtifactFragment1
   maxCount: 30
   itemSize: 5
+
+- type: stack
+  id: Capacitor
+  name: capacitor
+  spawn: CapacitorStockPart
+  maxCount: 10
+  itemSize: 3
+
+- type: stack
+  id: MicroManipulator
+  name: micro manipulator
+  spawn: MicroManipulatorStockPart
+  maxCount: 10
+  itemSize: 3
+
+- type: stack
+  id: MatterBin
+  name: matter bin
+  spawn: MatterBinStockPart
+  maxCount: 10
+  itemSize: 3

--- a/Resources/Prototypes/Stacks/science_stacks.yml
+++ b/Resources/Prototypes/Stacks/science_stacks.yml
@@ -3,21 +3,4 @@
   name: artifact fragment
   spawn: ArtifactFragment1
   maxCount: 30
-
-- type: stack
-  id: Capacitor
-  name: capacitor
-  spawn: CapacitorStockPart
-  maxCount: 10
-
-- type: stack
-  id: MicroManipulator
-  name: micro manipulator
-  spawn: MicroManipulatorStockPart
-  maxCount: 10
-
-- type: stack
-  id: MatterBin
-  name: matter bin
-  spawn: MatterBinStockPart
-  maxCount: 10
+  itemSize: 5


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
When we re-added item sizes during the upstream merge we forgot to also revert
the part of 09256cfaa572d326840edaea1dc0268cd9def5e3 that removed item sizes from the YAML.
