### PR TITLE
Re-adding the Salvage Shuttle

### DIFF
--- a/Resources/Maps/Shuttles/mining_legacy.yml
+++ b/Resources/Maps/Shuttles/mining_legacy.yml
@@ -11,7 +11,7 @@ tilemap:
 entities:
 - proto: ""
   entities:
-  - uid: 1
+  - uid: 181
     components:
     - type: MetaData
       name: NT-Reclaimer
@@ -34,7 +34,7 @@ entities:
           version: 6
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAACWQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAAAeQAAAAAAWQAAAAACeQAAAAAAWQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAACWQAAAAADeQAAAAAAeAAAAAAAWQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAADWQAAAAACeQAAAAAAeQAAAAAAWQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAWQAAAAACWQAAAAABWQAAAAADWQAAAAABWQAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAACWQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAACWQAAAAACWQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAACWQAAAAADWQAAAAACWQAAAAADWQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAWQAAAAADWQAAAAACWQAAAAAAWQAAAAADWQAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeQAAAAAAWQAAAAACWQAAAAABWQAAAAADWQAAAAABWQAAAAAA
           version: 6
     - type: Broadphase
     - type: Physics
@@ -130,6 +130,8 @@ entities:
             32: -3,5
             33: -2,-1
             34: -3,-2
+            35: -2,-3
+            36: -3,-3
             37: -3,-4
             38: -2,-5
             39: -1,-4
@@ -216,6 +218,8 @@ entities:
             123: -1.7526793,-4.109577
             124: -1.7526793,-4.500202
             125: -0.75267935,-2.5314522
+            126: -1.3308043,-2.1720772
+            127: -1.3933043,-2.6564522
         - node:
             cleanable: True
             angle: -3.141592653589793 rad
@@ -229,6 +233,7 @@ entities:
             108: -2.3933043,1.1278267
             109: -2.1276793,-1.5909233
             110: -2.4089293,-1.9971733
+            111: -1.9245543,-2.6690483
             112: -2.3620543,-3.0909233
             113: -1.8776793,-3.6846733
             114: -2.2683043,-4.0284233
@@ -270,6 +275,8 @@ entities:
             color: '#0000004A'
             id: footprint
           decals:
+            141: -2.6433043,-2.883874
+            142: -2.3776793,-2.508874
             143: -2.8933043,-1.8994989
             144: -2.3933043,-1.5869989
             145: -2.7683043,-0.89949894
@@ -406,36 +413,65 @@ entities:
       version: 2
       data:
         tiles:
-          -2,0:
-            0: 12000
           -2,-1:
+            0: 52428
             1: 8192
-            0: 34952
-          -2,1:
-            1: 2116
-          -1,0:
-            0: 32758
-          -1,1:
-            0: 9847
-            1: 22528
+          -1,-3:
+            0: 65504
           -1,-1:
-            0: 65471
-            1: 64
-          0,0:
-            0: 816
-          0,1:
-            1: 17
-          0,-2:
-            1: 16
-            0: 4096
-          0,-1:
-            0: 273
-            1: 8192
+            0: 65535
           -1,-2:
-            0: 63350
+            0: 65535
+          -2,1:
+            0: 52428
+          -1,0:
+            0: 65535
+          -1,1:
+            0: 65535
+          -1,2:
+            0: 61183
+          -1,3:
+            0: 52974
+          0,-3:
+            0: 65520
+          0,-2:
+            0: 65535
+          0,-1:
+            0: 65535
+          1,-3:
+            0: 13072
+          1,-2:
+            0: 13107
+          1,-1:
+            0: 21811
+          0,1:
+            0: 65535
+          0,2:
+            0: 65535
+          0,3:
+            0: 65535
+          0,0:
+            0: 65535
+          1,3:
+            0: 273
+          1,0:
+            0: 30583
+          1,1:
+            0: 30039
+          1,2:
+            0: 4403
+          0,4:
+            0: 127
+          -1,4:
+            0: 140
+          -2,0:
+            0: 52428
+            1: 8738
+          -2,2:
+            0: 140
           -2,-2:
-            1: 64
             0: 32768
