### PR TITLE
security plate carrier improvements

### DIFF
--- a/Content.Shared/_CD/Clothing/ClothingBlockSlotsOnEquipComponent.cs
+++ b/Content.Shared/_CD/Clothing/ClothingBlockSlotsOnEquipComponent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CD.Clothing;
+
+/// <summary>
+/// This component prevents equipping items in specified slots when this clothing item is worn,
+/// and prevents equipping this item if any of the specified slots are occupied.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ClothingBlockSlotsOnEquipComponent : Component
+{
+    /// <summary>
+    /// The slots that will be blocked when this clothing item is equipped
+    /// </summary>
+    [DataField]
+    public HashSet<string> BlockedSlots = [];
+}

--- a/Content.Shared/_CD/Clothing/ClothingBlockSlotsOnEquipComponent.cs
+++ b/Content.Shared/_CD/Clothing/ClothingBlockSlotsOnEquipComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared._CD.Clothing;
 /// This component prevents equipping items in specified slots when this clothing item is worn,
 /// and prevents equipping this item if any of the specified slots are occupied.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, Access(typeof(ClothingBlockSlotsOnEquipSystem))]
 public sealed partial class ClothingBlockSlotsOnEquipComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_CD/Clothing/ClothingBlockSlotsOnEquipSystem.cs
+++ b/Content.Shared/_CD/Clothing/ClothingBlockSlotsOnEquipSystem.cs
@@ -1,0 +1,63 @@
+using Content.Shared.Inventory;
+using Content.Shared.Inventory.Events;
+
+namespace Content.Shared._CD.Clothing;
+
+public sealed class ClothingBlockSlotsOnEquipSystem : EntitySystem
+{
+    [Dependency] private readonly InventorySystem _inventory = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ClothingBlockSlotsOnEquipComponent, BeingEquippedAttemptEvent>(OnBeingEquippedAttempt);
+        SubscribeLocalEvent<ClothingBlockSlotsOnEquipComponent, IsEquippingAttemptEvent>(OnIsEquippingAttempt);
+        SubscribeLocalEvent<InventoryComponent, IsEquippingAttemptEvent>(OnEquippingAttempt);
+    }
+
+    private void OnBeingEquippedAttempt(Entity<ClothingBlockSlotsOnEquipComponent> ent, ref BeingEquippedAttemptEvent args)
+    {
+        if (!HasComp<InventoryComponent>(args.EquipTarget))
+            return;
+
+        foreach (var slot in ent.Comp.BlockedSlots)
+        {
+            if (!_inventory.TryGetSlotEntity(args.EquipTarget, slot, out var existingItem))
+                continue;
+
+            var name = MetaData(existingItem.Value).EntityName;
+            args.Reason = Loc.GetString("clothing-blocked-slots-blocked", ("item", name));
+            args.Cancel();
+            return;
+        }
+    }
+
+    private void OnIsEquippingAttempt(Entity<ClothingBlockSlotsOnEquipComponent> ent, ref IsEquippingAttemptEvent args)
+    {
+        if (!ent.Comp.BlockedSlots.Contains(args.Slot))
+            return;
+
+        var name = MetaData(ent.Owner).EntityName;
+        args.Reason = Loc.GetString("clothing-blocked-slots-blocked", ("item", name));
+        args.Cancel();
+    }
+
+    private void OnEquippingAttempt(Entity<InventoryComponent> ent, ref IsEquippingAttemptEvent args)
+    {
+        var enumerator = _inventory.GetSlotEnumerator(ent.Owner);
+        while (enumerator.NextItem(out var equipped, out _))
+        {
+            if (!TryComp<ClothingBlockSlotsOnEquipComponent>(equipped, out var blockComp))
+                continue;
+
+            if (!blockComp.BlockedSlots.Contains(args.Slot))
+                continue;
+
+            var name = MetaData(equipped).EntityName;
+            args.Reason = Loc.GetString("clothing-blocked-slots-blocked", ("item", name));
+            args.Cancel();
+            return;
+        }
+    }
+}

