### PR TITLE
Move Slowdown Buff to Combat Boots

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -14,14 +14,15 @@
   parent: [ClothingShoesMilitaryBase, BaseRestrictedContraband]
   id: ClothingShoesBootsJack
   name: jackboots
-  description: A set of Jackboots, once able to hold knifes they have fallen from grace due to budget cuts, now just some stylish boots.
+  description: Sturdy boots made for heavy work. Originally standard issue for security teams.
   components:
   - type: Sprite
     sprite: Clothing/Shoes/Boots/jackboots.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/jackboots.rsi
-  - type: ClothingSlowOnDamageModifier
-    modifier: 0.5
+#  CD remove SlowOnDamageModifier
+#  - type: ClothingSlowOnDamageModifier
+#    modifier: 0.5
 
 - type: entity
   parent: ClothingShoesBaseButcherable
@@ -56,6 +57,9 @@
     sprite: Clothing/Shoes/Boots/combatboots.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/combatboots.rsi
+# CD add SlowOnDamageModifier
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
 
 - type: entity
   parent: ClothingShoesMilitaryBase

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1015,7 +1015,7 @@
   id: SecurityShoes
   name: loadout-group-security-shoes
   loadouts:
-  - JackBoots
+  - CombatBoots #CD change from JackBoots to CombatBoots
   - SecurityWinterBoots
 
 - type: loadoutGroup

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -24,7 +24,7 @@
 - type: startingGear
   id: SecurityCadetGear
   equipment:
-    shoes: ClothingShoesBootsJackFilled
+    shoes: ClothingShoesBootsCombatFilled #CD change from jackboots to combat boots.
     outerClothing: ClothingOuterArmorBasic
     id: SecurityCadetPDA
     ears: ClothingHeadsetSecurity


### PR DESCRIPTION
## About the PR
Removes the slowdown buff from jackboots and gives them to combat boots instead.
Gives all security roles combat boots instead of jackboots.
Redoes the description of jackboots since it was outdated.

## Why / Balance
Before jackboots were considered the security version and combat boots were considered vanity.

Problem; our players enjoy drip, jackboots are a pretty popular choice. They're also already in the QuickThreads vendor and maints loot.

Solution; make combat boots the security version and make jackboots vanity. It just makes more logical sense name wise, and we don't have syndicates/nukies to worry about anyways. (Easy enough to handle by just giving them jackboots too.)

**Changelog**
Jackboots had their slowdown reduction removed, and in their place combat boots now have it. Security now also all spawn with combat boots.