### PR TITLE
(hopefully) make the event scheduler less chaotic

### DIFF
--- a/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/BasicStationEventSchedulerComponent.cs
@@ -11,7 +11,7 @@ public sealed partial class BasicStationEventSchedulerComponent : Component
     /// How long the the scheduler waits to begin starting rules.
     /// </summary>
     [DataField]
-    public float MinimumTimeUntilFirstEvent = 200;
+    public float MinimumTimeUntilFirstEvent = 480;
 
     /// <summary>
     /// The minimum and maximum time between rule starts in seconds.

--- a/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
@@ -10,14 +10,14 @@ public sealed partial class RampingStationEventSchedulerComponent : Component
     ///     Max chaos chosen for a round will deviate from this
     /// </summary>
     [DataField]
-    public float AverageChaos = 6f;
+    public float AverageChaos = 4f;
 
     /// <summary>
     ///     Average time (in minutes) for when the ramping event scheduler should stop increasing the chaos modifier.
     ///     Close to how long you expect a round to last, so you'll probably have to tweak this on downstreams.
     /// </summary>
     [DataField]
-    public float AverageEndTime = 40f;
+    public float AverageEndTime = 200f;
 
     [DataField]
     public float EndTime;

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -77,14 +77,14 @@
     scheduledGameRules: !type:NestedSelector
       tableId: MeteorSwarmMildTable
 
-- type: entity
-  parent: BaseGameRule
-  id: KesslerSyndromeScheduler
-  components:
-  - type: GameRule
-  - type: RampingStationEventScheduler
-    scheduledGameRules: !type:NestedSelector
-      tableId: BasicMeteorSwarmEventsTable
+# - type: entity
+#   parent: BaseGameRule
+#   id: KesslerSyndromeScheduler
+#   components:
+#   - type: GameRule
+#   - type: RampingStationEventScheduler
+#     scheduledGameRules: !type:NestedSelector
+#       tableId: BasicMeteorSwarmEventsTable
 
 # Game Rules
 
@@ -108,8 +108,8 @@
     earliestStart: 2
     minimumPlayers: 0
   - type: MeteorSwarm
-    announcement: null
-    announcementSound: null
+    announcement: station-event-meteor-swarm-start-announcement
+    announcementSound: /Audio/Announcements/attention.ogg
     nonDirectional: true
     meteors:
       MeteorSpaceDust: 1

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -104,7 +104,7 @@
   id: GameRuleSpaceDustMinor
   components:
   - type: StationEvent
-    weight: 44
+    weight: 14
     earliestStart: 2
     minimumPlayers: 0
   - type: MeteorSwarm
@@ -145,7 +145,7 @@
   id: GameRuleMeteorSwarmSmall
   components:
   - type: StationEvent
-    weight: 18
+    weight: 8
     minimumPlayers: 15
   - type: MeteorSwarm
     meteors:
@@ -157,7 +157,7 @@
   id: GameRuleMeteorSwarmMedium
   components:
   - type: StationEvent
-    weight: 10
+    weight: 5
   - type: MeteorSwarm
     meteors:
       MeteorSmall: 3
@@ -169,7 +169,7 @@
 #   id: GameRuleMeteorSwarmLarge
 #   components:
 #   - type: StationEvent
-#     weight: 5
+#     weight: 2
 #   - type: MeteorSwarm
 #     meteors:
 #       MeteorSmall: 2

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -308,8 +308,8 @@
   - type: BasicStationEventScheduler
     minimumTimeUntilFirstEvent: 1200 # 20 mins
     minMaxEventTiming:
-      min: 600 # 10 mins
-      max: 1800 # 30 mins
+      min: 1800 # 30 mins
+      max: 3600 # 60 mins
     scheduledGameRules: !type:NestedSelector
       tableId: SpaceTrafficControlTable
 
@@ -320,8 +320,8 @@
   - type: BasicStationEventScheduler
     minimumTimeUntilFirstEvent: 1200 # 20 mins
     minMaxEventTiming:
-      min: 600 # 10 mins
-      max: 1800 # 30 mins
+      min: 1800 # 30 mins
+      max: 3600 # 60 mins
     scheduledGameRules: !type:NestedSelector
       tableId: UnknownShuttlesFriendlyTable
 

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -12,61 +12,61 @@
     - SpaceTrafficControlFriendlyEventScheduler
     - BasicRoundstartVariation
 