--- a/Content.Shared/_CD/Clothing/ClothingBlockSlotsOnEquipSystem.cs
+++ b/Content.Shared/_CD/Clothing/ClothingBlockSlotsOnEquipSystem.cs
@@ -1,5 +1,7 @@
+using Content.Shared.Examine;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
+using Robust.Shared.Utility;
 
 namespace Content.Shared._CD.Clothing;
 
@@ -11,11 +13,39 @@ public sealed class ClothingBlockSlotsOnEquipSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<ClothingBlockSlotsOnEquipComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<ClothingBlockSlotsOnEquipComponent, BeingEquippedAttemptEvent>(OnBeingEquippedAttempt);
         SubscribeLocalEvent<ClothingBlockSlotsOnEquipComponent, IsEquippingAttemptEvent>(OnIsEquippingAttempt);
         SubscribeLocalEvent<InventoryComponent, IsEquippingAttemptEvent>(OnEquippingAttempt);
     }
 
+    /// <summary>
+    /// Sets the description to indicate what slots will be blocked by wearing this item.
+    /// </summary>
+    private void OnExamined(EntityUid uid, ClothingBlockSlotsOnEquipComponent component, ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        // we push it as a message so that we can add a newline at the end
+        var msg = new FormattedMessage();
+        msg.AddText(Loc.GetString("clothing-blocked-slots-description"));
+
+        foreach (var slot in component.BlockedSlots)
+        {
+            msg.PushNewline();
+            var slotName = Loc.GetString($"clothing-slot-{slot}");
+            msg.AddMarkupOrThrow(Loc.GetString("clothing-blocked-slots-entry", ("slot", slotName)));
+        }
+
+        msg.PushNewline();
+        args.PushMessage(msg, 1);
+    }
+
+    /// <summary>
+    /// Checks if we can equip the item.
+    /// </summary>
+    /// <remarks>This is called to see if the specified slots are empty.</remarks>
     private void OnBeingEquippedAttempt(Entity<ClothingBlockSlotsOnEquipComponent> ent, ref BeingEquippedAttemptEvent args)
     {
         if (!HasComp<InventoryComponent>(args.EquipTarget))
@@ -33,6 +63,10 @@ public sealed class ClothingBlockSlotsOnEquipSystem : EntitySystem
         }
     }
 
+    /// <summary>
+    /// Checks if we can equip the item.
+    /// </summary>
+    /// <remarks>This is called to see if we're not trying to equip it in a slot it would block.</remarks>
     private void OnIsEquippingAttempt(Entity<ClothingBlockSlotsOnEquipComponent> ent, ref IsEquippingAttemptEvent args)
     {
         if (!ent.Comp.BlockedSlots.Contains(args.Slot))
@@ -43,6 +77,10 @@ public sealed class ClothingBlockSlotsOnEquipSystem : EntitySystem
         args.Cancel();
     }
 
