### PR TITLE
Make character name reset upon resetting records.

### DIFF
--- a/Content.Server/Mind/Commands/RenameCommand.cs
+++ b/Content.Server/Mind/Commands/RenameCommand.cs
@@ -13,6 +13,9 @@ using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.Player;
 
+// CD: imports
+using Content.Server._CD.Records;
+
 namespace Content.Server.Mind.Commands;
 
 [AdminCommand(AdminFlags.VarEdit)]
@@ -98,6 +101,13 @@ public sealed class RenameCommand : IConsoleCommand
             && _entManager.TryGetComponent<ActorComponent>(entityUid, out var actorComp))
         {
             adminSystem.UpdatePlayerList(actorComp.PlayerSession);
+        }
+
+        // CD: records
+        if (_entManager.TrySystem<CharacterRecordsSystem>(out var cdRecordsSys)
+            && _entManager.TryGetComponent<CharacterRecordKeyStorageComponent>(entityUid, out var cdCRecords))
+        {
+            cdRecordsSys.QueryRecords(cdCRecords.Key.Station)[cdCRecords.Key.Index].Name = name;
         }
     }
 

--- a/Content.Server/_CD/Records/CharacterRecordsSystem.cs
+++ b/Content.Server/_CD/Records/CharacterRecordsSystem.cs
@@ -169,6 +169,8 @@ public sealed class CharacterRecordsSystem : EntitySystem
             return;
 
         var records = PlayerProvidedCharacterRecords.DefaultRecords();
+        if (TryComp(player, out MetaDataComponent? meta))
+            recordsDb.Records[key.Key.Index].Name = meta.EntityName;
         recordsDb.Records[key.Key.Index].PRecords = records;
         RaiseLocalEvent(station, new CharacterRecordsModifiedEvent());
     }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Currently if a player joins with a stupid name and is not erased banned for
some reason there is no way for admins to remove the name from records.

Also added records support to the rename command.
