### PR TITLE
Removes cloning boards from expedition loot pool

### DIFF
--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -22,10 +22,10 @@
           cost: 2
         - proto: CircuitImprinter
           cost: 2
-        - proto: CloningConsoleComputerCircuitboard
-          cost: 2
-        - proto: CloningPodMachineCircuitboard
-          cost: 2
+#        - proto: CloningConsoleComputerCircuitboard
+#          cost: 2 # CD change, removed cloning
+#        - proto: CloningPodMachineCircuitboard
+#          cost: 2
         - proto: CognizineChemistryBottle
         - proto: FoodBoxDonkpocketCarp
           prob: 0.5
@@ -41,8 +41,8 @@
         - proto: GyroscopeUnanchored
           cost: 2
           prob: 0.1
-        - proto: MedicalScannerMachineCircuitboard
-          cost: 2
+#        - proto: MedicalScannerMachineCircuitboard
+#          cost: 2 #CD change, removed cloning
         - proto: NuclearBombKeg
           cost: 5
         - proto: OmnizineChemistryBottle


### PR DESCRIPTION
Salvage rewards pool hasn’t been used for almost a year so removing cloning boards from there didn’t do anything

Removing the static cloning parts in each of the salvage dungeon templates would require editing maps and I am NOT touching that

Why is nothing in this file sorted???????