+            1: 19656
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
@@ -453,7 +489,7 @@ entities:
           - 0
           - 0
         - volume: 2500
-          immutable: True
+          temperature: 293.15
           moles:
           - 0
           - 0
@@ -478,905 +514,866 @@ entities:
     - type: GridPathfinding
 - proto: AirlockCargoGlass
   entities:
-  - uid: 2
+  - uid: 29
     components:
     - type: Transform
       pos: -2.5,0.5
-      parent: 1
-  - uid: 3
+      parent: 181
+  - uid: 127
     components:
     - type: Transform
       pos: -1.5,0.5
-      parent: 1
+      parent: 181
 - proto: AirlockExternal
+  entities:
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 181
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 181
+- proto: AirlockShuttle
   entities:
   - uid: 4
     components:
     - type: Transform
-      pos: -0.5,2.5
-      parent: 1
-  - uid: 5
-    components:
-    - type: Transform
-      pos: -0.5,1.5
-      parent: 1
-- proto: AirlockShuttle
-  entities:
-  - uid: 6
-    components:
-    - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,2.5
-      parent: 1
-  - uid: 7
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,1.5
-      parent: 1
-- proto: APCBasic
-  entities:
-  - uid: 8
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-5.5
-      parent: 1
-  - uid: 9
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,3.5
-      parent: 1
-- proto: AtmosDeviceFanDirectional
-  entities:
-  - uid: 10
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 1
-  - uid: 11
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 12
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,2.5
-      parent: 1
+      parent: 181
   - uid: 13
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,1.5
-      parent: 1
-- proto: BlastDoorExterior1
+      parent: 181
+- proto: APCBasic
   entities:
