### PR TITLE
Avali Thermal slowdown fix

### DIFF
--- a/Resources/Prototypes/_CD/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_CD/Entities/Mobs/Species/avali.yml
@@ -63,6 +63,17 @@
     coldDamageThreshold: 223
     currentTemperature: 296.15
     specificHeat: 48
+    coldDamage: # same damage as moths
+      types:
+        Cold : 0.05 #per second, scales with temperature & other constants
+    heatDamage:
+      types:
+        Heat : 3 #per second, scales with temperature & other constants
+  - type: TemperatureSpeed
+    thresholds: # all temps are 10K colder then moths, adjusted for current temp.
+      265: 0.8
+      251: 0.6
+      226: 0.4
   - type: ThermalRegulator
     metabolismHeat: 400 # icebirb go brrr
     radiatedHeat: 100


### PR DESCRIPTION
## About the PR
Adds the missing thermal slowdown values to Avali

## Technical details
Adds missing values to avali.yml, adjusted to match the species stats.

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion

**Changelog**

Avali are no longer slowed down until much colder then other species.