### PR TITLE
Amber CD Port

### DIFF
--- a/Resources/CDMapPatches/amber.yml
+++ b/Resources/CDMapPatches/amber.yml
@@ -1,0 +1,7 @@
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -37.963028,-19.952396
+  id: ComputerTabletopMedicalRecords
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -18.963028,-51.952396
+  id: LockerLostAndFound
+...

--- a/Resources/CDMapPatches/amber.yml
+++ b/Resources/CDMapPatches/amber.yml
@@ -4,4 +4,3 @@
 - !type:CDSpawnEntityMapPatch
   worldPosition: -18.963028,-51.952396
   id: LockerLostAndFound
-...

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -2,7 +2,7 @@
   id: DefaultMapPool
   maps:
   - Aspid
-  #- Amber CD, temporarily derotated
+  - Amber
   - Bagel
   - Box
   - Cog

--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -45,6 +45,7 @@
             Psychologist: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
+            SeniorResearcher: [ 1, 1 ] #CD Role
             Scientist: [ 4, 4 ]
             ResearchAssistant: [ 1, 2 ]
             #security

--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -2,8 +2,9 @@
   id: Amber
   mapName: 'Amber'
   mapPath: /Maps/amber.yml
-  minPlayers: 7
-  maxPlayers: 50
+  minPlayers: 5 #CD change from 7 to 5.
+  maxPlayers: 25 #CD change from 50 to 25.
+  patchfile: /CDMapPatches/amber.yml #CD: Apply map patch.
   stations:
     Amber:
       stationProto: StandardNanotrasenStation
@@ -30,13 +31,15 @@
             Reporter: [ 1, 1 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
+            SeniorEngineer: [ 1, 1 ] #CD Role.
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 2, 4 ]
             TechnicalAssistant: [ 1, 1 ]
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
+            SeniorPhysician: [ 1, 1 ] #CD Role.
             Chemist: [ 2, 2 ]
-            MedicalDoctor: [ 2, 4 ]
+            MedicalDoctor: [ 2, 3 ] #CD change from 2-4 to 2-3.
             Paramedic: [ 2, 2 ]
             MedicalIntern: [ 1, 2 ]
             Psychologist: [ 1, 1 ]
@@ -47,7 +50,8 @@
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 4, 4 ]
+            SeniorOfficer: [ 1, 1 ] #CD Role.
+            SecurityOfficer: [ 3, 3 ] #CD change from 4-4 to 3-3.
             Detective: [ 1, 1 ]
             SecurityCadet: [ 1, 1 ]
             Lawyer: [ 1, 1 ]


### PR DESCRIPTION
## About the PR
Adjusts Amber's prototype to fit CD standards, including the CD roles and more fitting pop count (5-25).
Adds an Amber map patch for a lost and found locker in the bridge, and a medical records computer in the treatment bay.

## Why / Balance
25 max may be a *tad* bit small role wise. It's more like Core and Aspid in terms of that. But size wise it's more like Omega, Packed, etc, so I went with that instead.

**Changelog**
Amber has been updated to fit CD and now will appear between 5 and 25 population.