### PR TITLE
More Map Patches

### DIFF
--- a/Resources/CDMapPatches/box.yml
+++ b/Resources/CDMapPatches/box.yml
@@ -1,4 +1,3 @@
 - !type:CDSpawnEntityMapPatch
   worldPosition: -5.999672,-16.99885
   id: LockerLostAndFound
-...

--- a/Resources/CDMapPatches/box.yml
+++ b/Resources/CDMapPatches/box.yml
@@ -1,0 +1,4 @@
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -5.999672,-16.99885
+  id: LockerLostAndFound
+...

--- a/Resources/CDMapPatches/cog.yml
+++ b/Resources/CDMapPatches/cog.yml
@@ -1,4 +1,3 @@
 - !type:CDSpawnEntityMapPatch
   worldPosition: -43.40625,22.177084
   id: LockerLostAndFound
-...

--- a/Resources/CDMapPatches/cog.yml
+++ b/Resources/CDMapPatches/cog.yml
@@ -1,0 +1,4 @@
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -43.40625,22.177084
+  id: LockerLostAndFound
+...

--- a/Resources/CDMapPatches/oasis.yml
+++ b/Resources/CDMapPatches/oasis.yml
@@ -1,0 +1,22 @@
+- !type:CDSpawnEntityMapPatch
+  worldRotation: -1.5707963267948966 rad
+  worldPosition: 25.989584,8
+  id: ComputerStationRecords
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 22.989584,11
+  id: LockerLostAndFound
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -32.010418,-35
+  id: ComputerStationRecords
+- !type:CDSpawnEntityMapPatch
+  worldRotation: 1.5707963267948966 rad
+  worldPosition: -55.010418,11
+  id: ComputerStationRecords
+- !type:CDSpawnEntityMapPatch
+  worldRotation: 1.5707963267948966 rad
+  worldPosition: 2.9895833,44
+  id: ComputerTabletopStationRecords
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 36.989582,-40
+  id: ComputerStationRecords
+...

--- a/Resources/CDMapPatches/oasis.yml
+++ b/Resources/CDMapPatches/oasis.yml
@@ -19,4 +19,3 @@
 - !type:CDSpawnEntityMapPatch
   worldPosition: 36.989582,-40
   id: ComputerStationRecords
-...

--- a/Resources/CDMapPatches/omega.yml
+++ b/Resources/CDMapPatches/omega.yml
@@ -9,4 +9,3 @@
   worldRotation: 3.141592653589793 rad
   worldPosition: -14.228987,-30.914822
   id: ComputerMedicalRecords
-...

--- a/Resources/CDMapPatches/omega.yml
+++ b/Resources/CDMapPatches/omega.yml
@@ -1,0 +1,12 @@
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -2.2289867,26.085178
+  id: LockerLostAndFound
+- !type:CDSpawnEntityMapPatch
+  worldRotation: 1.5707963267948966 rad
+  worldPosition: -3.2289867,29.085178
+  id: ComputerStationRecords
+- !type:CDSpawnEntityMapPatch
+  worldRotation: 3.141592653589793 rad
+  worldPosition: -14.228987,-30.914822
+  id: ComputerMedicalRecords
+...

--- a/Resources/CDMapPatches/packed.yml
+++ b/Resources/CDMapPatches/packed.yml
@@ -1,0 +1,4 @@
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 29.9375,44.984375
+  id: LockerLostAndFound
+...

--- a/Resources/CDMapPatches/packed.yml
+++ b/Resources/CDMapPatches/packed.yml
@@ -1,4 +1,3 @@
 - !type:CDSpawnEntityMapPatch
   worldPosition: 29.9375,44.984375
   id: LockerLostAndFound
-...

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -3,6 +3,7 @@
   mapName: 'Box Station'
   mapPath: /Maps/box.yml
   minPlayers: 35 #CD
+  patchfile: /CDMapPatches/box.yml # CD Edit: Apply map patch
   stations:
     Boxstation:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -4,6 +4,7 @@
   mapPath: /Maps/cog.yml
   minPlayers: 25 #CD change
   maxPlayers: 45 #CD change
+  patchfile: /CDMapPatches/cog.yml # CD Edit: Apply map patch
   stations:
     Cog:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -3,6 +3,7 @@
   mapName: 'Oasis'
   mapPath: /Maps/oasis.yml
   minPlayers: 55 #CD change
+  patchfile: /CDMapPatches/oasis.yml # CD Edit: Apply map patch
   stations:
     Oasis:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -4,6 +4,7 @@
   mapPath: /Maps/omega.yml
   minPlayers: 5 #CD change
   maxPlayers: 25 #CD change
+  patchfile: /CDMapPatches/omega.yml # CD Edit: Apply map patch
   stations:
     Omega:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -4,6 +4,7 @@
   mapPath: /Maps/packed.yml
   minPlayers: 5
   maxPlayers: 25 #CD change
+  patchfile: /CDMapPatches/packed.yml # CD Edit: Apply map patch
   stations:
     Packed:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
## About the PR
Adds a map patch for the rest of the remaining non-CD maps that didn't have one. (Excludes Reach, because Reach, don't think I need to explain that one.)
##
**Box**
- Adds a LnF locker in the command conference room above HoP.

**Cog**
- Adds a LnF locker in HoP's bedroom.

**Oasis**
- Adds a LnF locker in the command conference room.
- Adds an employment records computer in every Head room excluding HoP and RD. (Space issues.)

**Omega**
- Adds a LnF locker in the bridge.
- Adds a an employment records computer in the bridge.
- Adds a medical records computer by the surgery room.

**Packed**
- Adds a LnF locker in the bridge.

## Why / Balance
Lost and Found lackage.

**Changelog**
Every map should have a Lost and Found locker now, plus records computers where relevant.