### PR TITLE
Fix missing locale issue cause by upstream merge

### DIFF
--- a/Resources/Locale/en-US/_CD/job/department.ftl
+++ b/Resources/Locale/en-US/_CD/job/department.ftl
@@ -1,2 +1,2 @@
 department-HighCommand = High Command
-department-HichCommand-description = Ensure the station is managed in a satisfactory way.
+department-HighCommand-description = Ensure the station is managed in a satisfactory way.

--- a/Resources/Prototypes/_CD/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/departments.yml
@@ -1,5 +1,6 @@
 - type: department
   id: HighCommand
+  name: department-HighCommand
   description: department-HighCommand-description
   color: "#334E6D"
   weight: 90


### PR DESCRIPTION
Fixes the Yaml linter issue on the latest commit. This issue was introduced by
the upstream merge adding a new required field to one of the prototypes I used
causing the tests to pass on that branch (but fail after merge) because
upstream was not merged on the branch.
