### PR TITLE
Lathe-able Record Boards

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -429,6 +429,9 @@
     - BoozeDispenserMachineCircuitboard
     - SodaDispenserMachineCircuitboard
     - SpaceHeaterMachineCircuitBoard
+    - StationRecordsComputerCircuitboard #CD additions start.
+    - MedicalRecordsComputerCircuitboard
+    - CriminalRecordsComputerCircuitboard #CD additions end.
     dynamicRecipes:
       - ThermomachineFreezerMachineCircuitBoard
       - HellfireFreezerMachineCircuitBoard

--- a/Resources/Prototypes/_CD/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_CD/Recipes/Lathes/electronics.yml
@@ -1,0 +1,26 @@
+- type: latheRecipe
+  id: StationRecordsComputerCircuitboard
+  result: StationRecordsComputerCircuitboard
+  category: Circuitry
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: MedicalRecordsComputerCircuitboard
+  result: MedicalRecordsComputerCircuitboard
+  category: Circuitry
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: CriminalRecordsComputerCircuitboard
+  result: CriminalRecordsComputerCircuitboard
+  category: Circuitry
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500


### PR DESCRIPTION
## About the PR
Gives the circuit imprinter recipes to create all three record computers without research or anything.

## Why / Balance
In case a map is missing one or one got destroyed.

**Changelog**
Record computer boards can now be made in the circuit imprinter.