### PR TITLE
Remove Mantle Timers

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
@@ -55,9 +55,10 @@
   id: QuartermasterMantle
   equipment: 
     neck: ClothingNeckMantleQM
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterQM
+#CD redaction
+#  effects:
+#  - !type:GroupLoadoutEffect
+#    proto: MasterQM
 
 - type: startingGear
   id: QuartermasterMantle

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -55,9 +55,10 @@
   id: CaptainMantle
   equipment:
     neck: ClothingNeckMantleCap
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterCap
+#CD redaction
+#  effects:
+#  - !type:GroupLoadoutEffect
+#    proto: MasterCap
 
 - type: startingGear
   id: CaptainMantle

--- a/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -45,9 +45,10 @@
   id: HoPMantle
   equipment:
     neck: ClothingNeckMantleHOP
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterHoP
+#CD redaction
+#  effects:
+#  - !type:GroupLoadoutEffect
+#    proto: MasterHoP
 
 - type: startingGear
   id: HoPMantle

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
@@ -49,9 +49,10 @@
   id: ChiefEngineerMantle
   equipment:
     neck: ClothingNeckMantleCE
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterCE
+#CD redaction
+#  effects:
+#  - !type:GroupLoadoutEffect
+#    proto: MasterCE
 
 - type: startingGear
   id: ChiefEngineerMantle

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
@@ -50,9 +50,10 @@
   id: ChiefMedicalOfficerMantle
   equipment:
     neck: ClothingNeckMantleCMO
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterCMO
+#CD redaction
+#  effects:
+#  - !type:GroupLoadoutEffect
+#    proto: MasterCMO
 
 - type: startingGear
   id: ChiefMedicalOfficerMantle

--- a/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
@@ -18,9 +18,10 @@
   id: ResearchDirectorMantle
   equipment:
     neck: ClothingNeckMantleRD
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterRD
+#CD redaction
+#  effects:
+#  - !type:GroupLoadoutEffect
+#    proto: MasterRD
 
 - type: startingGear
   id: ResearchDirectorMantle

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -60,9 +60,10 @@
   id: HeadofSecurityMantle
   equipment:
     neck: ClothingNeckMantleHOS
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MasterHoS
+#CD redaction
+#  effects:
+#  - !type:GroupLoadoutEffect
+#    proto: MasterHoS
 
 - type: startingGear
   id: HeadofSecurityMantle


### PR DESCRIPTION
## About the PR
Removes the time-gate on all head mantles.

## Why / Balance
Doesn't fit with our style, you could get them on the Terminal round-start anyways.

**Changelog**
Mantles are no longer time locked in loadouts.