-  - uid: 14
-    components:
-    - type: Transform
-      pos: -5.5,-2.5
-      parent: 1
-  - uid: 15
-    components:
-    - type: Transform
-      pos: -5.5,-3.5
-      parent: 1
-  - uid: 16
-    components:
-    - type: Transform
-      pos: -5.5,-1.5
-      parent: 1
-- proto: BookHowToSurvive
-  entities:
-  - uid: 17
-    components:
-    - type: Transform
-      pos: -4.4318056,-4.361971
-      parent: 1
-- proto: BorgModuleMining
-  entities:
-  - uid: 18
-    components:
-    - type: Transform
-      pos: -1.4982989,5.541272
-      parent: 1
-- proto: CableApcExtension
-  entities:
-  - uid: 19
-    components:
-    - type: Transform
-      pos: -3.5,-6.5
-      parent: 1
-  - uid: 20
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 1
-  - uid: 21
-    components:
-    - type: Transform
-      pos: -4.5,3.5
-      parent: 1
-  - uid: 22
-    components:
-    - type: Transform
-      pos: -3.5,3.5
-      parent: 1
-  - uid: 23
-    components:
-    - type: Transform
-      pos: -2.5,3.5
-      parent: 1
-  - uid: 24
-    components:
-    - type: Transform
-      pos: -3.5,-3.5
-      parent: 1
-  - uid: 25
-    components:
-    - type: Transform
-      pos: -4.5,-1.5
-      parent: 1
-  - uid: 26
-    components:
-    - type: Transform
-      pos: -0.5,-3.5
-      parent: 1
-  - uid: 27
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
-      parent: 1
-  - uid: 28
-    components:
-    - type: Transform
-      pos: -3.5,-2.5
-      parent: 1
-  - uid: 29
-    components:
-    - type: Transform
-      pos: -0.5,-1.5
-      parent: 1
-  - uid: 30
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 1
-  - uid: 31
-    components:
-    - type: Transform
-      pos: -3.5,-5.5
-      parent: 1
-  - uid: 32
-    components:
-    - type: Transform
-      pos: -4.5,-2.5
-      parent: 1
-  - uid: 33
-    components:
-    - type: Transform
-      pos: -0.5,-5.5
-      parent: 1
-  - uid: 34
-    components:
-    - type: Transform
-      pos: -2.5,4.5
-      parent: 1
-  - uid: 35
-    components:
-    - type: Transform
-      pos: -2.5,2.5
-      parent: 1
-  - uid: 36
-    components:
-    - type: Transform
-      pos: -2.5,1.5
-      parent: 1
-  - uid: 37
-    components:
-    - type: Transform
-      pos: -2.5,5.5
-      parent: 1
-  - uid: 38
-    components:
-    - type: Transform
-      pos: -1.5,2.5
-      parent: 1
-  - uid: 39
-    components:
-    - type: Transform
-      pos: -0.5,2.5
-      parent: 1
-  - uid: 40
-    components:
-    - type: Transform
-      pos: -4.5,1.5
-      parent: 1
-  - uid: 41
-    components:
-    - type: Transform
-      pos: -3.5,1.5
-      parent: 1
-  - uid: 42
-    components:
-    - type: Transform
-      pos: 0.5,2.5
-      parent: 1
-  - uid: 43
-    components:
-    - type: Transform
-      pos: -5.5,1.5
-      parent: 1
-  - uid: 44
-    components:
-    - type: Transform
-      pos: -0.5,-2.5
-      parent: 1
-  - uid: 45
-    components:
-    - type: Transform
-      pos: -3.5,-4.5
-      parent: 1
-- proto: CableHV
-  entities:
-  - uid: 46
-    components:
-    - type: Transform
-      pos: -3.5,-6.5
-      parent: 1
-  - uid: 47
-    components:
-    - type: Transform
-      pos: -3.5,-5.5
-      parent: 1
-  - uid: 48
-    components:
-    - type: Transform
-      pos: -4.5,-5.5
-      parent: 1
-- proto: CableMV
-  entities:
-  - uid: 49
-    components:
-    - type: Transform
-      pos: -0.5,-5.5
-      parent: 1
-  - uid: 50
-    components:
-    - type: Transform
-      pos: -2.5,-3.5
-      parent: 1
-  - uid: 51
-    components:
-    - type: Transform
-      pos: -2.5,2.5
-      parent: 1
-  - uid: 52
-    components:
-    - type: Transform
-      pos: -2.5,3.5
-      parent: 1
-  - uid: 53
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
-      parent: 1
-  - uid: 54
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 1
-  - uid: 55
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 1
-  - uid: 56
-    components:
-    - type: Transform
-      pos: -4.5,3.5
-      parent: 1
-  - uid: 57
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 58
-    components:
-    - type: Transform
-      pos: -3.5,3.5
-      parent: 1
-  - uid: 59
-    components:
-    - type: Transform
-      pos: -2.5,1.5
-      parent: 1
-  - uid: 60
-    components:
-    - type: Transform
-      pos: -2.5,-4.5
-      parent: 1
-  - uid: 61
-    components:
-    - type: Transform
-      pos: -4.5,-5.5
-      parent: 1
-  - uid: 62
-    components:
-    - type: Transform
-      pos: -3.5,-5.5
-      parent: 1
-  - uid: 63
-    components:
-    - type: Transform
-      pos: -2.5,-5.5
-      parent: 1
-  - uid: 64
-    components:
-    - type: Transform
-      pos: -1.5,-5.5
-      parent: 1
-- proto: Catwalk
-  entities:
-  - uid: 65
-    components:
-    - type: Transform
-      pos: -2.5,-5.5
-      parent: 1
-- proto: Chair
-  entities:
-  - uid: 66
+  - uid: 7
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,5.5
-      parent: 1
-- proto: ComputerBroken
-  entities:
-  - uid: 67
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,5.5
-      parent: 1
-- proto: ComputerShuttleSalvage
-  entities:
-  - uid: 152
-    components:
-    - type: Transform
-      pos: -2.5,6.5
-      parent: 1
-- proto: FloraRockSolid02
-  entities:
-  - uid: 69
-    components:
-    - type: MetaData
-      desc: God I wish this ship had windshield wipers...
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.756568,7.314354
-      parent: 1
-- proto: GasPassiveVent
-  entities:
-  - uid: 71
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,5.5
-      parent: 1
-- proto: GasPipeBend
-  entities:
+      pos: -0.5,-5.5
+      parent: 181
   - uid: 68
     components:
     - type: Transform
