### PR TITLE
Fix Synth Typing Indicator

### DIFF
--- a/Content.Shared/Chat/TypingIndicator/TypingIndicatorComponent.cs
+++ b/Content.Shared/Chat/TypingIndicator/TypingIndicatorComponent.cs
@@ -7,13 +7,13 @@ namespace Content.Shared.Chat.TypingIndicator;
 ///     Show typing indicator icon when player typing text in chat box.
 ///     Added automatically when player poses entity.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 // [Access(typeof(SharedTypingIndicatorSystem))]
 public sealed partial class TypingIndicatorComponent : Component
 {
     /// <summary>
     ///     Prototype id that store all visual info about typing indicator.
     /// </summary>
-    [DataField("proto")]
+    [DataField("proto"), AutoNetworkedField]
     public ProtoId<TypingIndicatorPrototype> TypingIndicatorPrototype = "default";
 }


### PR DESCRIPTION
AutoGenerateComponentState got overwritten during the upstream merge. It's now readded. 
