### PR TITLE
Avali Guidebook Temp Typo Fix

### DIFF
--- a/Resources/ServerInfo/Guidebook/_CD/Mobs/Avali.xml
+++ b/Resources/ServerInfo/Guidebook/_CD/Mobs/Avali.xml
@@ -6,7 +6,7 @@
   </Box>
 
   Adapted to live in cold envinronments, their bodies are capable of handling extremely cold temperatures. Their temperature range is
-  [color=#12ABE8] approximately -50C to -35C[/color]. Additionally, due to their traditionally smaller stature [color=#ffa500]
+  [color=#12ABE8] approximately -50C to 36C[/color]. Additionally, due to their traditionally smaller stature [color=#ffa500]
   they are 5% less dense than the average species[/color] meaning they are slightly more susceptible to being shoved over
   and its more difficult for them to pull objects.
 


### PR DESCRIPTION
## About the PR
When I made the guidebook I added a pretty severe typo for the temperatures. This fixes it. Their actual temperature range is -50C to 36C. Not -35C.

## Why / Balance
Correct information in guidebooks are important.

## Technical details
XML text change.

(Note, I haven't tested in game. If I need to I can, just ask, but this should be fine.)