### PR TITLE
Increase Character Description Examine Range

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -42,7 +42,7 @@ namespace Content.Shared.Examine
         public const float DeadExamineRange = 0.75f;
 
         public const float ExamineRange = 16f;
-        protected const float ExamineDetailsRange = 3f;
+        protected const float ExamineDetailsRange = 8f; // CD change from 3 to 8.
 
         protected const float ExamineBlurrinessMult = 2.5f;
 


### PR DESCRIPTION
## About the PR
Makes it so you can view character descriptions from 8 tiles away instead of 3.

## Why / Balance
I remember RMC doing this and in general, I don't want to have to hug someone to read their typically at least one paragraph long description.

## Media
![image](https://github.com/user-attachments/assets/47248806-9772-4333-86a3-68147a2e53be)

**Changelog**
You can now view character descriptions from a much greater range.