-      pos: -4.5,5.5
-      parent: 1
-  - uid: 70
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,4.5
-      parent: 1
-- proto: GasPort
-  entities:
-  - uid: 72
-    components:
-    - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -5.5,2.5
-      parent: 1
-- proto: GasVentPump
+      pos: -4.5,3.5
+      parent: 181
+- proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 73
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,2.5
-      parent: 1
-- proto: GasVentScrubber
-  entities:
-  - uid: 74
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,4.5
-      parent: 1
-- proto: Girder
-  entities:
-  - uid: 75
-    components:
-    - type: Transform
-      pos: -6.5,1.5
-      parent: 1
-  - uid: 76
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-4.5
-      parent: 1
-- proto: Grille
-  entities:
-  - uid: 77
-    components:
-    - type: Transform
-      pos: 0.5,-1.5
-      parent: 1
-  - uid: 78
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-7.5
-      parent: 1
-  - uid: 79
-    components:
-    - type: Transform
-      pos: -3.5,6.5
-      parent: 1
-  - uid: 80
-    components:
-    - type: Transform
-      pos: -0.5,5.5
-      parent: 1
-  - uid: 81
-    components:
-    - type: Transform
-      pos: -2.5,7.5
-      parent: 1
-  - uid: 82
-    components:
-    - type: Transform
-      pos: -1.5,6.5
-      parent: 1
-- proto: GrilleBroken
-  entities:
-  - uid: 83
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-7.5
-      parent: 1
-  - uid: 84
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-2.5
-      parent: 1
-  - uid: 85
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-7.5
-      parent: 1
-- proto: GrilleDiagonal
-  entities:
-  - uid: 86
-    components:
-    - type: Transform
-      pos: -4.5,6.5
-      parent: 1
-  - uid: 87
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,6.5
-      parent: 1
-  - uid: 88
-    components:
-    - type: Transform
-      pos: -3.5,7.5
-      parent: 1
-- proto: Gyroscope
-  entities:
-  - uid: 89
-    components:
-    - type: Transform
-      pos: -0.5,-0.5
-      parent: 1
-- proto: MachineFrameDestroyed
-  entities:
-  - uid: 90
-    components:
-    - type: Transform
-      pos: -6.5,-0.5
-      parent: 1
-  - uid: 91
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 1
-- proto: PersonalAI
-  entities:
-  - uid: 92
-    components:
-    - type: Transform
-      pos: -1.4453101,4.467156
-      parent: 1
-- proto: PortableGeneratorJrPacman
-  entities:
-  - uid: 93
-    components:
-    - type: Transform
-      pos: -3.5,-6.5
-      parent: 1
-  - uid: 94
-    components:
-    - type: Transform
-      pos: -5.5,1.5
-      parent: 1
-- proto: PoweredSmallLight
-  entities:
-  - uid: 95
-    components:
-    - type: Transform
-      pos: -5.5,2.5
-      parent: 1
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 96
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,1.5
-      parent: 1
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 97
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,4.5
-      parent: 1
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 98
-    components:
-    - type: Transform
-      pos: -0.5,-0.5
-      parent: 1
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 99
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-4.5
-      parent: 1
-    - type: ApcPowerReceiver
-      powerLoad: 0
-- proto: Rack
-  entities:
-  - uid: 100
-    components:
-    - type: Transform
-      pos: -1.5,4.5
-      parent: 1
-  - uid: 101
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 1
-  - uid: 102
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-4.5
-      parent: 1
-- proto: RandomPosterAny
-  entities:
-  - uid: 103
-    components:
-    - type: Transform
-      pos: -0.5,3.5
-      parent: 1
-  - uid: 104
-    components:
-    - type: Transform
-      pos: -4.5,-6.5
-      parent: 1
-- proto: ShardGlass
-  entities:
-  - uid: 105
-    components:
-    - type: Transform
-      pos: -1.4543252,-6.373854
-      parent: 1
-  - uid: 106
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.209693,5.033104
-      parent: 1
-  - uid: 107
-    components:
-    - type: Transform
-      pos: -1.9830661,4.992176
-      parent: 1
-  - uid: 108
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.1829958,-1.9819856
-      parent: 1
-  - uid: 109
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.4314065,-3.745016
-      parent: 1
-  - uid: 110
-    components:
-    - type: Transform
-      pos: -0.876719,-2.9715786
-      parent: 1
-  - uid: 111
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.365943,5.814354
-      parent: 1
-  - uid: 112
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.3605752,-6.748854
-      parent: 1
-  - uid: 113
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.787818,6.126854
-      parent: 1
-- proto: SignalButtonExt1
-  entities:
-  - uid: 114
-    components:
-    - type: Transform
-      pos: -5.5,-0.5
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        16:
-        - Pressed: Toggle
-        14:
-        - Pressed: Toggle
-        15:
-        - Pressed: Toggle
-- proto: SubstationWallBasic
-  entities:
-  - uid: 115
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-5.5
-      parent: 1
-- proto: Table
-  entities:
-  - uid: 116
-    components:
-    - type: Transform
-      pos: -1.5,5.5
-      parent: 1
-- proto: Thruster
-  entities:
-  - uid: 117
-    components:
-    - type: Transform
-      pos: 0.5,4.5
-      parent: 1
-  - uid: 118
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-6.5
-      parent: 1
-- proto: WallSolid
-  entities:
-  - uid: 119
-    components:
-    - type: Transform
-      pos: -3.5,0.5
-      parent: 1
-  - uid: 120
-    components:
-    - type: Transform
-      pos: -4.5,-6.5
-      parent: 1
-  - uid: 121
-    components:
-    - type: Transform
-      pos: 0.5,0.5
-      parent: 1
-  - uid: 122
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 123
-    components:
-    - type: Transform
-      pos: -0.5,-5.5
-      parent: 1
-  - uid: 124
-    components:
-    - type: Transform
-      pos: -0.5,3.5
-      parent: 1
-  - uid: 125
-    components:
-    - type: Transform
-      pos: 0.5,-5.5
-      parent: 1
-  - uid: 126
-    components:
-    - type: Transform
-      pos: -5.5,-4.5
-      parent: 1
-  - uid: 127
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,3.5
-      parent: 1
   - uid: 128
     components:
     - type: Transform
