### PR TITLE
Remove Opporozidone and Cloning, Increase Rot Timer

### DIFF
--- a/Content.Shared/Atmos/Rotting/PerishableComponent.cs
+++ b/Content.Shared/Atmos/Rotting/PerishableComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class PerishableComponent : Component
     /// How long it takes after death to start rotting.
     /// </summary>
     [DataField("rotAfter"), ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan RotAfter = TimeSpan.FromMinutes(15);
+    public TimeSpan RotAfter = TimeSpan.FromMinutes(25); // CD: Increased to 25 from 15
 
     /// <summary>
     /// How much rotting has occured

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -152,8 +152,8 @@
           reagents:
             - ReagentId: Ash
               Quantity: 25
-            - ReagentId: Necrosol
-              Quantity: 25
+            # - ReagentId: Necrosol # CD Change: removed necrosol
+            #   Quantity: 25
     - type: GuideHelp
       guides:
       - MinorAntagonists

--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -31,11 +31,11 @@
     CratePartsT3: 1.0
     CratePartsT3T4: 0.5
     TechnologyDiskRare: 0.5
-    # cloning boards
-    CloningPodMachineCircuitboard: 0.5
-    MedicalScannerMachineCircuitboard: 0.5
-    CloningConsoleComputerCircuitboard: 0.5
-    BiomassReclaimerMachineCircuitboard: 0.5
+    # cloning boards # CD Change: Removed Cloning
+    # CloningPodMachineCircuitboard: 0.5
+    # MedicalScannerMachineCircuitboard: 0.5
+    # CloningConsoleComputerCircuitboard: 0.5
+    # BiomassReclaimerMachineCircuitboard: 0.5
     # basic weapons
     Machete: 0.25
     Katana: 0.25

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1182,34 +1182,34 @@
 #           - !type:MobStateCondition
 #             mobstate: Dead
 
-- type: reagent
-  id: Necrosol
-  name: reagent-name-necrosol
-  group: Medicine
-  desc: reagent-desc-necrosol
-  physicalDesc: reagent-physical-desc-necrotic
-  flavor: medicine
-  color: "#86a5bd"
-  worksOnTheDead: true
-  plantMetabolism:
-  - !type:PlantAdjustToxins
-    amount: -5
-  - !type:PlantAdjustHealth
-    amount: 5
-  - !type:PlantCryoxadone {}
-  metabolisms:
-    Medicine:
-      effects:
-        - !type:HealthChange
-          conditions:
-          - !type:Temperature
-            max: 213.0
-          damage:
-            groups:
-              Brute: -4
-              Burn: -5
-            types:
-              Poison: -2
+# - type: reagent # CD Change: removed necrosol
+#   id: Necrosol
+#   name: reagent-name-necrosol
+#   group: Medicine
+#   desc: reagent-desc-necrosol
+#   physicalDesc: reagent-physical-desc-necrotic
+#   flavor: medicine
+#   color: "#86a5bd"
+#   worksOnTheDead: true
+#   plantMetabolism:
+#   - !type:PlantAdjustToxins
+#     amount: -5
+#   - !type:PlantAdjustHealth
+#     amount: 5
+#   - !type:PlantCryoxadone {}
+#   metabolisms:
+#     Medicine:
+#       effects:
+#         - !type:HealthChange
+#           conditions:
+#           - !type:Temperature
+#             max: 213.0
+#           damage:
+#             groups:
+#               Brute: -4
+#               Burn: -5
+#             types:
+#               Poison: -2
 
 - type: reagent
   id : Aloxadone

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1161,26 +1161,26 @@
         - !type:ReagentThreshold
           min: 12
           
-- type: reagent
-  id: Opporozidone #Name based of an altered version of the startreck chem "Opporozine"
-  name: reagent-name-opporozidone
-  group: Medicine
-  desc: reagent-desc-opporozidone
-  physicalDesc: reagent-physical-desc-sickly
-  flavor: acid
-  color: "#b5e36d"
-  worksOnTheDead: true
-  metabolisms:
-    Medicine:
-      effects:
-        - !type:ReduceRotting
-          seconds: 20
-          conditions:
-          #Patient must be dead and in a cryo tube (or something cold)
-          - !type:Temperature
-            max: 150.0
-          - !type:MobStateCondition
-            mobstate: Dead
+# - type: reagent # CD Change: Removed opporozidone
+#   id: Opporozidone #Name based of an altered version of the startreck chem "Opporozine"
+#   name: reagent-name-opporozidone
+#   group: Medicine
+#   desc: reagent-desc-opporozidone
+#   physicalDesc: reagent-physical-desc-sickly
+#   flavor: acid
+#   color: "#b5e36d"
+#   worksOnTheDead: true
+#   metabolisms:
+#     Medicine:
+#       effects:
+#         - !type:ReduceRotting
+#           seconds: 20
+#           conditions:
+#           #Patient must be dead and in a cryo tube (or something cold)
+#           - !type:Temperature
+#             max: 150.0
+#           - !type:MobStateCondition
+#             mobstate: Dead
 
 - type: reagent
   id: Necrosol

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -570,19 +570,19 @@
 #   products:
 #     Opporozidone: 3
 
-- type: reaction
-  id: Necrosol
-  impact: Medium
-  minTemp: 370
-  reactants:
-    Blood:
-      amount: 3
-    Omnizine:
-      amount: 1
-    Cryoxadone:
-      amount: 2
-  products:
-    Necrosol: 2
+# - type: reaction # CD Change: removed necrosol
+#   id: Necrosol
+#   impact: Medium
+#   minTemp: 370
+#   reactants:
+#     Blood:
+#       amount: 3
+#     Omnizine:
+#       amount: 1
+#     Cryoxadone:
+#       amount: 2
+#   products:
+#     Necrosol: 2
 
 - type: reaction
   id: Aloxadone

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -557,18 +557,18 @@
   products:
     Insuzine: 3
 
-- type: reaction
-  id: Opporozidone
-  minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
-  reactants:
-    Cognizine: 
-      amount: 1
-    Plasma:
-      amount: 2
-    Doxarubixadone:
-      amount: 1
-  products:
-    Opporozidone: 3
+# - type: reaction # CD Change: Removed Opporozidone
+#   id: Opporozidone
+#   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
+#   reactants:
+#     Cognizine: 
+#       amount: 1
+#     Plasma:
+#       amount: 2
+#     Doxarubixadone:
+#       amount: 1
+#   products:
+#     Opporozidone: 3
 
 - type: reaction
   id: Necrosol

--- a/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
@@ -48,7 +48,5 @@ The standard pressure for a gas pump is 100.325 kpa. Cryoxadone works at under 1
 <GuideReagentEmbed Reagent="Doxarubixadone"/>
 <GuideReagentEmbed Reagent="Dexalin"/>
 <GuideReagentEmbed Reagent="Leporazine"/>
-<!-- <GuideReagentEmbed Reagent="Necrosol"/> !-->
-<!-- <GuideReagentEmbed Reagent="Opporozidone"/> -->
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
@@ -48,7 +48,7 @@ The standard pressure for a gas pump is 100.325 kpa. Cryoxadone works at under 1
 <GuideReagentEmbed Reagent="Doxarubixadone"/>
 <GuideReagentEmbed Reagent="Dexalin"/>
 <GuideReagentEmbed Reagent="Leporazine"/>
-<GuideReagentEmbed Reagent="Necrosol"/>
-<GuideReagentEmbed Reagent="Opporozidone"/>
+<!-- <GuideReagentEmbed Reagent="Necrosol"/> !-->
+<!-- <GuideReagentEmbed Reagent="Opporozidone"/> -->
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Service/Botany.xml
+++ b/Resources/ServerInfo/Guidebook/Service/Botany.xml
@@ -82,7 +82,7 @@ Some chemicals have special effects on plants.
 
 <GuideReagentEmbed Reagent="Dylovene"/>
 <GuideReagentEmbed Reagent="Cryoxadone"/>
-<GuideReagentEmbed Reagent="Necrosol"/>
+<!-- <GuideReagentEmbed Reagent="Necrosol"/> !-->
 <GuideReagentEmbed Reagent="Phalanximine"/>
 <GuideReagentGroupEmbed Group="Botanical"/>
   

--- a/Resources/ServerInfo/Guidebook/Service/Botany.xml
+++ b/Resources/ServerInfo/Guidebook/Service/Botany.xml
@@ -82,7 +82,6 @@ Some chemicals have special effects on plants.
 
 <GuideReagentEmbed Reagent="Dylovene"/>
 <GuideReagentEmbed Reagent="Cryoxadone"/>
-<!-- <GuideReagentEmbed Reagent="Necrosol"/> !-->
 <GuideReagentEmbed Reagent="Phalanximine"/>
 <GuideReagentGroupEmbed Group="Botanical"/>
   


### PR DESCRIPTION
These frankly make rotting slowly something that medical can just completely bypass. With the timer increased it should be rare enough as-is, and I think those deaths should remain impactful rather than being a minor inconvenience. 
Also edited to remove necrosol because while perma-killing by poison is a very uncommon strat, I think it's better to leave it as an option for antags and the like, especially in a situation like this where the "rare" chems are basically just an inconvenience. 