-- type: gamePreset
-  id: KesslerSyndrome
-  alias:
-    - kessler
-    - junk
-    - meteorhell
-  name: kessler-syndrome-title
-  showInVote: false # secret
-  description: kessler-syndrome-description
-  rules:
-    - KesslerSyndromeScheduler
-    - RampingStationEventScheduler
-    - SpaceTrafficControlEventScheduler
-    - BasicRoundstartVariation
+# - type: gamePreset
+#   id: KesslerSyndrome
+#   alias:
+#     - kessler
+#     - junk
+#     - meteorhell
+#   name: kessler-syndrome-title
+#   showInVote: false # secret
+#   description: kessler-syndrome-description
+#   rules:
+#     - KesslerSyndromeScheduler
+#     - RampingStationEventScheduler
+#     - SpaceTrafficControlEventScheduler
+#     - BasicRoundstartVariation
 
-- type: gamePreset
-  id: AllAtOnce
-  alias:
-  - all
-  name: all-at-once-title
-  description: all-at-once-description
-  showInVote: false
-  rules:
-    - Nukeops
-    - Traitor
-    - Revolutionary
-    - Zombie
-    - KesslerSyndromeScheduler
-    - RampingStationEventScheduler
-    - SpaceTrafficControlEventScheduler
-    - BasicRoundstartVariation
+# - type: gamePreset
+#   id: AllAtOnce
+#   alias:
+#   - all
+#   name: all-at-once-title
+#   description: all-at-once-description
+#   showInVote: false
+#   rules:
+#     - Nukeops
+#     - Traitor
+#     - Revolutionary
+#     - Zombie
+#     - KesslerSyndromeScheduler
+#     - RampingStationEventScheduler
+#     - SpaceTrafficControlEventScheduler
+#     - BasicRoundstartVariation
 
-- type: gamePreset
-  id: AllerAtOnce
-  alias:
-  - allall
-  - aller
-  - badidea
-  - punishment
-  name: aller-at-once-title
-  description: all-at-once-description
-  showInVote: false #Please god dont do this
-  rules:
-    - Nukeops
-    - Traitor
-    - Revolutionary
-    - Zombie
-    - BasicStationEventScheduler
-    - KesslerSyndromeScheduler
-    - MeteorSwarmMildScheduler
-    - MeteorSwarmScheduler
-    - RampingStationEventScheduler
-    - SpaceTrafficControlEventScheduler
-    - SpaceTrafficControlFriendlyEventScheduler
-    - BasicRoundstartVariation
+# - type: gamePreset
+#   id: AllerAtOnce
+#   alias:
+#   - allall
+#   - aller
+#   - badidea
+#   - punishment
+#   name: aller-at-once-title
+#   description: all-at-once-description
+#   showInVote: false #Please god dont do this
+#   rules:
+#     - Nukeops
+#     - Traitor
+#     - Revolutionary
+#     - Zombie
+#     - BasicStationEventScheduler
+#     - KesslerSyndromeScheduler
+#     - MeteorSwarmMildScheduler
+#     - MeteorSwarmScheduler
+#     - RampingStationEventScheduler
+#     - SpaceTrafficControlEventScheduler
+#     - SpaceTrafficControlFriendlyEventScheduler
+#     - BasicRoundstartVariation
 
 - type: gamePreset
   id: Extended
@@ -219,18 +219,18 @@
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
 
-- type: gamePreset
-  id: Zombieteors
-  alias:
-  - zombieteors
-  - zombombies
-  - meteombies
-  name: zombieteors-title
-  description: zombieteors-description
-  showInVote: false
-  rules:
-  - Zombie
-  - BasicStationEventScheduler
-  - KesslerSyndromeScheduler
-  - SpaceTrafficControlEventScheduler
-  - BasicRoundstartVariation
+# - type: gamePreset
+#   id: Zombieteors
+#   alias:
+#   - zombieteors
+#   - zombombies
+#   - meteombies
+#   name: zombieteors-title
+#   description: zombieteors-description
+#   showInVote: false
+#   rules:
+#   - Zombie
+#   - BasicStationEventScheduler
+#   - KesslerSyndromeScheduler
+#   - SpaceTrafficControlEventScheduler
+#   - BasicRoundstartVariation


### PR DESCRIPTION
I'm not 100% sure how exactly this works, but I *believe* this should result in less events spawning, more similar to how it was before the refactor. 