### PR TITLE
Convex CD Port

### DIFF
--- a/Resources/CDMapPatches/convex.yml
+++ b/Resources/CDMapPatches/convex.yml
@@ -1,0 +1,11 @@
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -41.5,-32.5
+  id: LockerLostAndFound
+- !type:CDSpawnEntityMapPatch
+  worldRotation: 1.5707963267948966 rad
+  worldPosition: -38.5,-33.5
+  id: ComputerJobSlots
+- !type:CDSpawnEntityMapPatch
+  worldRotation: -1.5707963267948966 rad
+  worldPosition: 55.5,2.5
+  id: ComputerShuttleSalvage

--- a/Resources/Prototypes/Maps/convex.yml
+++ b/Resources/Prototypes/Maps/convex.yml
@@ -2,7 +2,8 @@
   id: Convex
   mapName: 'Convex'
   mapPath: /Maps/convex.yml
-  minPlayers: 75
+  minPlayers: 45 #CD change from 75 to 45
+  patchfile: /CDMapPatches/convex.yml #CD map patch
   stations:
     Convex:
       stationProto: StandardNanotrasenStation
@@ -29,30 +30,34 @@
             Reporter: [ 1, 2 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
+            SeniorEngineer: [ 1, 1 ] #CD role
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 5, 5 ]
-            TechnicalAssistant: [ 4, 4 ]
+            TechnicalAssistant: [ 2, 2 ] #CD change from 4-4 to 2-2
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
-            Chemist: [ 3, 3 ]
-            MedicalDoctor: [ 6, 6 ]
+            SeniorPhysician: [ 1, 1 ] #CD Role
+            Chemist: [ 2, 2 ] #CD change from 3-3 to 2-2
+            MedicalDoctor: [ 4, 4 ] #CD change from 6-6 to 4-4
             Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 4, 4 ]
+            MedicalIntern: [ 2, 2 ] #CD change from 4-4 to 2-2
             #science
             ResearchDirector: [ 1, 1 ]
+            SeniorResearcher: [ 1, 1 ] #CD role
             Scientist: [ 5, 5 ]
-            ResearchAssistant: [ 6, 6 ]
+            ResearchAssistant: [ 2, 2 ] #CD change from 6-6 to 2-2
             #security
             HeadOfSecurity: [ 1, 1 ]
+            SeniorOfficer: [ 1, 1 ] #CD Role
             Warden: [ 1, 1 ]
-            SecurityOfficer: [ 8, 8 ]
+            SecurityOfficer: [ 4, 4 ] #CD change from 8-8 to 4-4
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            SecurityCadet: [ 2, 2 ] #CD change from 4-4 to 2-2
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 3 ]
-            CargoTechnician: [ 4, 4 ]
+            CargoTechnician: [ 3, 3 ] #CD change from 4-4 to 3-3
             #civilian
             Passenger: [ -1, -1 ]
             Clown: [ 1, 1 ]


### PR DESCRIPTION
## About the PR
Changes Convex station.

- Adjusts the player minimum to 45.
- Adds CD senor roles.
- Adjusts Upstream role counts. (Of note, security officer is set to 4-4 instead of the regular 3-3 because it's a sizable map)
- Adds map patches for CD entities.

**Changelog**
Convex station has been updated to match CD and now appears at 45+ player population.