### PR TITLE
Bugfix: Senior officer vox start with their selected outerclothing

### DIFF
--- a/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
@@ -48,7 +48,7 @@
 - type: roleLoadout
   id: JobSeniorOfficer
   groups:
-  - GroupTankHarness
+#  - GroupTankHarness # CD
   - SeniorOfficerHead
   - SeniorOfficerJumpsuit
   - SecurityBackpack

--- a/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
@@ -48,7 +48,7 @@
 - type: roleLoadout
   id: JobSeniorOfficer
   groups:
-#  - GroupTankHarness # CD
+#  - GroupTankHarness # CD: fixes bug where vox detectives start with their outerclothing on the floor
   - SeniorOfficerHead
   - SeniorOfficerJumpsuit
   - SecurityBackpack

--- a/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_CD/Loadouts/role_loadouts.yml
@@ -48,7 +48,6 @@
 - type: roleLoadout
   id: JobSeniorOfficer
   groups:
-#  - GroupTankHarness # CD: fixes bug where vox detectives start with their outerclothing on the floor
   - SeniorOfficerHead
   - SeniorOfficerJumpsuit
   - SecurityBackpack


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Voxes as a Senior Officer no longer start with a tank harness, and instead start with their selected outer clothing equipped.

## Why / Balance
Fixes #498

I was bored

## Technical details
Just comments out `GroupTankHarness` like I did for vox detectives on upstream. I can't do this fix on upstream and have you guys merge it as SeniorOfficer roles don't exist for upstream.

## Media
![Content Client_2nunO2Hu7g](https://github.com/user-attachments/assets/9cf97be7-679e-4885-9178-72d9b9c715dc)

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
I'm doing this in the style of an upstream CL

🆑 
- fix: Senior Officer Vox now start the shift with their selected outer clothing equipped. Previously it would be overridden by a tank harness and your clothing would start on the floor.
