### PR TITLE
Avali Speech Fix.

### DIFF
--- a/Resources/Prototypes/_CD/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_CD/Entities/Mobs/Species/avali.yml
@@ -20,6 +20,9 @@
     spawned:
     - id: FoodMeatChicken
       amount: 3
+  - type: Speech
+    speechVerb: Parrot # RMC did it right.
+    speechSounds: MaleAvali
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
## About the PR
Title / Copied speech tag added to Avali in RMC.

## Why / Balance
Speech sounds were broken, this fixes it.

## Technical details
3 lines of code in avali species yml

## Requirements

- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
:cl:

fix: Avali now chirp and squeak correctly.
