### PR TITLE
SOP Books

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
+++ b/Resources/Prototypes/Catalog/Fills/Books/bookshelf.yml
@@ -23,6 +23,15 @@
       - id: BookSpaceEncyclopedia
       - id: BookSpaceLaw
       - id: BookTheBookOfControl
+      #CD Addions
+      - id: BookSOPCommand
+      - id: BookSOPSecurity
+      - id: BookSOPEngineering
+      - id: BookSOPMedical
+      - id: BookSOPScience
+      - id: BookSOPCargo
+      - id: BookSOPService
+      - id: BookSOPGeneral
     # Handwritten books
     - !type:GroupSelector
       rolls: !type:RangeNumberSelector

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -21,6 +21,9 @@
       prob: 0.3
       rolls: !type:ConstantNumberSelector
         value: 3
+    #CD Addions
+    - id: BookSOPCargo
+      prob: 0.2
 
 - type: entity
   id: LockerSalvageSpecialistFilledHardsuit

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -96,6 +96,9 @@
       - id: HolofanProjector
       - id: RCD
       - id: RCDAmmo
+      #CD Addions
+      - id: BookSOPEngineering
+        prob: 0.2
 
 - type: entity
   id: LockerAtmosphericsFilled
@@ -112,6 +115,9 @@
       - id: HolofanProjector
       - id: RCD
       - id: RCDAmmo
+      #CD Addions
+      - id: BookSOPEngineering
+        prob: 0.2
 
 - type: entity
   id: LockerEngineerFilledHardsuit
@@ -126,6 +132,9 @@
       - id: ClothingShoesBootsMag
       - id: RCD
       - id: RCDAmmo
+      #CD Addions
+      - id: BookSOPEngineering
+        prob: 0.2
 
 - type: entity
   id: LockerEngineerFilled
@@ -139,6 +148,9 @@
       - id: trayScanner
       - id: RCD
       - id: RCDAmmo
+      #CD Addions
+      - id: BookSOPEngineering
+        prob: 0.2
 
 - type: entity
   id: ClosetRadiationSuitFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -17,6 +17,11 @@
     - id: RubberStampApproved
     - id: RubberStampDenied
     - id: RubberStampQm
+    #CD Addions
+    - id: BookSOPCargo
+      prob: 0.2
+    - id: BookSOPCommand
+      prob: 0.2
 
 - type: entity
   id: LockerQuarterMasterFilled
@@ -50,6 +55,11 @@
     - id: SpaceCash1000
     - id: WeaponDisabler
     - id: ClothingEyesGlassesCommand
+    #CD Addions
+    - id: BookSOPGeneral
+      prob: 0.2
+    - id: BookSOPCommand
+      prob: 0.2
 
 # No laser table + Laser table
 - type: entityTable
@@ -133,6 +143,11 @@
     - id: RubberStampHop
     - id: WeaponDisabler
     - id: ClothingEyesHudCommand
+    #CD Addions
+    - id: BookSOPService
+      prob: 0.2
+    - id: BookSOPCommand
+      prob: 0.2
 
 - type: entity
   id: LockerHeadOfPersonnelFilled
@@ -161,6 +176,11 @@
     - id: RCD
     - id: RCDAmmo
     - id: RubberStampCE
+    #CD Addions
+    - id: BookSOPEngineering
+      prob: 0.2
+    - id: BookSOPCommand
+      prob: 0.2
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable
@@ -218,6 +238,11 @@
     - id: MedicalTechFabCircuitboard
     - id: MedkitFilled
     - id: RubberStampCMO
+    #CD Addions
+    - id: BookSOPMedical
+      prob: 0.2
+    - id: BookSOPCommand
+      prob: 0.2
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable
@@ -268,6 +293,11 @@
     - id: ProtolatheMachineCircuitboard
     - id: ResearchComputerCircuitboard
     - id: RubberStampRd
+    #CD Addions
+    - id: BookSOPScience
+      prob: 0.2
+    - id: BookSOPCommand
+      prob: 0.2
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable
@@ -325,6 +355,11 @@
     - id: RubberStampHos
     - id: SecurityTechFabCircuitboard
     - id: WeaponDisabler
+    #CD Addions
+    - id: BookSOPSecurity
+      prob: 0.2
+    - id: BookSOPCommand
+      prob: 0.2
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -19,9 +19,8 @@
     - id: RubberStampQm
     #CD Addions
     - id: BookSOPCargo
-      prob: 0.2
     - id: BookSOPCommand
-      prob: 0.2
+      prob: 0.3
 
 - type: entity
   id: LockerQuarterMasterFilled
@@ -57,9 +56,7 @@
     - id: ClothingEyesGlassesCommand
     #CD Addions
     - id: BookSOPGeneral
