### PR TITLE
CD Custom Races now use Human emote sounds for missing sounds

### DIFF
--- a/Resources/Prototypes/_CD/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_CD/Voice/speech_emote_sounds.yml
@@ -6,8 +6,40 @@
   sounds:
     Scream:
       path: /Audio/_CD/Voice/Avali/avali_scream.ogg
-#    Laugh:
-#      path: /Audio/_CD/Voice/Avali/avali_laugh.ogg
+    Laugh:
+      collection: MaleLaugh
+    Sneeze:
+      collection: MaleSneezes
+    Cough:
+      collection: MaleCoughs
+    CatMeow:
+      collection: CatMeows
+    CatHisses:
+      collection: CatHisses
+    MonkeyScreeches:
+      collection: MonkeyScreeches
+    RobotBeep:
+      collection: RobotBeeps
+    Yawn:
+      collection: MaleYawn
+    Snore:
+      collection: Snores
+    Honk:
+      collection: BikeHorn
+    Sigh:
+      collection: MaleSigh
+    Crying:
+      collection: MaleCry
+    Whistle:
+      collection: Whistles
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
+    Gasp:
+      collection: MaleGasp
+    DefaultDeathgasp:
+      collection: MaleDeathGasp
 
 - type: emoteSounds
   id: FemaleAvali
@@ -16,8 +48,40 @@
   sounds:
     Scream:
       path: /Audio/_CD/Voice/Avali/avali_scream.ogg
-#    Laugh:
-#      path: /Audio/_CD/Voice/Avali/avali_laugh.ogg
+    Laugh:
+      collection: FemaleLaugh
+    Sneeze:
+      collection: FemaleSneezes
+    Cough:
+      collection: FemaleCoughs
+    CatMeow:
+      collection: CatMeows
+    CatHisses:
+      collection: CatHisses
+    MonkeyScreeches:
+      collection: MonkeyScreeches
+    RobotBeep:
+      collection: RobotBeeps
+    Yawn:
+      collection: FemaleYawn
+    Snore:
+      collection: Snores
+    Honk:
+      collection: CluwneHorn
+    Sigh:
+      collection: FemaleSigh
+    Crying:
+      collection: FemaleCry
+    Whistle:
+      collection: Whistles
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
+    Gasp:
+      collection: FemaleGasp
+    DefaultDeathgasp:
+      collection: FemaleDeathGasp
 
 # Vulp Sounds
 - type: emoteSounds
@@ -31,12 +95,34 @@
       collection: MaleSneezes
     Cough:
       collection: MaleCoughs
-    Whistle:
-      collection: Whistles
+    CatMeow:
+      collection: CatMeows
+    CatHisses:
+      collection: CatHisses
+    MonkeyScreeches:
+      collection: MonkeyScreeches
+    RobotBeep:
+      collection: RobotBeeps
+    Yawn:
+      collection: MaleYawn
+    Snore:
+      collection: Snores
+    Honk:
+      collection: BikeHorn
     Sigh:
       collection: MaleSigh
-    Scream:
-      collection: MaleScreams
+    Crying:
+      collection: MaleCry
+    Whistle:
+      collection: Whistles
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
+    Gasp:
+      collection: MaleGasp
+    DefaultDeathgasp:
+      collection: MaleDeathGasp
     Growl:
       collection: VulpkaninGrowls
     Snarl:
@@ -53,18 +139,6 @@
   params:
     variation: 0.125
   sounds:
-    Laugh:
-      collection: FemaleLaugh
-    Sneeze:
-      collection: FemaleSneezes
-    Cough:
-      collection: FemaleCoughs
-    Whistle:
-      collection: Whistles
-    Sigh:
-      collection: FemaleSigh
-    Scream:
-      collection: FemaleScreams
     Growl:
       collection: VulpkaninGrowls
     Snarl:
@@ -75,6 +149,40 @@
       collection: VulpkaninWhines
     Howl:
       collection: VulpkaninHowls
+    Laugh:
+      collection: FemaleLaugh
+    Sneeze:
+      collection: FemaleSneezes
+    Cough:
+      collection: FemaleCoughs
+    CatMeow:
+      collection: CatMeows
+    CatHisses:
+      collection: CatHisses
+    MonkeyScreeches:
+      collection: MonkeyScreeches
+    RobotBeep:
+      collection: RobotBeeps
+    Yawn:
+      collection: FemaleYawn
+    Snore:
+      collection: Snores
+    Honk:
+      collection: CluwneHorn
+    Sigh:
+      collection: FemaleSigh
+    Crying:
+      collection: FemaleCry
+    Whistle:
+      collection: Whistles
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
+    Gasp:
+      collection: FemaleGasp
+    DefaultDeathgasp:
+      collection: FemaleDeathGasp
 
 - type: emoteSounds
   id: MaleRodentia
@@ -89,16 +197,34 @@
       collection: MaleSneezes
     Cough:
       collection: MaleCoughs
+    CatMeow:
+      collection: CatMeows
+    CatHisses:
+      collection: CatHisses
+    MonkeyScreeches:
+      collection: MonkeyScreeches
+    RobotBeep:
+      collection: RobotBeeps
     Yawn:
       collection: MaleYawn
     Snore:
       collection: Snores
+    Honk:
+      collection: BikeHorn
     Sigh:
       collection: MaleSigh
     Crying:
       collection: MaleCry
     Whistle:
       collection: Whistles
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
+    Gasp:
+      collection: MaleGasp
+    DefaultDeathgasp:
+      collection: MaleDeathGasp
     Squeak:
       path: /Audio/Animals/mouse_squeak.ogg
 
@@ -115,15 +241,33 @@
       collection: FemaleSneezes
     Cough:
       collection: FemaleCoughs
+    CatMeow:
+      collection: CatMeows
+    CatHisses:
+      collection: CatHisses
+    MonkeyScreeches:
+      collection: MonkeyScreeches
+    RobotBeep:
+      collection: RobotBeeps
     Yawn:
       collection: FemaleYawn
     Snore:
       collection: Snores
+    Honk:
+      collection: CluwneHorn
     Sigh:
       collection: FemaleSigh
     Crying:
       collection: FemaleCry
     Whistle:
       collection: Whistles
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
+    Gasp:
+      collection: FemaleGasp
+    DefaultDeathgasp:
+      collection: FemaleDeathGasp
     Squeak:
       path: /Audio/Animals/mouse_squeak.ogg


### PR DESCRIPTION
## About the PR
Made it so all races that are custom to CD (Avali, Vulpkanins and Rodentia) use human sounds for their respective genders if they don't have any sounds. This also means sounds for Hew, Weh, Honk etc are also included. Gasps and Deathgasps also function.

## Why / Balance
So many sounds were missing and I rather have these sounds than none, until we can get replacement sounds. For example the Avali PR that adds their laugh. these sounds do sound fine even when they are human sounding, but this expecially fixes the missing gasps and death gasps. **Vulps also now Bark when screaming, but can be easily reverted if wanted.**

Had to MANUALLY copy paste the applicable sounds into their respective emoteSounds. This is because RMC inherits using a parent field which is NOT available on upstream yet.

## Media
N/A

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
Avalis, Vulpkanins and Rodentia can now make their missing emote sounds now including gasps, weh, whistles etc.
