### PR TITLE
Map Patch Maintenance

### DIFF
--- a/Resources/CDMapPatches/amber.yml
+++ b/Resources/CDMapPatches/amber.yml
@@ -1,6 +1,13 @@
 - !type:CDSpawnEntityMapPatch
-  worldPosition: -37.963028,-19.952396
-  id: ComputerTabletopMedicalRecords
-- !type:CDSpawnEntityMapPatch
-  worldPosition: -18.963028,-51.952396
+  worldPosition: -21,-43
   id: LockerLostAndFound
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -18.267515,-38.68574
+  id: JobSlotsComputerFlatpack
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 19,-16
+  id: SpawnMobPebble
+- !type:CDSpawnEntityMapPatch
+  worldRotation: -1.5707963267948966 rad
+  worldPosition: 13,36
+  id: ComputerShuttleSalvage

--- a/Resources/CDMapPatches/bagel.yml
+++ b/Resources/CDMapPatches/bagel.yml
@@ -5,7 +5,7 @@
   worldRotation: 1.5707963267948966 rad
   worldPosition: 46.95583,-17.07162
   id: ComputerTabletopMedicalRecords
-  - !type:CDSpawnEntityMapPatch
+- !type:CDSpawnEntityMapPatch
   worldPosition: 3.841084,-31.042545
   id: JobSlotsComputerFlatpack
 - !type:CDSpawnEntityMapPatch

--- a/Resources/CDMapPatches/bagel.yml
+++ b/Resources/CDMapPatches/bagel.yml
@@ -5,3 +5,12 @@
   worldRotation: 1.5707963267948966 rad
   worldPosition: 46.95583,-17.07162
   id: ComputerTabletopMedicalRecords
+  - !type:CDSpawnEntityMapPatch
+  worldPosition: 3.841084,-31.042545
+  id: JobSlotsComputerFlatpack
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -48.04417,-0.071621865
+  id: SpawnMobPebble
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 56.95583,2.928378
+  id: ComputerShuttleSalvage

--- a/Resources/CDMapPatches/box.yml
+++ b/Resources/CDMapPatches/box.yml
@@ -1,3 +1,12 @@
 - !type:CDSpawnEntityMapPatch
   worldPosition: -5.999672,-16.99885
   id: LockerLostAndFound
+  - !type:CDSpawnEntityMapPatch
+  worldPosition: -10.734194,-20.737495
+  id: JobSlotsComputerFlatpack
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -33.999672,-35.998848
+  id: ComputerShuttleSalvage
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 73.00033,-22.99885
+  id: SpawnMobPebble

--- a/Resources/CDMapPatches/box.yml
+++ b/Resources/CDMapPatches/box.yml
@@ -1,7 +1,7 @@
 - !type:CDSpawnEntityMapPatch
   worldPosition: -5.999672,-16.99885
   id: LockerLostAndFound
-  - !type:CDSpawnEntityMapPatch
+- !type:CDSpawnEntityMapPatch
   worldPosition: -10.734194,-20.737495
   id: JobSlotsComputerFlatpack
 - !type:CDSpawnEntityMapPatch

--- a/Resources/CDMapPatches/convex.yml
+++ b/Resources/CDMapPatches/convex.yml
@@ -9,3 +9,6 @@
   worldRotation: -1.5707963267948966 rad
   worldPosition: 55.5,2.5
   id: ComputerShuttleSalvage
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -58.5,0.5
+  id: SpawnMobPebble

--- a/Resources/CDMapPatches/core.yml
+++ b/Resources/CDMapPatches/core.yml
@@ -4,3 +4,14 @@
 - !type:CDSpawnEntityMapPatch
   worldPosition: 42.125523,-23.54723
   id: LockerLostAndFound
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 41.05958,-22.325739
+  id: JobSlotsComputerFlatpack
+- !type:CDSpawnEntityMapPatch
+  worldRotation: 3.141592653589793 rad
+  worldPosition: 39.125523,21.45277
+  id: ComputerShuttleSalvage
+- !type:CDSpawnEntityMapPatch
+  worldRotation: 3.141592653589793 rad
+  worldPosition: 66.12552,-8.547231
+  id: SpawnMobPebble

--- a/Resources/CDMapPatches/elkridge.yml
+++ b/Resources/CDMapPatches/elkridge.yml
@@ -8,3 +8,6 @@
   worldRotation: 3.141592653589793 rad
   worldPosition: 19.953125,33.953125
   id: ComputerShuttleSalvage
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -14.046875,7.953125
+  id: SpawnMobPebble

--- a/Resources/CDMapPatches/loop.yml
+++ b/Resources/CDMapPatches/loop.yml
@@ -12,3 +12,6 @@
   worldRotation: 1.5707963267948966 rad
   worldPosition: -30.124258,59.92165
   id: ComputerJobSlots
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 25.875742,27.921648
+  id: SpawnMobPebble

