### PR TITLE
Disable planet arrivals.

### DIFF
--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -22,8 +22,9 @@ public sealed partial class CCVars
     /// <summary>
     ///     Whether the arrivals terminal should be on a planet map.
     /// </summary>
+    // CD: Our arrivals map does not support planets. Set to false
     public static readonly CVarDef<bool> ArrivalsPlanet =
-        CVarDef.Create("shuttle.arrivals_planet", true, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.arrivals_planet", false, CVar.SERVERONLY);
 
     /// <summary>
     ///     Whether the arrivals shuttle is enabled.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Our arrivals map does not support planets, and it seems to cause release builds 
to not get in-game unless you set this cvar to false. This is already set on the 
server and probably should be set in the repo in-order to stop being a footgun.

