### PR TITLE
Add antag target preferences.

### DIFF
--- a/Resources/Locale/en-US/_CD/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/_CD/prototypes/roles/antags.ftl
@@ -1,8 +1,15 @@
-﻿roles-low-impact-antag = Low-Impact Antagonist
+roles-low-impact-antag = 1. Low-Impact Antagonist
 roles-low-impact-antag-desc = Often small, basic tasks that result in little more than jail time.
 
-roles-moderate-impact-antag = Moderate-Impact Antagonist
+roles-moderate-impact-antag = 2. Moderate-Impact Antagonist
 roles-moderate-impact-antag-desc = More complicated tasks that may take the focus of your round and/or have multi-round punishments.
 
-roles-high-impact-antag = High-Impact Antagonist
+roles-high-impact-antag = 3. High-Impact Antagonist
 roles-high-impact-antag-desc = Incredibly disruptive actions that are likely to define a character once done.
+
+roles-antag-target-opt-in = 4. Antag Target Opt in
+roles-antag-target-opt-in-desc = Admins or other players may take intentional antagonistic action against you (short of round removal).
+
+roles-round-removal-opt-in = 5. Round-Removal Target Opt in
+roles-round-removal-opt-in-desc = Admins or other players are permitted to intentionally round-remove you thorough events or antagonistic action.
+

--- a/Resources/Prototypes/_CD/Roles/Antags/preferences.yml
+++ b/Resources/Prototypes/_CD/Roles/Antags/preferences.yml
@@ -21,3 +21,19 @@
   setPreference: true
   objective: roles-high-impact-antag-desc
   visiblePreference: true
+
+- type: antag
+  id: RoundRemovalOptIn
+  name: roles-round-removal-opt-in
+  antagonist: true
+  setPreference: true
+  objective: roles-round-removal-opt-in-desc
+  visiblePreference: true
+
+- type: antag
+  id: AntagTargetOptIn
+  name: roles-antag-target-opt-in
+  antagonist: true
+  setPreference: true
+  objective: roles-antag-target-opt-in-desc
+  visiblePreference: true


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added preferences so players can opt-in to being antag targets.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
This is mainly so admins don't need to bwoink players and spoil that they are a target.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I prefixed the locale string for each antag pref with a number. This is because the game sorts them alphabetically. It looks *much* better than the alternative.


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog

We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the
name that you would like to be credited as.
-->
You can now opt-in to being intentionally targeted for general antagonistic activity and round removal under the antag tab in the character creator. Keep in mind not enabling this will not prevent harm from befalling you throughout normal gameplay (our minor crimes rule still applies).