-      prob: 0.2
     - id: BookSOPCommand
-      prob: 0.2
 
 # No laser table + Laser table
 - type: entityTable
@@ -145,9 +142,8 @@
     - id: ClothingEyesHudCommand
     #CD Addions
     - id: BookSOPService
-      prob: 0.2
     - id: BookSOPCommand
-      prob: 0.2
+      prob: 0.3
 
 - type: entity
   id: LockerHeadOfPersonnelFilled
@@ -178,9 +174,8 @@
     - id: RubberStampCE
     #CD Addions
     - id: BookSOPEngineering
-      prob: 0.2
     - id: BookSOPCommand
-      prob: 0.2
+      prob: 0.3
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable
@@ -240,9 +235,8 @@
     - id: RubberStampCMO
     #CD Addions
     - id: BookSOPMedical
-      prob: 0.2
     - id: BookSOPCommand
-      prob: 0.2
+      prob: 0.3
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable
@@ -295,9 +289,8 @@
     - id: RubberStampRd
     #CD Addions
     - id: BookSOPScience
-      prob: 0.2
     - id: BookSOPCommand
-      prob: 0.2
+      prob: 0.3
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable
@@ -357,9 +350,8 @@
     - id: WeaponDisabler
     #CD Addions
     - id: BookSOPSecurity
-      prob: 0.2
     - id: BookSOPCommand
-      prob: 0.2
+      prob: 0.3
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -69,6 +69,9 @@
         prob: 0.05
         orGroup: Surgshrubs
       - id: ClothingMaskSterile
+      #CD Addions
+      - id: BookSOPMedical
+        prob: 0.2
 
 - type: entity
   parent: LockerWallMedical
@@ -102,6 +105,9 @@
         prob: 0.05
         orGroup: Surgshrubs
       - id: ClothingMaskSterile
+      #CD Addions
+      - id: BookSOPMedical
+        prob: 0.2
 
 - type: entity
   id: LockerChemistryFilled
@@ -123,6 +129,9 @@
       - id: ClothingMaskSterile
       - id: HandLabeler
         prob: 0.5
+      #CD Addions
+      - id: BookSOPMedical
+        prob: 0.2
 
 - type: entity
   id: LockerParamedicFilled
@@ -143,5 +152,8 @@
       - id: ClothingMaskSterile
       - id: HandheldGPSBasic
       - id: MedkitFilled
-      - id: ETUGarmentBag #CD exclusive
+      #CD Addions
+      - id: ETUGarmentBag
         prob: 0.3
+      - id: BookSOPMedical
+        prob: 0.2

--- a/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
@@ -13,3 +13,6 @@
       - id: NodeScanner
       - id: NetworkConfigurator
         prob: 0.5
+      #CD Addions
+      - id: BookSOPScience
+        prob: 0.2

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -24,6 +24,9 @@
         amount: 2
       - id: RemoteSignaller
         amount: 2
+      #CD Addions
+      - id: BookSOPSecurity
+        prob: 0.2
 
 - type: entity
   id: LockerWardenFilled
@@ -50,6 +53,9 @@
         amount: 2
       - id: RemoteSignaller
         amount: 2
+      #CD Addions
+      - id: BookSOPSecurity
+        prob: 0.2
 
 - type: entity
   id: LockerSecurityFilled
@@ -78,6 +84,9 @@
         prob: 0.6
       - id: BookSpaceLaw
         prob: 0.5
+      #CD Addions
+      - id: BookSOPSecurity
+        prob: 0.2
 
 - type: entity
   id: LockerBrigmedicFilled
@@ -137,6 +146,9 @@
       - id: HoloprojectorSecurity
       - id: BoxEvidenceMarkers
       - id: HandLabeler
+      #CD Addions
+      - id: BookSOPSecurity
+        prob: 0.2
 
 - type: entity
   id: ClosetBombFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -21,6 +21,9 @@
         amount: 2
       - id: RagItem
         amount: 2
+      #CD Addions
+      - id: BookSOPService
+        prob: 0.2
 
 #- type: entity
 #  id: LockerFormalFilled
@@ -52,6 +55,9 @@
       - id: DrinkMilkCarton
         amount: 2
       - id: DrinkSoyMilkCarton
+      #CD Addions
+      - id: BookSOPService
+        prob: 0.2
 
 - type: entity
   id: ClosetJanitorFilled
@@ -77,6 +83,9 @@
         amount: 2
       - id: Plunger
         amount: 2
+      #CD Addions
+      - id: BookSOPService
+        prob: 0.2
 
 - type: entity
   id: ClosetLegalFilled

