### PR TITLE
First attempt at fixing the record order bug

### DIFF
--- a/Content.Server/_CD/Records/RecordsSerialization.cs
+++ b/Content.Server/_CD/Records/RecordsSerialization.cs
@@ -46,6 +46,7 @@ public static class RecordsSerialization
     private static List<PlayerProvidedCharacterRecords.RecordEntry> DeserializeEntries(List<CDModel.CharacterRecordEntry> entries, CDModel.DbRecordEntryType ty)
     {
         return entries.Where(e => e.Type == ty)
+            .OrderBy(e => e.Id) // attempt at fixing the record order changing bug.
             .Select(e => new PlayerProvidedCharacterRecords.RecordEntry(e.Title, e.Involved, e.Description))
             .ToList();
     }


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

I am not able to reproduse it locally. This is a bit of a shot in the
dark based on the results of messing around with the rider postgres browser.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

When I originally wrote the code I assumed that SQL queries would automatically
order by ID. I think I might be wrong about this, so I forced it to order them
by id which *should* fix the issue.

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!--
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog

We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the
name that you would like to be credited as.
-->
Records entries should hopefully no-longer change their order semi-randomly. Please let us know if the issue still persists.
