### PR TITLE
Add custom meteor swarm announcements 

### DIFF
--- a/Resources/Locale/en-US/_CD/station/events.ftl
+++ b/Resources/Locale/en-US/_CD/station/events.ftl
@@ -1,1 +1,7 @@
 ﻿station-event-ion-storm-synth = You detect an Ion Storm. Your internal systems may be tampered with or damaged as a result. 
+
+station-event-space-dust-minor-start-announcement = The station is passing through a small debris cloud, expect very minor damage to external fittings and fixtures.
+station-event-space-dust-moderate-start-announcement = The station is passing through a debris cloud, expect some damage to exposed station fixtures.
+station-event-meteor-swarm-small-start-announcement = A small meteor field has been detected on collision course with the station. Please be cautious around exposed areas of the station.
+station-event-meteor-swarm-moderate-start-announcement = A meteor field has been detected on collision course with the station. Crew are advised to avoid exposed areas of the station, and inform engineering staff of any damaged locations.
+station-event-meteor-swarm-heavy-start-announcement = A large meteor field is on a collision course with the station. Station crew are advised to head towards a central, safe area, and engineering staff should prepare for heavy damage. 

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -109,7 +109,7 @@
     earliestStart: 2
     minimumPlayers: 0
   - type: MeteorSwarm
-    announcement: station-event-meteor-swarm-start-announcement
+    announcement: station-event-space-dust-minor-start-announcement # CD Change: custom announcement
     announcementSound: /Audio/Announcements/attention.ogg
     nonDirectional: true
     meteors:
@@ -129,7 +129,7 @@
     weight: 22
     minimumPlayers: 0
   - type: MeteorSwarm
-    announcement: station-event-space-dust-start-announcement
+    announcement: station-event-space-dust-moderate-start-announcement # CD Change: custom announcement
     announcementSound: /Audio/Announcements/attention.ogg
     nonDirectional: true
     meteors:
@@ -150,6 +150,7 @@
     weight: 8
     minimumPlayers: 15
   - type: MeteorSwarm
+    announcement: station-event-meteor-swarm-small-start-announcement # CD Change: custom announcement
     meteors:
       # CD: Decrease count
       MeteorSmall: 5
@@ -162,6 +163,7 @@
   - type: StationEvent
     weight: 5
   - type: MeteorSwarm
+    announcement: station-event-meteor-swarm-moderate-start-announcement # CD Change: custom announcement
     meteors:
       # CD: Decrease count
       MeteorSmall: 2
@@ -175,6 +177,7 @@
 #   - type: StationEvent
 #     weight: 2
 #   - type: MeteorSwarm
+#     announcement: station-event-meteor-swarm-heavy-start-announcement # CD Change: custom announcement
 #     meteors:
 #       MeteorSmall: 2
 #       MeteorMedium: 4


### PR DESCRIPTION
Meteor swarms and space dust now give custom announcements based on the severity, so crew and engineering can hamper their expectations accordingly. 