### PR TITLE
significantly nerf anomalous infection chance

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/anomaly.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/anomaly.yml
@@ -22,7 +22,7 @@
     - AnomalyFlora
     - AnomalyShadow
     - AnomalyTech
-    rareChance: 0.3
+    rareChance: 0.05 # These should be suitably rare and anomalies spawn all the time
     rarePrototypes:
     - RandomAnomalyInjectorSpawner
     offset: 0.15 # not to put it higher. The anomaly sychnronizer looks for anomalies within this radius, and if the radius is higher, the anomaly can be attracted from a neighboring tile.


### PR DESCRIPTION
These are fairly dangerous and I've heard from others upstream that they appear far too frequently for even LRP. With how many anomalies are often generated in rounds 1/20 should be more appropriate than 1/3 (assuming this works the way I think it does). 