+    /// <summary>
+    /// Checks if we can equip other items.
+    /// </summary>
+    /// <remarks>This is called whenever we try to equip an item to see if the slot isn't currently blocked.</remarks>
     private void OnEquippingAttempt(Entity<InventoryComponent> ent, ref IsEquippingAttemptEvent args)
     {
         var enumerator = _inventory.GetSlotEnumerator(ent.Owner);

--- a/Resources/Locale/en-US/_CD/clothing/clothing-slots.ftl
+++ b/Resources/Locale/en-US/_CD/clothing/clothing-slots.ftl
@@ -1,0 +1,18 @@
+### General clothing slots because apparently they don't exist
+
+clothing-slot-head = Head
+clothing-slot-eyes = Eyes
+clothing-slot-ears = Ears
+clothing-slot-mask = Mask
+clothing-slot-outerClothing = Outer Clothing
+clothing-slot-jumpsuit = Jumpsuit
+clothing-slot-innerClothing = Inner Clothing
+clothing-slot-neck = Neck
+clothing-slot-back = Back
+clothing-slot-belt = Belt
+clothing-slot-gloves = Gloves
+clothing-slot-shoes = Shoes
+clothing-slot-id = ID Card
+clothing-slot-pocket1 = Left Pocket
+clothing-slot-pocket2 = Right Pocket
+clothing-slot-suitStorage = Suit Storage

--- a/Resources/Locale/en-US/_CD/clothing/components/clothing-block-slots-on-equip-component.ftl
+++ b/Resources/Locale/en-US/_CD/clothing/components/clothing-block-slots-on-equip-component.ftl
@@ -1,0 +1,1 @@
+clothing-blocked-slots-blocked = That slot is blocked by {$item}.

--- a/Resources/Locale/en-US/_CD/clothing/components/clothing-block-slots-on-equip-component.ftl
+++ b/Resources/Locale/en-US/_CD/clothing/components/clothing-block-slots-on-equip-component.ftl
@@ -1,1 +1,3 @@
 clothing-blocked-slots-blocked = That slot is blocked by {$item}.
+clothing-blocked-slots-description = This item blocks the following slots when worn:
+clothing-blocked-slots-entry = - [color=yellow]{$slot}[/color]

--- a/Resources/Prototypes/_CD/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_CD/Catalog/Fills/Items/belt.yml
@@ -1,6 +1,6 @@
 - type: entity
-  id: ClothingBeltSecurityPlateCarrier
-  parent: ClothingBeltSecurityPlateCarrierFilled
+  id: ClothingBeltSecurityPlateCarrierFilled
+  parent: ClothingBeltSecurityPlateCarrier
   suffix: Filled
   components:
   - type: EntityTableContainerFill

--- a/Resources/Prototypes/_CD/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_CD/Catalog/Fills/Items/belt.yml
@@ -1,0 +1,9 @@
+- type: entity
+  id: ClothingBeltSecurityPlateCarrier
+  parent: ClothingBeltSecurityPlateCarrierFilled
+  suffix: Filled
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: BeltSecurityEntityTable

--- a/Resources/Prototypes/_CD/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_CD/Entities/Clothing/Belt/belts.yml
@@ -15,9 +15,8 @@
     capacity: 20
 
 # Reverts the sprite changes in: https://github.com/space-wizards/space-station-14/pull/29441/files.
-# It is intentional that this does not provide armor until its possible for this item to block equipping armor.
 - type: entity
-  parent: ClothingBeltSecurity
+  parent: [ ClothingBeltSecurity, ClothingOuterArmorBasic ] # same armor but cant be equiped at the same time
   id: ClothingBeltSecurityPlateCarrier
   name: security plate carrier
   description: Unique and versatile plate carrier, designed to hold security gear.
@@ -26,3 +25,6 @@
     sprite: _CD/Clothing/Belt/securityplatecarrier.rsi
   - type: Clothing
     sprite: _CD/Clothing/Belt/securityplatecarrier.rsi
+  - type: ClothingBlockSlotsOnEquip
+    blockedSlots:
+    - "outerClothing"

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Security/security_officer.yml
@@ -21,7 +21,7 @@
 - type: loadout
   id: SecurityPlateCarrier
   equipment:
-    belt: ClothingBeltSecurityPlateCarrier
+    belt: ClothingBeltSecurityPlateCarrierFilled
 
 - type: loadout
   id: SecurityGreatcoat


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
adds the ClothingBlockSlotsOnEquipComponent to the plate carrier and makes it block outerClothing, while also giving it the same stats as the armor vest
makes it use the sec belt fill and changes the loadout to use the filled version

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
fixes https://github.com/cosmatic-drift-14/cosmatic-drift/issues/452

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
<details><summary>Click me!</summary>
<br>
gottem

![image](https://github.com/user-attachments/assets/ea33374a-c7c4-4cd3-938d-9c2333da90d4)

![image](https://github.com/user-attachments/assets/3037ea87-588e-4566-91a2-3361cfb104c0)

</details>
