### PR TITLE
Disable merging stacks with labels

### DIFF
--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -12,6 +12,9 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
+// CD: imports
+using Content.Shared.Labels.Components;
+
 namespace Content.Shared.Stacks
 {
     [UsedImplicitly]
@@ -114,6 +117,10 @@ namespace Content.Shared.Stacks
                 return false;
 
             if (string.IsNullOrEmpty(recipientStack.StackTypeId) || !recipientStack.StackTypeId.Equals(donorStack.StackTypeId))
+                return false;
+
+            // CD: Cannot merge stacks with labels
+            if (HasComp<LabelComponent>(donor) || HasComp<LabelComponent>(recipient))
                 return false;
 
             transferred = Math.Min(donorStack.Count, GetAvailableSpace(recipientStack));
@@ -327,6 +334,10 @@ namespace Content.Shared.Stacks
         public bool TryAdd(EntityUid insertEnt, EntityUid targetEnt, int count, StackComponent? insertStack = null, StackComponent? targetStack = null)
         {
             if (!Resolve(insertEnt, ref insertStack) || !Resolve(targetEnt, ref targetStack))
+                return false;
+
+            // CD: Don't merge labeled stacks
+            if (HasComp<LabelComponent>(insertEnt) || HasComp<LabelComponent>(targetEnt))
                 return false;
 
             var available = GetAvailableSpace(targetStack);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Title/QOL.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Mainly because salvagers like to label fultons.

Fixes https://github.com/cosmatic-drift-14/cosmatic-drift/issues/333

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Check for the component before merging.


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl: Aquif
- fix: Stacks with labels will no longer stack with any other stacks.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
