### PR TITLE
Reduced the size for jaws of life so it can fit in normal toolbelts.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -11,7 +11,7 @@
     sprite: Objects/Tools/jaws_of_life.rsi
     state: jaws_pry
   - type: Item
-    size: 50
+    size: 20
   - type: Clothing
     sprite: Objects/Tools/jaws_of_life.rsi
     quickEquip: false


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
The size of jaws of life is now 20 so that it can fit in normal toolbelts.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It's kinda stupid having to keep a jaws of life in your backpack when you have a perfectly functional toolbelt.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- tweak: Changed the jaws of life size from 50 to 20.