### PR TITLE
Role Slot Adjustments

### DIFF
--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -34,19 +34,19 @@
             SeniorEngineer: [ 1, 1 ] #CD Role
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 3, 3 ]
-            TechnicalAssistant: [ 4, 4 ]
+            TechnicalAssistant: [ 2, 2 ] #CD change from 4 to 2.
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             SeniorPhysician: [ 1, 1 ] #CD Role
-            Chemist: [ 2, 3 ]
+            Chemist: [ 2, 2 ] #CD change from 3 to 2.
             MedicalDoctor: [ 3, 3 ]
             Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ]
+            MedicalIntern: [ 2, 2 ] #CD change from 4 to 2.
             #science
             ResearchDirector: [ 1, 1 ]
             SeniorResearcher: [ 1, 1 ] #CD Role
             Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 4, 4 ]
+            ResearchAssistant: [ 2, 2 ] #CD change from 4 to 2.
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -20,7 +20,7 @@
             #service
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
+            Bartender: [ 1, 2 ] #CD change from 2 minimum to 1 minimum.
             Botanist: [ 3, 3 ]
             Chef: [ 2, 2 ]
             Janitor: [ 2, 2 ]
@@ -32,20 +32,20 @@
             SeniorEngineer: [ 1, 1 ] #CD Role
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 4, 4 ]
+            TechnicalAssistant: [ 2, 2 ] #CD change from 4 to 2.
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 2, 2 ]
             SeniorPhysician: [ 1, 1 ] #CD Role
             MedicalDoctor: [ 4, 4 ]
             Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ]
+            MedicalIntern: [ 2, 2 ] #CD change from 4 to 2.
             Psychologist: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
             SeniorResearcher: [ 1, 1 ] #CD Role      
             Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 4, 4 ] 
+            ResearchAssistant: [ 2, 2 ] #CD change from 4 to 2.
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -28,27 +28,27 @@
             Chaplain: [ 1, 1 ]
             Reporter: [ 2, 2 ]
             Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 3 ]
+            ServiceWorker: [ 2, 2 ] #CD change from 3 to 2.
             Zookeeper: [ 1, 1 ] 
             #engineering
             ChiefEngineer: [ 1, 1 ]
             SeniorEngineer: [ 1, 1 ] #CD role
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 3, 3 ]
+            TechnicalAssistant: [ 2, 2 ] #CD change from 3 to 2.
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             SeniorPhysician: [ 1, 1 ] #CD role
-            Chemist: [ 3, 3 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 3, 3 ]
+            Chemist: [ 2, 2 ] #CD change from 3 to 2.
+            MedicalDoctor: [ 3, 3 ] #CD change from 4 to 3.
+            MedicalIntern: [ 2, 2 ] #CD change from 3 to 2.
             Psychologist: [ 1, 1 ]
             Paramedic: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
             SeniorResearcher: [ 1, 1 ]  #CD role
             Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 3, 3 ]
+            ResearchAssistant: [ 2, 2 ] #CD change from 3 to 2.
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
@@ -60,7 +60,7 @@
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 4, 4 ]
+            CargoTechnician: [ 3, 3 ] #CD change from 4 to 3.
             #civilian
             Passenger: [ -1, -1 ]
             Clown: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -29,7 +29,7 @@
             HeadOfPersonnel: [ 1, 1 ]
             Chaplain: [ 1, 1 ]
             Librarian: [ 1, 1 ]
-            ServiceWorker: [ 3, 3 ]
+            ServiceWorker: [ 2, 2 ] #CD change from 3 to 2.
             #engineering
             ChiefEngineer: [ 1, 1 ]
             StationEngineer: [ 3, 3 ]
@@ -52,8 +52,8 @@
             HeadOfSecurity: [ 1, 1 ]
             SecurityOfficer: [ 3, 3 ]
             Warden: [ 1, 1 ]
-            Lawyer: [ 1, 1 ]
-            SecurityCadet: [ 1, 1 ]
+            Lawyer: [ 1, 2 ] #CD change from 1 maximum to 2 maximum.
+            SecurityCadet: [ 2, 2 ] #CD change from 1 to 2.
             Detective: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
             #supply

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -21,7 +21,7 @@
             #service
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
+            Bartender: [ 1, 2 ] #CD change from 2 minimum to 1 minimum.
             Botanist: [ 2, 3 ]
             Chef: [ 2, 2 ]
             Janitor: [ 1, 2 ]
