### PR TITLE
Fix EMT Jacket

### DIFF
--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Medical/paramedic.yml
@@ -41,4 +41,4 @@
 - type: loadout
   id: BlueHighvisBomber
   equipment: 
-    jumpsuit: ClothingOuterCoatBlueHiVis
+    outerClothing: ClothingOuterCoatBlueHiVis


### PR DESCRIPTION
## About the PR
The EMT Jacket properly spawn and no longer means players spawn without a jumpsuit.

## Why / Balance
Bug - Closes #455 
