### PR TITLE
Job Slots Computer Board and Flatpack

### DIFF
--- a/Resources/Prototypes/_CD/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/_CD/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -1,0 +1,10 @@
+- type: entity
+  parent: BaseComputerCircuitboard
+  id: JobSlotsComputerCircuitboard
+  name: job slots computer board
+  description: A computer printed circuit board for a job slots console.
+  components:
+    - type: Sprite
+      state: cpu_command
+    - type: ComputerBoard
+      prototype: ComputerJobSlots

--- a/Resources/Prototypes/_CD/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_CD/Entities/Objects/Devices/flatpack.yml
@@ -1,0 +1,14 @@
+- type: entity
+  parent: BaseFlatpack
+  id: JobSlotsComputerFlatpack
+  name: job slots console flatpack
+  description: A flatpack used for constructing a job slots console.
+  components:
+  - type: Flatpack
+    entity: ComputerJobSlots
+  - type: Sprite
+    layers:
+    - state: base
+    - state: overlay
+      color: "#334E6D"
+    - state: icon-default

--- a/Resources/Prototypes/_CD/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_CD/Entities/Structures/Machines/Computers/computers.yml
@@ -17,7 +17,7 @@
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
   - type: Computer
-    board: ComputerMassMediaCircuitboard
+    board: JobSlotsComputerCircuitboard
   - type: DeviceNetworkRequiresPower
   - type: JobSlotsConsole
     blacklist:


### PR DESCRIPTION
## About the PR
Gives the job slots console a computer board and flatpack.

## Why / Balance
I want to use it for mapping reasons.

**Changelog**
Nada. Bit small for one.