### PR TITLE
Added: Trooper Gear for Senior Officer Loadouts

### DIFF
--- a/Resources/Prototypes/_CD/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_CD/Loadouts/loadout_groups.yml
@@ -115,6 +115,7 @@
   - SecurityVeteranBeret
   - SecurityBeret
   - SecurityHat
+  - TrooperHat
 
 - type: loadoutGroup
   id: SeniorOfficerJumpsuit
@@ -128,6 +129,7 @@
   - SecurityJumpskirt
   - SecurityJumpsuitGrey
   - SecurityJumpskirtGrey
+  - TrooperUniform
 
 - type: loadoutGroup
   id: SecurityGlassesOrHud


### PR DESCRIPTION
## About the PR
Adds Trooper Gear (including the hat obviously, for the drip) to Senior Officer Loadouts.

## Media
![image](https://github.com/user-attachments/assets/20b19d45-bfae-467e-aad5-4dbc4918bd25)

## Requirements

- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Senior Officers can now wear Trooper Gear for that added security drip. 
