### PR TITLE
Detective Ledger adjustment

### DIFF
--- a/Resources/Prototypes/_CD/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_CD/Entities/Objects/Misc/paper.yml
@@ -17,7 +17,7 @@
     - state: clipboard_over
   - type: Item
     sprite: _CD/Objects/Misc/ledger.rsi
-    size: 20
+    size: 10
   - type: Clothing
     sprite: _CD/Objects/Misc/ledger.rsi
   - type: Storage


### PR DESCRIPTION
## About the PR
As reported by players, the Ledger is impractically large, so this halves the size and makes it fit in jackets

## Why / Balance
It was bigger then a full oxygen tank

## Technical details
Changes _CD's paper.yml, changes a 20 to a 10

## Requirements
<!--
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
* Tweak: Halved the size of the detective ledger
