### PR TITLE
Make shuttle votes use game time

### DIFF
--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -62,7 +62,9 @@ namespace Content.Server.RoundEnd
         public TimeSpan? ExpectedShuttleLength => ExpectedCountdownEnd - LastCountdownStart;
         public TimeSpan? ShuttleTimeLeft => ExpectedCountdownEnd - _gameTiming.CurTime;
 
-        public TimeSpan AutoCallStartTime;
+        // CD: not needed
+        // public TimeSpan AutoCallStartTime;
+        private TimeSpan _lastShuttleVoteRoundTime = TimeSpan.Zero;
         private bool _autoCalledBefore = false;
 
         public override void Initialize()
@@ -74,7 +76,8 @@ namespace Content.Server.RoundEnd
 
         private void SetAutoCallTime()
         {
-            AutoCallStartTime = _gameTiming.CurTime;
+            // CD: not needed
+            // AutoCallStartTime = _gameTiming.CurTime;
         }
 
         private void Reset()
@@ -356,20 +359,19 @@ namespace Content.Server.RoundEnd
 
         public override void Update(float frameTime)
         {
+            // CD: fairly large changes to this logic
             // Check if we should auto-call.
             int mins = _autoCalledBefore ? _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallExtensionTime)
-                                        : _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallTime);
-            if (mins != 0 && _gameTiming.CurTime - AutoCallStartTime > TimeSpan.FromMinutes(mins))
+                                         : _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallTime);
+            if (mins != 0 && _gameTicker.RoundDuration() - _lastShuttleVoteRoundTime > TimeSpan.FromMinutes(mins))
             {
                 if (!_shuttle.EmergencyShuttleArrived && ExpectedCountdownEnd is null)
                 {
                     // CD: reuse this code for our shuttle vote because this would have needed to be disabled anyway
                     _cdShuttleVoteSystem.RunRestartVote();
                     _autoCalledBefore = true;
+                    _lastShuttleVoteRoundTime = _gameTicker.RoundDuration();
                 }
-
-                // Always reset auto-call in case of a recall.
-                SetAutoCallTime();
             }
         }
     }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1606,7 +1606,7 @@ namespace Content.Shared.CCVar
         ///     the shuttle again.
         /// </summary>
         public static readonly CVarDef<int> EmergencyShuttleAutoCallExtensionTime =
-            CVarDef.Create("shuttle.auto_call_extension_time", 45, CVar.SERVERONLY);
+            CVarDef.Create("shuttle.auto_call_extension_time", 30, CVar.SERVERONLY);
 
         /*
          * Crew Manifests

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1599,14 +1599,14 @@ namespace Content.Shared.CCVar
         ///     Time in minutes after round start to auto-call the shuttle. Set to zero to disable.
         /// </summary>
         public static readonly CVarDef<int> EmergencyShuttleAutoCallTime =
-            CVarDef.Create("shuttle.auto_call_time", 90, CVar.SERVERONLY);
+            CVarDef.Create("shuttle.auto_call_time", 70, CVar.SERVERONLY);
 
         /// <summary>
         ///     Time in minutes after the round was extended (by recalling the shuttle) to call
         ///     the shuttle again.
         /// </summary>
         public static readonly CVarDef<int> EmergencyShuttleAutoCallExtensionTime =
-            CVarDef.Create("shuttle.auto_call_extension_time", 30, CVar.SERVERONLY);
+            CVarDef.Create("shuttle.auto_call_extension_time", 45, CVar.SERVERONLY);
 
         /*
          * Crew Manifests


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixed shuttle votes not using game time and the extremely cursed way we prevented people from recalling the shuttle.

