### PR TITLE
Remove the unknown shuttle announcement. 

### DIFF
--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -41,9 +41,9 @@
   id: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
+    startAnnouncement: null # CD: Removed the announcement
+    #startAudio: CD: Also removed the start audio
+    #  path: /Audio/Announcements/attention.ogg
     weight: 10 # 10 default
     reoccurrenceDelay: 30
     duration: 1
@@ -65,7 +65,7 @@
   id: UnknownShuttleTravelingCuisine
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming
+    startAnnouncement: null # CD: Removed the announcement
     maxOccurrences: 2 # should be the same as [copies] in shuttle_incoming_event.yml
   - type: LoadMapRule
     preloadedGrid: TravelingCuisine
@@ -75,7 +75,7 @@
   id: UnknownShuttleDisasterEvacPod
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming
+    startAnnouncement: null # CD: Removed the announcement
     maxOccurrences: 3 # should be the same as [copies] in shuttle_incoming_event.yml
   - type: LoadMapRule
     preloadedGrid: DisasterEvacPod
@@ -86,7 +86,7 @@
 #   id: UnknownShuttleHonki
 #   components:
 #   - type: StationEvent
-#     startAnnouncement: station-event-unknown-shuttle-incoming #!!
+#     startAnnouncement: null # CD: Removed the announcement #!!
 #     weight: 2
 #   - type: LoadMapRule
 #     preloadedGrid: Honki
@@ -119,7 +119,7 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming #!!
+    startAnnouncement: null # CD: Removed the announcement #!!
     weight: 2 # Its just a big ship, so it needs to be rarer to be interesting.
   - type: LoadMapRule
     preloadedGrid: Cruiser
@@ -129,7 +129,7 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming #!!
+    startAnnouncement: null # CD: Removed the announcement #!!
   - type: LoadMapRule
     preloadedGrid: Cryptid
 
@@ -138,7 +138,7 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming #!!
+    startAnnouncement: null # CD: Removed the announcement #!!
   - type: LoadMapRule
     preloadedGrid: Eternal
 
@@ -147,7 +147,7 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming #!!
+    startAnnouncement: null # CD: Removed the announcement #!!
   - type: LoadMapRule
     preloadedGrid: Flatline
 
@@ -156,7 +156,7 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming #!!
+    startAnnouncement: null # CD: Removed the announcement #!!
     weight: 5 # Its just a big ship, so it needs to be rarer to be interesting.
   - type: LoadMapRule
     preloadedGrid: Gym
@@ -166,7 +166,7 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming #!!
+    startAnnouncement: null # CD: Removed the announcement #!!
     weight: 2 # Its just a big ship, so it needs to be rarer to be interesting.
     earliestStart: 45 # late to hopefully have enough ghosts to fill all roles quickly. (5-6)
   - type: LoadMapRule
@@ -188,7 +188,7 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming #!!
+    startAnnouncement: null # CD: Removed the announcement #!!
   - type: LoadMapRule
     preloadedGrid: Joe
 
@@ -197,7 +197,7 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming #!!
+    startAnnouncement: null # CD: Removed the announcement #!!
   - type: LoadMapRule
     preloadedGrid: Lambordeere
 
@@ -206,7 +206,7 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming #!!
+    startAnnouncement: null # CD: Removed the announcement #!!
   - type: LoadMapRule
     preloadedGrid: Meatzone
 
@@ -215,7 +215,7 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming #!!
+    startAnnouncement: null # CD: Removed the announcement #!!
     weight: 11 # this is higher because its just a little generic personal shuttle
     maxOccurrences: 4
   - type: LoadMapRule
@@ -226,7 +226,7 @@
   parent: BaseUnknownShuttleRule
   components:
   - type: StationEvent
-    startAnnouncement: station-event-unknown-shuttle-incoming #!!
+    startAnnouncement: null # CD: Removed the announcement #!!
   - type: LoadMapRule
     preloadedGrid: Spacebus
 


### PR DESCRIPTION
Generally better to have this be quiet imo, especially as the ghost roles being taken is super unlikely. Hailing channel also solves this issue & leads to more RP. 