### PR TITLE
Add disposals damage with a cap.

### DIFF
--- a/Content.Server/Disposal/Tube/Components/DisposalTubeComponent.cs
+++ b/Content.Server/Disposal/Tube/Components/DisposalTubeComponent.cs
@@ -32,7 +32,7 @@ public sealed partial class DisposalTubeComponent : Component
     {
         DamageDict = new()
         {
-            { "Blunt", 0.0 },
+            { "Blunt", 3.0 }, // CD: 1 was not enough. It took multiple minutes in a 2x2 loop to kill somebody. This seemed to be a good number.
         }
     };
 }

--- a/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Disposal.Tube.Components;
 using Content.Server.Disposal.Unit.Components;
 using Content.Shared.Body.Components;
 using Content.Shared.Damage;
+using Content.Shared.Damage.Components;
 using Content.Shared.Item;
 using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
@@ -214,7 +215,11 @@ namespace Content.Server.Disposal.Unit.EntitySystems
             {
                 foreach (var ent in holder.Container.ContainedEntities)
                 {
-                    _damageable.TryChangeDamage(ent, to.DamageOnTurn);
+                    // CD: Cap disposals damage at being dead
+                    if (HasComp<StaminaComponent>(ent) // don't break cups because that would spill liquid on the tile above.
+                            && TryComp<DamageableComponent>(ent, out var damage)
+                            && damage.TotalDamage < 201)
+                        _damageable.TryChangeDamage(ent, to.DamageOnTurn);
                 }
                 _audio.PlayPvs(to.ClangSound, toUid);
             }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->
Title, adds disposal damage with a cap. The numbers were based on some testing on fland.

## Requirements

- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the name that you would like to be credited as.
-->
Disposals now deals damage, however it will not continue to hurt you once you are dead.
