### PR TITLE
Fix Survival Gear For CD Roles

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -18,6 +18,8 @@
     - Human
     - Moth
     - Reptilian
+    - Avali #CD additions start
+    - Vulpkanin #CD additions end
 
 - type: loadoutEffectGroup
   id: EffectSpeciesVox

--- a/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
@@ -2,6 +2,7 @@
 - type: roleLoadout
   id: JobPrivateInvestigator
   groups: #Using Detective groups is probably a bad idea, but it's easier this way.
+  - GroupTankHarness
   - DetectiveHead
   - DetectiveJumpsuit
   - CommonBackpack
@@ -9,23 +10,29 @@
   - PrivateInvestigatorGloves
   - PrivateInvestigatorShoes
   - PrivateInvestigatorGlasses
+  - Survival
   - Trinkets
+  - GroupSpeciesBreathTool
 
 # Engineering
 - type: roleLoadout
   id: JobSeniorEngineer
   groups:
+  - GroupTankHarness
   - StationEngineerHead
   - SeniorEngineerJumpsuit
   - StationEngineerBackpack
   - StationEngineerOuterClothing
   - StationEngineerShoes
+  - SurvivalExtended
   - Trinkets
+  - GroupSpeciesBreathTool
 
 # Science
 - type: roleLoadout
   id: JobSeniorResearcher
   groups:
+  - GroupTankHarness
   - ScientistHead
   - ScientistNeck
   - SeniorResearcherJumpsuit
@@ -33,12 +40,15 @@
   - SeniorResearcherOuterClothing
   - ScientistGloves
   - ScientistShoes
+  - Survival
   - Trinkets
+  - GroupSpeciesBreathTool
 
 # Security
 - type: roleLoadout
   id: JobSeniorOfficer
   groups:
+  - GroupTankHarness
   - SecurityHead
   - SeniorOfficerJumpsuit
   - SecurityBackpack
@@ -46,12 +56,15 @@
   - SecurityShoes
   - SecurityBelt
   - SecurityGlassesOrHud
+  - SurvivalSecurity
   - Trinkets
+  - GroupSpeciesBreathToolSecurity
 
 # Medical
 - type: roleLoadout
   id: JobSeniorPhysician
   groups:
+  - GroupTankHarness
   - SeniorPhysicianHead
   - MedicalMask
   - SeniorPhysicianJumpsuit
@@ -59,11 +72,16 @@
   - MedicalBackpack
   - SeniorPhysicianOuterClothing
   - MedicalShoes
+  - SurvivalMedical
   - Trinkets
+  - GroupSpeciesBreathToolMedical
 
 # Wildcards
 - type: roleLoadout
   id: JobPrisoner
   groups:
+  - GroupTankHarness
   - PrisonerJumpsuit
   - PrisonerFun
+  - GroupSpeciesBreathTool
+  - Survival

--- a/Resources/Prototypes/_CD/Roles/Jobs/Civilian/private_investigator.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Civilian/private_investigator.yml
@@ -17,7 +17,6 @@
     ears: ClothingHeadsetService
   storage:
     back:
-    - BoxSurvival
     - ForensicScanner
     - ForensicPad
     - ForensicPad

--- a/Resources/Prototypes/_CD/Roles/Jobs/Engineering/senior_engineer.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Engineering/senior_engineer.yml
@@ -22,6 +22,3 @@
     eyes: ClothingEyesGlassesMeson
     belt: ClothingBeltUtilityEngineering
     ears: ClothingHeadsetEngineering
-  storage:
-    back:
-    - BoxSurvivalEngineering

--- a/Resources/Prototypes/_CD/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Medical/senior_physician.yml
@@ -20,6 +20,3 @@
     id: SeniorPhysicianPDA
     ears: ClothingHeadsetMedical
     belt: ClothingBeltMedicalFilled
-  storage:
-    back:
-    - BoxSurvivalMedical

--- a/Resources/Prototypes/_CD/Roles/Jobs/Science/senior_researcher.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Science/senior_researcher.yml
@@ -18,6 +18,3 @@
   equipment:
     id: SeniorResearcherPDA
     ears: ClothingHeadsetScience
-  storage:
-    back:
-    - BoxSurvival

--- a/Resources/Prototypes/_CD/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Security/senior_officer.yml
@@ -28,6 +28,5 @@
     pocket1: WeaponPistolMk58
   storage:
     back:
-    - BoxSurvivalSecurity
     - Flash
     - MagazinePistol


### PR DESCRIPTION
## About the PR
- Avalis and Vulp now spawn with survival boxes.
- All CD unique roles now spawn with species matching survival boxes (excluding prisoner for the boxes point) and survival gear.

## Why / Balance
Maintenance.

## Media
![image](https://github.com/user-attachments/assets/1ac997f8-5a92-4ff8-90af-d63a15afb923)

**Changelog**
Survival gear has been fixed so all CD unique roles and species get their appropriate survival equipment and boxes.