### PR TITLE
Revert part of 'Make station components use StationPostInitEvent' 

### DIFF
--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -78,7 +78,7 @@ public sealed class ArrivalsSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<StationArrivalsComponent, StationPostInitEvent>(OnStationPostInit);
+        SubscribeLocalEvent<StationArrivalsComponent, ComponentStartup>(OnStationPostInit); // CD change- use ComponentStartup instead of StationPostInitEvent
 
         SubscribeLocalEvent<ArrivalsShuttleComponent, ComponentStartup>(OnShuttleStartup);
         SubscribeLocalEvent<ArrivalsShuttleComponent, FTLTagEvent>(OnShuttleTag);
@@ -527,7 +527,7 @@ public sealed class ArrivalsSystem : EntitySystem
         }
     }
 
-    private void OnStationPostInit(EntityUid uid, StationArrivalsComponent component, ref StationPostInitEvent args)
+    private void OnStationPostInit(EntityUid uid, StationArrivalsComponent component, ComponentStartup args) // CD: Use ComponentStartup instead of OnStationPostInit
     {
         if (!Enabled)
             return;


### PR DESCRIPTION
This is to, hopefully, fix arrivals being paused. Entirely untested, but that's why we're a playtest baby. 