-      pos: -5.5,0.5
-      parent: 1
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 181
   - uid: 129
     components:
     - type: Transform
-      pos: -4.5,-7.5
-      parent: 1
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 181
   - uid: 130
     components:
     - type: Transform
-      pos: -5.5,-0.5
-      parent: 1
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 181
   - uid: 131
     components:
     - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-- proto: WallSolidRust
-  entities:
-  - uid: 132
-    components:
-    - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -4.5,3.5
-      parent: 1
+      pos: 1.5,2.5
+      parent: 181
   - uid: 133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -5.5,-5.5
-      parent: 1
-  - uid: 134
+      pos: 1.5,1.5
+      parent: 181
+- proto: BlastDoorExterior1
+  entities:
+  - uid: 37
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,4.5
-      parent: 1
-  - uid: 135
+      pos: -5.5,-2.5
+      parent: 181
+  - uid: 47
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-6.5
-      parent: 1
-  - uid: 136
+      pos: -5.5,-3.5
+      parent: 181
+  - uid: 69
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-7.5
-      parent: 1
-  - uid: 137
+      pos: -5.5,-1.5
+      parent: 181
+- proto: BorgModuleMining
+  entities:
+  - uid: 94
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,3.5
-      parent: 1
-  - uid: 138
+      pos: -1.4982989,5.541272
+      parent: 181
+- proto: CableApcExtension
+  entities:
+  - uid: 1
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 139
+      pos: -3.5,-6.5
+      parent: 181
+  - uid: 3
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,0.5
-      parent: 1
-  - uid: 140
+      pos: -0.5,-4.5
+      parent: 181
+  - uid: 15
     components:
     - type: Transform
-      pos: -0.5,0.5
-      parent: 1
-  - uid: 141
+      pos: -4.5,3.5
+      parent: 181
+  - uid: 21
     components:
     - type: Transform
-      pos: -4.5,0.5
-      parent: 1
-  - uid: 142
+      pos: -3.5,3.5
+      parent: 181
+  - uid: 28
     components:
     - type: Transform
