### PR TITLE
Paramedics get the handheld monitor and it can be printed at the medfab

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -153,6 +153,7 @@
       - id: HandheldGPSBasic
       - id: MedkitFilled
       #CD Addions
+      - id: HandheldCrewMonitor
       - id: ETUGarmentBag
         prob: 0.3
       - id: BookSOPMedical

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -906,6 +906,7 @@
       - Hemostat
       - ClothingEyesGlassesChemical
       - WhiteCane
+      - HandheldCrewMonitor # CD addition
     dynamicRecipes:
       - ChemicalPayload
       - CryostasisBeaker

--- a/Resources/Prototypes/_CD/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_CD/Recipes/Lathes/medical.yml
@@ -1,0 +1,10 @@
+- type: latheRecipe
+  id: HandheldCrewMonitor
+  result: HandheldCrewMonitorEmpty
+  category: Tools
+  completetime: 4
+  materials:
+    Glass: 600
+    Steel: 600
+    Plastic: 600
+    Gold: 300


### PR DESCRIPTION
## About the PR
The handheld crew monitor can now be found in the paramedic's locker roundstart, or printed using 6 steel, 6 glass, 6 plastic and 3 gold at the medfab.

## Why / Balance
I played a round of paramedic to try and be a bit more active around the station, I felt even more glued to medical than I did as a normal doctor because of the crew monitor. There can be a sudden catastrophe in sci from artifacts, because of sci from anomalies, or just entirely random and unrelated from some guy falling out an airlock. Even in a HRP environment the game can suddenly be chaotic as ever, so giving the paramedic at least something to allow them freedom of movement without significantly hindering themselves is nice.
I feel like medical in general has a lot of issues with being glued to their department and unable to get out and around the station to interact with others because of the threat of a sudden catastrophe, so this is at least somewhat handling that.

## Media

https://github.com/user-attachments/assets/f4afd9b1-6904-4ca2-9129-447bfcd79e25


## Requirements

- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

The handheld crew monitor can now be printed at the medfab and will be found in paramedic lockers. (Credit to Alzore)