@@ -33,20 +33,20 @@
             SeniorEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 3, 3 ]
-            TechnicalAssistant: [ 3, 3 ]
+            TechnicalAssistant: [ 2, 2 ] #CD change from 3 to 2.
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             SeniorPhysician: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 3, 3 ]
+            MedicalDoctor: [ 3, 3 ] #CD change from 4 to 3.
+            MedicalIntern: [ 2, 2 ] #CD change from 3 to 2.
             Psychologist: [ 1, 1 ]
             Paramedic: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
             SeniorResearcher: [ 1, 1 ]
             Scientist: [ 3, 3 ]
-            ResearchAssistant: [ 3, 3 ]
+            ResearchAssistant: [ 2, 2 ] #CD change from 3 to 2.
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -32,26 +32,26 @@
             SeniorEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 6 ]
-            TechnicalAssistant: [ 3, 6 ]
+            TechnicalAssistant: [ 2, 2 ] #CD change from 3-6 to 2-2.
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             SeniorPhysician: [ 1, 1 ]
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 5, 5 ]
-            MedicalIntern: [ 3, 6 ]
+            MedicalDoctor: [ 4, 4 ] #CD change from 5 to 4.
+            MedicalIntern: [ 2, 2 ] #CD change from 3-6 to 2-2.
             Paramedic: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
             SeniorResearcher: [ 1, 1 ]
             Scientist: [ 4, 6 ]
-            ResearchAssistant: [ 3, 6 ]
+            ResearchAssistant: [ 2, 2 ] #CD change from 3-6 to 2-2.
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
             SecurityOfficer: [ 3, 3 ]
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 3, 3 ]
+            SecurityCadet: [ 2, 2 ] #CD change from 3 to 2.
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -20,7 +20,7 @@
             #service
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
+            Bartender: [ 1, 2 ] #CD change from 2-2 to 1-2.
             Botanist: [ 2, 3 ]
             Chef: [ 2, 2 ]
             Janitor: [ 3, 3 ]
@@ -34,20 +34,20 @@
             SeniorEngineer: [ 1, 1 ] #CD role
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ]
+            TechnicalAssistant: [ 2, 2 ] #CD change from 4 to 2.
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             SeniorPhysician: [ 1, 1 ] #CD role
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 6, 6 ]
+            MedicalDoctor: [ 4, 4 ] #CD change from 6 to 4.
             Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ]
+            MedicalIntern: [ 2, 2 ] #CD change from 4 to 2.
             Psychologist: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
             SeniorResearcher: [ 1, 1 ]  #CD role
             Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 6, 6 ]
+            ResearchAssistant: [ 2, 2 ] #CD change from 6 to 2.
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
             #security
@@ -61,7 +61,7 @@
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 4, 4 ]
+            CargoTechnician: [ 3, 3 ] #CD change from 4 to 3.
             #civilian
             Passenger: [ -1, -1 ]
             Clown: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -31,7 +31,7 @@
             SeniorEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 3, 3 ]
-            TechnicalAssistant: [ 3, 3 ]
+            TechnicalAssistant: [ 2, 2 ] #CD change from 3 to 2.
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             SeniorPhysician: [ 1, 1 ]


### PR DESCRIPTION
## About the PR
This changes the role slots of several Upstream maps.

Any bartender count was brought down to 1-2 if it didn't have a second set of dispensers.
All intern roles were reduced to 2-2.
Doctors were reduced to 3-3 except for Meta, Box, and Oasis which have 4-4.
Any chemist slots above 3 were reduced to 2-2.
Cargo techs were set to 3-3 if they exceeded 3.
Core got an extra lawyer, just because having two is more interesting.

## Why / Balance
This is mostly playing it by touch in an effort to declutter some departments like medbay which have recently had an influx of complaints, also a couple adjustments made to the other roles from my personal experience.

Not touching any CD map because that's up to their respective maintainers.

**Changelog**
Most maps have gotten slightly readjusted job slots, the biggest changes were to medical and intern roles to hopefully make departments feel less cramped.