### PR TITLE
Reduce listinv ore size

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -55,7 +55,7 @@
   - type: Stack
     count: 1
   - type: Item
-    size: 2
+    size: 1
 
 - type: entity
   parent: OreBase
@@ -88,7 +88,7 @@
   - type: Stack
     count: 1
   - type: Item
-    size: 2
+    size: 1
 
 - type: entity
   parent: OreBase
@@ -121,7 +121,7 @@
     - type: Stack
       count: 1
     - type: Item
-      size: 2
+      size: 1
 
 - type: entity
   parent: OreBase
@@ -159,7 +159,7 @@
     - type: Stack
       count: 1
     - type: Item
-      size: 2
+      size: 1
 
 - type: entity
   parent: OreBase
@@ -192,7 +192,7 @@
   - type: Stack
     count: 1
   - type: Item
-    size: 2
+    size: 1
 
 - type: entity
   parent: OreBase
@@ -225,7 +225,7 @@
   - type: Stack
     count: 1
   - type: Item
-    size: 2
+    size: 1
 
 - type: entity
   parent: OreBase
@@ -266,7 +266,7 @@
   - type: Stack
     count: 1
   - type: Item
-    size: 2
+    size: 1
 
 
 - type: entity
@@ -309,7 +309,7 @@
   - type: Stack
     count: 1
   - type: Item
-    size: 2
+    size: 1
 
 - type: entity
   parent: OreBase
@@ -350,7 +350,7 @@
   - type: Stack
     count: 1
   - type: Item
-    size: 2
+    size: 1
 
 - type: entity
   parent: OreBase
@@ -385,4 +385,4 @@
   - type: Stack
     count: 1
   - type: Item
-    size: 2
+    size: 1

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -8,7 +8,7 @@
     sprite: Objects/Materials/ore.rsi
   - type: Item
     sprite: Objects/Materials/ore.rsi
-    size: 60
+    size: 30
   - type: Tag
     tags:
     - Ore

--- a/Resources/Prototypes/Stacks/Materials/ore.yml
+++ b/Resources/Prototypes/Stacks/Materials/ore.yml
@@ -4,7 +4,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: gold }
   spawn: GoldOre1
   maxCount: 30
-  itemSize: 2
+  itemSize: 1
   
 - type: stack
   id: DiamondOre
@@ -12,7 +12,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: diamond }
   spawn: DiamondOre1
   maxCount: 30
-  itemSize: 2
+  itemSize: 1
 
 - type: stack
   id: SteelOre
@@ -20,7 +20,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: iron }
   spawn: SteelOre1
   maxCount: 30
-  itemSize: 2
+  itemSize: 1
 
 - type: stack
   id: PlasmaOre
@@ -28,7 +28,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: plasma }
   spawn: PlasmaOre1
   maxCount: 30
-  itemSize: 2
+  itemSize: 1
 
 - type: stack
   id: SilverOre
@@ -36,7 +36,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: silver }
   spawn: SilverOre1
   maxCount: 30
-  itemSize: 2
+  itemSize: 1
 
 - type: stack
   id: SpaceQuartz
@@ -44,7 +44,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: spacequartz }
   spawn: SpaceQuartz1
   maxCount: 30
-  itemSize: 2
+  itemSize: 1
 
 - type: stack
   id: UraniumOre
@@ -52,7 +52,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: uranium }
   spawn: UraniumOre1
   maxCount: 30
-  itemSize: 2
+  itemSize: 1
 
 
 - type: stack
@@ -61,7 +61,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: bananium }
   spawn: BananiumOre1
   maxCount: 30
-  itemSize: 2
+  itemSize: 1
 
 - type: stack
   id: Coal
@@ -69,7 +69,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: coal }
   spawn: Coal1
   maxCount: 30
-  itemSize: 2
+  itemSize: 1
 
 - type: stack
   id: SaltOre
@@ -77,4 +77,4 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: salt }
   spawn: Salt1
   maxCount: 30
-  itemSize: 2
+  itemSize: 1

--- a/Resources/Prototypes/Stacks/Materials/ore.yml
+++ b/Resources/Prototypes/Stacks/Materials/ore.yml
@@ -4,7 +4,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: gold }
   spawn: GoldOre1
   maxCount: 30
-  itemSize: 1
+  itemSize: 1  #CD Change
   
 - type: stack
   id: DiamondOre
@@ -12,7 +12,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: diamond }
   spawn: DiamondOre1
   maxCount: 30
-  itemSize: 1
+  itemSize: 1  #CD Change
 
 - type: stack
   id: SteelOre
@@ -20,7 +20,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: iron }
   spawn: SteelOre1
   maxCount: 30
-  itemSize: 1
+  itemSize: 1  #CD Change
 
 - type: stack
   id: PlasmaOre
@@ -28,7 +28,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: plasma }
   spawn: PlasmaOre1
   maxCount: 30
-  itemSize: 1
+  itemSize: 1 #CD Change
 
 - type: stack
   id: SilverOre
@@ -36,7 +36,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: silver }
   spawn: SilverOre1
   maxCount: 30
-  itemSize: 1
+  itemSize: 1  #CD Change
 
 - type: stack
   id: SpaceQuartz
@@ -44,7 +44,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: spacequartz }
   spawn: SpaceQuartz1
   maxCount: 30
-  itemSize: 1
+  itemSize: 1  #CD Change
 
 - type: stack
   id: UraniumOre
@@ -52,7 +52,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: uranium }
   spawn: UraniumOre1
   maxCount: 30
-  itemSize: 1
+  itemSize: 1  #CD Change
 
 
 - type: stack
@@ -61,7 +61,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: bananium }
   spawn: BananiumOre1
   maxCount: 30
-  itemSize: 1
+  itemSize: 1  #CD Change
 
 - type: stack
   id: Coal
@@ -69,7 +69,7 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: coal }
   spawn: Coal1
   maxCount: 30
-  itemSize: 1
+  itemSize: 1  #CD Change
 
 - type: stack
   id: SaltOre
@@ -77,4 +77,4 @@
   icon: { sprite: /Textures/Objects/Materials/ore.rsi, state: salt }
   spawn: Salt1
   maxCount: 30
-  itemSize: 1
+  itemSize: 1  #CD Change


### PR DESCRIPTION
## About the PR
Ore bags currently have an issue where they do not fill to capacity and are significantly smaller than their upstream counterpart to a crippling level. This should hopefully fix the issue when mining materials where the ore bag fills too quickly and as well as not to capacity.

## Why / Balance
Salvagers currently cannot mine as much ore as they probably should be able to vs upstream, meaning it takes more trips and therefore more time to mine due to having to go back and empty out the ore bags very frequently.

## Media
N/A

- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Ore is now smaller!
