### PR TITLE
Added Wheelchairs to Medical Lathes

### DIFF
--- a/Resources/Prototypes/_CD/Recipes/Lathes/Packs/cdpacks.yml
+++ b/Resources/Prototypes/_CD/Recipes/Lathes/Packs/cdpacks.yml
@@ -10,9 +10,9 @@
   recipes:
   - CassetteTape
   - TapeRecorder
-  - GoldRing 
-  - SilverRing 
-  - GoldRingDiamond 
+  - GoldRing
+  - SilverRing
+  - GoldRingDiamond
   - SilverRingDiamond
 
 - type: latheRecipePack
@@ -20,6 +20,7 @@
   recipes:
   - HandheldCrewMonitor
   - MedCrutchesForearm
+  - VehicleWheelchairFolded
 
 - type: latheRecipePack
   id: CDSecfabStatic


### PR DESCRIPTION
## About the PR
Added missing wheelchairs to medical lathes.

## Why / Balance
They were missing due to the recent lathe pack change (I think?).

## Technical details
Added VehicleWheelchairFolded to CDMedfabStatic

## Media
![image](https://github.com/user-attachments/assets/51190bb3-cbf5-4469-bb8d-93c6998fe2f2)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
Wheelchairs can now be made again at medical lathes
