### PR TITLE
Re-enable Space Dragons

### DIFF
--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -97,12 +97,12 @@ public sealed partial class DragonSystem : EntitySystem
             if (!_mobState.IsDead(uid))
                 comp.RiftAccumulator += frameTime;
 
-            // Delete it, naughty dragon!
-            if (comp.RiftAccumulator >= comp.RiftMaxAccumulator)
-            {
-                Roar(uid, comp);
-                QueueDel(uid);
-            }
+            // Delete it, naughty dragon! #CD disable no rift deleting
+            // if (comp.RiftAccumulator >= comp.RiftMaxAccumulator)
+            // {
+            //     Roar(uid, comp);
+            //     QueueDel(uid);
+            // }
         }
     }
 

--- a/Resources/Locale/en-US/dragon/dragon.ftl
+++ b/Resources/Locale/en-US/dragon/dragon.ftl
@@ -2,4 +2,4 @@ dragon-round-end-agent-name = dragon
 
 objective-issuer-dragon = [color=#7567b6]Space Dragon[/color]
 
-dragon-role-briefing = Summon 3 carp rifts and take over this quadrant! The station is located {$direction}.
+dragon-role-briefing = You're here for your own goals and reasons. Kill and conquer, engage in diplomacy, or anything in between. The station is located {$direction}.

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -133,9 +133,9 @@ ghost-role-information-ifrit-name = Ifrit
 ghost-role-information-ifrit-description = Listen to your owner. Don't tank damage. Punch people hard.
 
 ghost-role-information-space-dragon-name = Space Dragon
-ghost-role-information-space-dragon-description = Call in 3 carp rifts and take over this quadrant! You have only 5 minutes in between each rift before you will disappear.
-ghost-role-information-space-dragon-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all your summoned carp.
-ghost-role-information-space-dragon-summoned-carp-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with your dragon and its allies.
+ghost-role-information-space-dragon-description = You're here for your own goals and reasons. Kill and conquer, engage in diplomacy, or anything in between.
+ghost-role-information-space-dragon-rules = You are a [color=yellow][bold]Free Agent[/bold][/color] alongside all your summoned carp.
+ghost-role-information-space-dragon-summoned-carp-rules = You are a [color=yellow][bold]Free Agent[/bold][/color] with your dragon and its allies.
 
 ghost-role-information-space-dragon-dungeon-description = Defend the expedition dungeon with your fishy comrades!
 ghost-role-information-space-dragon-dungeon-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all dungeon mobs.

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -16,7 +16,7 @@
     description: ghost-role-information-space-dragon-description
     rules: ghost-role-information-space-dragon-rules
     mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
+    - MindRoleGhostRoleFreeAgent #CD change from team antag to free agent.
     raffle:
       settings: default
   - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -163,7 +163,7 @@
   id: DragonSpawn
   components:
   - type: StationEvent
-    weight: 1
+    weight: 1 #CD change from 6.5 to 1
     earliestStart: 40
     reoccurrenceDelay: 20
     minimumPlayers: 20

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -175,7 +175,7 @@
   - type: DragonRule
   - type: AntagObjectives
     objectives:
-    - CarpRiftsObjective
+#   - CarpRiftsObjective |CD disabled for free agent status
     - DragonSurviveObjective
   - type: AntagSelection
     agentName: dragon-round-end-agent-name

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -30,7 +30,7 @@
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - id: ClosetSkeleton
-    # - id: DragonSpawn
+    - id: DragonSpawn
     # - id: KingRatMigration
     # - id: NinjaSpawn
     # - id: ParadoxCloneSpawn # CD: Disabled pending rework
@@ -158,34 +158,34 @@
   - type: RandomEntityStorageSpawnRule
     prototype: MobSkeletonCloset
 
-# - type: entity
-#   parent: BaseGameRule
-#   id: DragonSpawn
-#   components:
-#   - type: StationEvent
-#     weight: 6.5
-#     earliestStart: 40
-#     reoccurrenceDelay: 20
-#     minimumPlayers: 20
-#     duration: null
-#   - type: SpaceSpawnRule
-#     spawnDistance: 0
-#   - type: AntagSpawner
-#     prototype: MobDragon
-#   - type: DragonRule
-#   - type: AntagObjectives
-#     objectives:
-#     - CarpRiftsObjective
-#     - DragonSurviveObjective
-#   - type: AntagSelection
-#     agentName: dragon-round-end-agent-name
-#     definitions:
-#     - spawnerPrototype: SpawnPointGhostDragon
-#       min: 1
-#       max: 1
-#       pickPlayer: false
-#       mindRoles:
-#       - MindRoleDragon
+- type: entity
+  parent: BaseGameRule
+  id: DragonSpawn
+  components:
+  - type: StationEvent
+    weight: 1
+    earliestStart: 40
+    reoccurrenceDelay: 20
+    minimumPlayers: 20
+    duration: null
+  - type: SpaceSpawnRule
+    spawnDistance: 0
+  - type: AntagSpawner
+    prototype: MobDragon
+  - type: DragonRule
+  - type: AntagObjectives
+    objectives:
+    - CarpRiftsObjective
+    - DragonSurviveObjective
+  - type: AntagSelection
+    agentName: dragon-round-end-agent-name
+    definitions:
+    - spawnerPrototype: SpawnPointGhostDragon
+      min: 1
+      max: 1
+      pickPlayer: false
+      mindRoles:
+      - MindRoleDragon
 
 # - type: entity
 #   parent: BaseGameRule

--- a/Resources/Prototypes/Objectives/dragon.yml
+++ b/Resources/Prototypes/Objectives/dragon.yml
@@ -32,7 +32,7 @@
   parent: [BaseDragonObjective, BaseSurviveObjective]
   id: DragonSurviveObjective
   name: Survive
-  description: You have to stay alive to maintain control.
+  description: Dying would be counter productive. #CD description change.
   components:
   - type: Objective
     icon:

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -124,7 +124,7 @@
   components:
   - type: MindRole
     antagPrototype: Dragon
-    roleType: TeamAntagonist
+    roleType: FreeAgent #CD change from team antag to free agent.
     exclusiveAntag: true
   - type: DragonRole
   - type: RoleBriefing


### PR DESCRIPTION
## About the PR
Re-enables the Space Dragon event at weight 1 because it was fixed Upstream to not delete bodies on butcher.

Also makes it a free agent and disables the 5 minute timer that deletes the dragon when no rifts are active. (Technically a buff.)

_What's the worst that could happen..?_

**Media**
![image](https://github.com/user-attachments/assets/0d2bf4f8-24e9-4256-9369-b6e66d65209f)

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Space Dragons can now very rarely appear as a ghost role again and attempt to either conquer or befriend the station.