--- a/Resources/Prototypes/_CD/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/_CD/Entities/Objects/Misc/books.yml
@@ -1,0 +1,167 @@
+- type: entity
+  id: BookSOPGeneral
+  parent: BaseGuidebook
+  name: General Operating Procedure
+  description: The standard procedures followed on any uniform NT station.
+  components:
+  - type: Sprite
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#cccccc"
+    - state: decor_wingette_circle
+      color: "#cccccc"
+    - state: decor_wingette
+      color: "#434343"
+    - state: icon_letter_N
+      color: "#cccccc"
+  - type: GuideHelp
+    guides:
+    - CDSop
+
+- type: entity
+  id: BookSOPCommand
+  parent: BaseGuidebook
+  name: Command Operating Procedure
+  description: The standard procedures followed by command staff on any uniform NT station.
+  components:
+  - type: Sprite
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#1b67a5"
+    - state: decor_wingette_circle
+      color: "#1b67a5"
+    - state: decor_wingette
+      color: "#434343"
+    - state: icon_letter_N
+      color: "#1b67a5"
+  - type: GuideHelp
+    guides:
+    - CDSopCommand
+
+- type: entity
+  id: BookSOPSecurity
+  parent: BaseGuidebook
+  name: Security Operating Procedure
+  description: The standard procedures followed by security staff on any uniform NT station.
+  components:
+  - type: Sprite
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#cb0000"
+    - state: decor_wingette_circle
+      color: "#cb0000"
+    - state: decor_wingette
+      color: "#434343"
+    - state: icon_letter_N
+      color: "#cb0000"
+  - type: GuideHelp
+    guides:
+    - CDSopSecurity
+
+- type: entity
+  id: BookSOPEngineering
+  parent: BaseGuidebook
+  name: Engineering Operating Procedure
+  description: The standard procedures followed by engineering staff on any uniform NT station.
+  components:
+  - type: Sprite
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#f39f27"
+    - state: decor_wingette_circle
+      color: "#f39f27"
+    - state: decor_wingette
+      color: "#434343"
+    - state: icon_letter_N
+      color: "#f39f27"
+  - type: GuideHelp
+    guides:
+    - CDSopEngineering
+
+- type: entity
+  id: BookSOPMedical
+  parent: BaseGuidebook
+  name: Medical Operating Procedure
+  description: The standard procedures followed by medical staff on any uniform NT station.
+  components:
+  - type: Sprite
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#5b97bc"
+    - state: decor_wingette_circle
+      color: "#5b97bc"
+    - state: decor_wingette
+      color: "#434343"
+    - state: icon_letter_N
+      color: "#5b97bc"
+  - type: GuideHelp
+    guides:
+    - CDSopMedical
+
+- type: entity
+  id: BookSOPScience
+  parent: BaseGuidebook
+  name: Science Operating Procedure
+  description: The standard procedures followed by science staff on any uniform NT station.
+  components:
+  - type: Sprite
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#ee82ee"
+    - state: decor_wingette_circle
+      color: "#ee82ee"
+    - state: decor_wingette
+      color: "#434343"
+    - state: icon_letter_N
+      color: "#ee82ee"
+  - type: GuideHelp
+    guides:
+    - CDSopScience
+
+- type: entity
+  id: BookSOPCargo
+  parent: BaseGuidebook
+  name: Cargo Operating Procedure
+  description: The standard procedures followed by cargo staff on any uniform NT station.
+  components:
+  - type: Sprite
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#b18644"
+    - state: decor_wingette_circle
+      color: "#b18644"
+    - state: decor_wingette
+      color: "#434343"
+    - state: icon_letter_N
+      color: "#b18644"
+  - type: GuideHelp
+    guides:
+    - CDSopCargo
+
+- type: entity
+  id: BookSOPService
+  parent: BaseGuidebook
+  name: Service Operating Procedure
+  description: The standard procedures followed by service staff on any uniform NT station.
+  components:
+  - type: Sprite
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#9fed58"
+    - state: decor_wingette_circle
+      color: "#9fed58"
+    - state: decor_wingette
+      color: "#434343"
+    - state: icon_letter_N
+      color: "#9fed58"
+  - type: GuideHelp
+    guides:
+    - CDSopService


### PR DESCRIPTION
## About the PR
Adds an SOP book for each SOP guidebook entry.
Places them rarely in related department lockers and bookcases.

## Why / Balance
Mostly just to draw attention to the SOP, but also gives people confirmation that the SOP is an in-world document.

## Media
![image](https://github.com/user-attachments/assets/09edfe3a-badf-4fea-a181-d0a6dfce4ac0)

**Changelog**
New SOP books linking to the SOP guidebook entries will occasionally spawn in their related department lockers.