-      pos: -0.5,4.5
-      parent: 1
-  - uid: 143
+      pos: -2.5,3.5
+      parent: 181
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 181
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 181
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 181
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 181
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 181
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 181
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 181
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 181
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 181
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 181
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 181
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 181
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 181
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 181
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 181
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 181
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 181
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 181
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 181
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 181
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 181
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 181
+- proto: CableHV
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 181
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 181
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 181
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 181
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 181
+  - uid: 76
     components:
     - type: Transform
       pos: -4.5,-5.5
-      parent: 1
-- proto: WeldingFuelTank
+      parent: 181
+- proto: CableMV
   entities:
-  - uid: 144
+  - uid: 8
     components:
-    - type: MetaData
-      desc: They took every drop of fuel in the budget cuts, at least the tank is still here..
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 181
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 181
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 181
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 181
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 181
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 181
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 181
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 181
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 181
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 181
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 181
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 181
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 181
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 181
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 181
+  - uid: 73
+    components:
     - type: Transform
       pos: -1.5,-5.5
-      parent: 1
-- proto: Window
+      parent: 181
+- proto: CableTerminal
   entities:
-  - uid: 145
+  - uid: 77
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 181
+- proto: Catwalk
+  entities:
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 181
+- proto: Chair
+  entities:
+  - uid: 55
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 181
+- proto: ComputerCargoOrders
+  entities:
+  - uid: 153
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 181
+- proto: ComputerShuttle
+  entities:
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 181
+- proto: GasPort
+  entities:
+  - uid: 25
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 181
+- proto: GasVentPump
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-4.5
+      parent: 181
+- proto: GeneratorBasic
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 181
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 181
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 181
+- proto: Grille
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 181
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 181
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 181
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 181
+  - uid: 56
     components:
     - type: Transform
       pos: -3.5,6.5
-      parent: 1
-  - uid: 146
+      parent: 181
+  - uid: 57
     components:
     - type: Transform
       pos: -0.5,5.5
-      parent: 1
-  - uid: 147
+      parent: 181
+  - uid: 136
     components:
     - type: Transform
-      pos: -3.5,-7.5
-      parent: 1
-  - uid: 148
+      pos: -2.5,7.5
+      parent: 181
+  - uid: 151
     components:
     - type: Transform
-      pos: -4.5,5.5
-      parent: 1
-- proto: WindowDiagonal
+      pos: -1.5,6.5
+      parent: 181
+- proto: GrilleDiagonal
   entities:
-  - uid: 149
+  - uid: 46
     components:
     - type: Transform
-      pos: -3.5,7.5
-      parent: 1
-  - uid: 150
+      pos: -4.5,6.5
+      parent: 181
+  - uid: 101
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,6.5
-      parent: 1
-  - uid: 151
+      parent: 181
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 181
+- proto: Gyroscope
+  entities:
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 181
+- proto: PersonalAI
+  entities:
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -1.4453101,4.467156
+      parent: 181
+- proto: PoweredSmallLight
+  entities:
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 181
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 140
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 181
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 141
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 181
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 181
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 143
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-4.5
+      parent: 181
+    - type: ApcPowerReceiver
+      powerLoad: 0
+- proto: Rack
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 181
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 181
+- proto: RandomPosterAny
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 181
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 181
+- proto: SignalButtonExt1
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 181
+    - type: DeviceLinkSource
+      linkedPorts:
+        69:
+        - Pressed: Toggle
+        37:
+        - Pressed: Toggle
+        47:
+        - Pressed: Toggle
+- proto: SMESBasic
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 181
+- proto: SubstationWallBasic
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 181
+- proto: Table
+  entities:
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 181
+- proto: Thruster
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 181
+  - uid: 115
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 181
+  - uid: 119
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-6.5
+      parent: 181
+  - uid: 120
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 181
+- proto: WallSolid
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 181
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 181
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 181
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 181
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 181
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 181
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 181
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 181
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 181
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 181
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 181
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 181
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 181
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 181
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 181
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 181
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 181
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 181
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 181
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 181
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 181
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 181
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 181
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 181
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 181
+- proto: WallSolidRust
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 181
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 181
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 181
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 181
+  - uid: 147
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 181
+- proto: Window
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 181
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 181
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 181
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 181
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 181
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 181
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 181
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 181
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 181
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 181
+- proto: WindowDiagonal
+  entities:
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 181
+  - uid: 92
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 181
+  - uid: 105
     components:
     - type: Transform
       pos: -4.5,6.5
