### PR TITLE
Very Lightweight and Heavyweight drunk traits

### DIFF
--- a/Resources/Locale/en-US/_CD/traits/traits.ftl
+++ b/Resources/Locale/en-US/_CD/traits/traits.ftl
@@ -3,3 +3,12 @@ trait-synth-desc = You are a biomechanical construct, who bleeds coolant and is 
 
 trait-mobster-name = Mobster accent
 trait-mobster-desc = Nyehh, yous sound like da mobster boss type, see?
+
+cd-trait-category-drinking-skill = Alcohol Tolerance
+
+cd-trait-very-lightweight-name = Very Lightweight drunk
+cd-trait-very-lightweight-desc = Alcohol has a much stronger effect on you.
+
+cd-trait-heavyweight-name = Heavyweight drunk
+cd-trait-heavyweight-desc = Alcohol has a weaker effect on you.
+

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -10,7 +10,8 @@
   id: LightweightDrunk
   name: trait-lightweight-name
   description: trait-lightweight-desc
-  category: Quirks
+  category: DrinkingSkill # CD: Multiple levels
+  cost: 1 # CD: Multiple levels
   components:
   - type: LightweightDrunk
     boozeStrengthMultiplier: 2

--- a/Resources/Prototypes/_CD/Traits/categories.yml
+++ b/Resources/Prototypes/_CD/Traits/categories.yml
@@ -1,0 +1,4 @@
+- type: traitCategory
+  id: DrinkingSkill
+  name: cd-trait-category-drinking-skill
+  maxTraitPoints: 1

--- a/Resources/Prototypes/_CD/Traits/traits.yml
+++ b/Resources/Prototypes/_CD/Traits/traits.yml
@@ -1,6 +1,26 @@
-﻿- type: trait
+- type: trait
   id: Synthetic
   name: trait-synth-name
   description: trait-synth-desc
   components:
     - type: Synth
+
+- type: trait
+  id: VeryLightweightDrunk
+  name: cd-trait-very-lightweight-name
+  description: cd-trait-very-lightweight-desc
+  category: DrinkingSkill
+  cost: 1
+  components:
+  - type: LightweightDrunk
+    boozeStrengthMultiplier: 4
+
+- type: trait
+  id: HeavyweightDrunk
+  name: cd-trait-heavyweight-name
+  description: cd-trait-heavyweight-desc
+  category: DrinkingSkill
+  cost: 1
+  components:
+  - type: LightweightDrunk
+    boozeStrengthMultiplier: 0.5


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Add Very Lightweight and Heavyweight drunk traits

I think it is fine to have a Heavyweight drunk trait because it is mainly an RP thing. It is basically impossible to get drunk without the players consent anyways.

I also created a category for them so that you can only have one drinking skill trait at a time.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog

We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the
name that you would like to be credited as.
-->
Added the Heavyweight and Very Lightweight drunk traits. You can only have one Alcohol Tolerance trait at a time.
