### PR TITLE
Revert "Revert "Extend Round End Time""

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -415,10 +415,10 @@ namespace Content.Shared.CCVar
 
         /// <summary>
         /// The time in seconds that the server should wait before restarting the round.
-        /// Defaults to 2 minutes.
+        /// Defaults to 5 minutes. CD change from 2 to 5 because the Cvar doesn't work.
         /// </summary>
         public static readonly CVarDef<float> RoundRestartTime =
-            CVarDef.Create("game.round_restart_time", 120f, CVar.SERVERONLY);
+            CVarDef.Create("game.round_restart_time", 300f, CVar.SERVERONLY);
 
         /// <summary>
         /// Respawn time, how long the player has to wait in seconds after death.


### PR DESCRIPTION
Reverts cosmatic-drift-14/cosmatic-drift#114

I asked in axolotl's dev chat a long time ago how they extend the round end and YuNii said they just change this CVAR. It must have been broken when we tried to change it. The only difference is Axolotl changes it in the config instead of the repo. If this does not work I don't know what to say.