--- a/Resources/CDMapPatches/marathon.yml
+++ b/Resources/CDMapPatches/marathon.yml
@@ -5,3 +5,12 @@
 - !type:CDSpawnEntityMapPatch
   worldPosition: -4.2289867,36.08518
   id: LockerLostAndFound
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 5.919492,29.096252
+  id: JobSlotsComputerFlatpack
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 42.77101,-18.914822
+  id: ComputerShuttleSalvage
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 41.77101,6.085179
+  id: SpawnMobPebble

--- a/Resources/CDMapPatches/meta.yml
+++ b/Resources/CDMapPatches/meta.yml
@@ -5,3 +5,14 @@
   worldRotation: 1.5707963267948966 rad
   worldPosition: -11.228987,-4.914821
   id: ComputerStationRecords
+- !type:CDSpawnEntityMapPatch
+  worldRotation: 1.5707963267948966 rad
+  worldPosition: -16.228987,-3.9148211
+  id: ComputerJobSlots
+- !type:CDSpawnEntityMapPatch
+  worldRotation: 1.5707963267948966 rad
+  worldPosition: -62.22899,28.085178
+  id: ComputerShuttleSalvage
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 5.7710133,-53.91482
+  id: SpawnMobPebble

--- a/Resources/CDMapPatches/oasis.yml
+++ b/Resources/CDMapPatches/oasis.yml
@@ -1,21 +1,13 @@
 - !type:CDSpawnEntityMapPatch
-  worldRotation: -1.5707963267948966 rad
-  worldPosition: 25.989584,8
-  id: ComputerStationRecords
-- !type:CDSpawnEntityMapPatch
   worldPosition: 22.989584,11
   id: LockerLostAndFound
 - !type:CDSpawnEntityMapPatch
-  worldPosition: -32.010418,-35
-  id: ComputerStationRecords
+  worldPosition: 38.91138,-6.342976
+  id: JobSlotsComputerFlatpack
 - !type:CDSpawnEntityMapPatch
   worldRotation: 1.5707963267948966 rad
-  worldPosition: -55.010418,11
-  id: ComputerStationRecords
+  worldPosition: -62.010418,-27
+  id: ComputerShuttleSalvage
 - !type:CDSpawnEntityMapPatch
-  worldRotation: 1.5707963267948966 rad
-  worldPosition: 2.9895833,44
-  id: ComputerTabletopStationRecords
-- !type:CDSpawnEntityMapPatch
-  worldPosition: 36.989582,-40
-  id: ComputerStationRecords
+  worldPosition: 15.989583,-31
+  id: SpawnMobPebble

--- a/Resources/CDMapPatches/omega.yml
+++ b/Resources/CDMapPatches/omega.yml
@@ -2,10 +2,19 @@
   worldPosition: -2.2289867,26.085178
   id: LockerLostAndFound
 - !type:CDSpawnEntityMapPatch
-  worldRotation: 1.5707963267948966 rad
-  worldPosition: -3.2289867,29.085178
-  id: ComputerStationRecords
-- !type:CDSpawnEntityMapPatch
   worldRotation: 3.141592653589793 rad
   worldPosition: -14.228987,-30.914822
   id: ComputerMedicalRecords
+- !type:CDSpawnEntityMapPatch
+  worldRotation: 3.141592653589793 rad
+  worldPosition: 1.7710133,26.085178
+  id: ComputerStationRecords
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 10.634776,22.361364
+  id: JobSlotsComputerFlatpack
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 35.77101,14.085178
+  id: ComputerShuttleSalvage
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 27.771013,-20.914822
+  id: SpawnMobPebble

--- a/Resources/CDMapPatches/packed.yml
+++ b/Resources/CDMapPatches/packed.yml
@@ -1,3 +1,13 @@
 - !type:CDSpawnEntityMapPatch
   worldPosition: 29.9375,44.984375
   id: LockerLostAndFound
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 18.706285,-2.9669185
+  id: JobSlotsComputerFlatpack
+- !type:CDSpawnEntityMapPatch
+  worldRotation: -1.5707963267948966 rad
+  worldPosition: 6.9375,37.984375
+  id: ComputerShuttleSalvage
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 50.9375,9.984375
+  id: SpawnMobPebble

--- a/Resources/CDMapPatches/plasma.yml
+++ b/Resources/CDMapPatches/plasma.yml
@@ -1,11 +1,12 @@
 - !type:CDSpawnEntityMapPatch
-  worldPosition: -46.731743,-6.401249
+  worldPosition: 18,11
   id: LockerLostAndFound
 - !type:CDSpawnEntityMapPatch
-  worldRotation: -1.5707963267948966 rad
-  worldPosition: -54.731743,-6.401249
-  id: ComputerJobSlots
-- !type:CDSpawnEntityMapPatch
-  worldRotation: 3.141592653589793 rad
-  worldPosition: -99.73174,30.598751
+  worldPosition: -33,61
   id: ComputerShuttleSalvage
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -75,-30
+  id: SpawnMobPebble
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 10,11
+  id: ComputerJobSlots


### PR DESCRIPTION
## About the PR
Updates all current CD map patches to include the newest stuff. Including Pebble.

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Pebble, the Argocyte pet, will now spawn on all Upstream maps. Additionally all upstream maps should now have the job slots console and salvage shuttle consoles.