-      parent: 1
+      parent: 181
+  - uid: 112
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 181
 ...

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -17,6 +17,7 @@
     - id: RubberStampApproved
     - id: RubberStampDenied
     - id: RubberStampQm
+    - id: SalvageShuttleConsoleCircuitboard # CD change
 
 - type: entity
   id: LockerQuarterMasterFilled

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -52,6 +52,9 @@
             - type: TradeStation
           paths:
             - /Maps/Shuttles/trading_outpost.yml
+        mining: !type:GridSpawnGroup # CD change
+          paths:
+          - /Maps/Shuttles/mining.yml # CD change
         # Spawn last
         ruins: !type:GridSpawnGroup
           hide: true

--- a/Resources/Prototypes/_CD/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/_CD/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -1,0 +1,10 @@
+- type: entity
+  parent: BaseComputerCircuitboard
+  id: SalvageShuttleConsoleCircuitboard
+  name: salvage shuttle console board
+  description: A computer printed circuit board for a salvage shuttle console.
+  components:
+    - type: ComputerBoard
+      prototype: ComputerShuttleSalvage
+    - type: StealTarget
+      stealGroup: SalvageShuttleConsoleCircuitboard

--- a/Resources/Prototypes/_CD/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_CD/Entities/Structures/Machines/Computers/computers.yml
@@ -1,0 +1,30 @@
+- type: entity
+  parent: BaseComputerShuttle
+  id: ComputerShuttleSalvage
+  name: salvage shuttle console
+  description: Used to pilot the salvage shuttle.
+  components:
+    - type: Sprite
+      layers:
+        - map: ["computerLayerBody"]
+          state: computer
+        - map: ["computerLayerKeyboard"]
+          state: generic_keyboard
+        - map: ["computerLayerScreen"]
+          state: shuttle
+        - map: ["computerLayerKeys"]
+          state: generic_keys
+    - type: DroneConsole
+      components:
+        - type: SalvageShuttle
+    - type: RadarConsole
+      maxRange: 256
+    - type: PointLight
+      radius: 1.5
+      energy: 1.6
+      color: "#43ccb5"
+    - type: Computer
+      board: SalvageShuttleConsoleCircuitboard
+    # type: StealTarget
+      # stealGroup: SalvageShuttleConsoleCircuitboard 
+      ## left it here incase someone adds the thief objectives part back

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -386,9 +386,7 @@ ClothingBeltSuspenders: ClothingBeltSuspendersRed
 ClothingNeckShockCollar: ClothingBackpackElectropack
 
 # 2024-08-22
-ComputerShuttleSalvage: null
-SalvageShuttleConsoleCircuitboard: null
-SalvageShuttleCircuitboardStealObjective: null
+ # Originally the pr that removed the salvage shuttle, this change has been reverted, CD change
 
 # 2024-08-28
 ClothingBackpackDuffelSyndicateCostumeCentcom: null


### PR DESCRIPTION

## **ITS BACK!**
The reclaimer has returned, with a few dents and holes you'll have to patch up.

To be more specific, the reclaimer and salvage shuttle console board/computer have been re-added.
You can also find a spare board in the QM's locker, just remember to ask first.

## Why / Balance
I was asked very nicely.

## Media
The (NEW) reclaimer _(posters shown are randomized)_
![image](https://github.com/user-attachments/assets/bfe8e494-54b6-492b-969c-37284f443253)
Salvage shuttle console
![image](https://github.com/user-attachments/assets/9d701bb0-ec0a-4e40-8492-52e3122aed19)
Board found in the QM's locker
![image](https://github.com/user-attachments/assets/cccd4649-1c58-4eff-ba24-9156908b04c5)


## Requirements

- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
- The reclaimer has returned.
- Salvage shuttle boards and computers exist again.
- Qm lockers come with 1 spare salvage shuttle console board.
