### PR TITLE
admin records console can filter by record entry type again

### DIFF
--- a/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
+++ b/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
@@ -27,6 +27,7 @@ public sealed partial class CharacterRecordViewer : FancyWindow
     public event Action<StationRecordFilterType, string?>? OnFiltersChanged;
 
     private bool _isPopulating;
+    private bool _filtersChanged;
     private StationRecordFilterType _filterType;
 
     private RecordConsoleType? _type;
@@ -147,6 +148,7 @@ public sealed partial class CharacterRecordViewer : FancyWindow
             RecordEntryViewType.SelectId(args.Id);
             // This is a hack to get the server to send us another packet with the new entries
             OnFiltersChanged?.Invoke(_filterType, RecordFiltersValue.Text);
+            _filtersChanged = true;
         };
     }
 
@@ -301,8 +303,9 @@ public sealed partial class CharacterRecordViewer : FancyWindow
         RecordContainerStatus.Visible = false;
         RecordContainer.Visible = true;
 
-        // Do not needlessly reload the record if not needed. This is mainly done to prevent a bug in the admin record viewer.
-        if (state.SelectedIndex == _openRecordKey)
+        // Do not needlessly reload the record if not needed. This is mainly done to prevent a bug in the admin record viewer
+        // AND the admin record filter.
+        if (state.SelectedIndex == _openRecordKey && _filtersChanged == false)
             return;
         _openRecordKey = state.SelectedIndex;
 
@@ -345,12 +348,15 @@ public sealed partial class CharacterRecordViewer : FancyWindow
                 {
                 case RecordConsoleType.Employment:
                     SetEntries(cr.EmploymentEntries, true);
+                    _filtersChanged = false;
                     break;
                 case RecordConsoleType.Medical:
                     SetEntries(cr.MedicalEntries, true);
+                    _filtersChanged = false;
                     break;
                 case RecordConsoleType.Security:
                     SetEntries(cr.SecurityEntries, true);
+                    _filtersChanged = false;
                     break;
                 }
                 break;

--- a/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
+++ b/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
@@ -146,9 +146,9 @@ public sealed partial class CharacterRecordViewer : FancyWindow
             if (args.Id == RecordEntryViewType.SelectedId)
                 return;
             RecordEntryViewType.SelectId(args.Id);
+            _filtersChanged = true;
             // This is a hack to get the server to send us another packet with the new entries
             OnFiltersChanged?.Invoke(_filterType, RecordFiltersValue.Text);
-            _filtersChanged = true;
         };
     }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->
fixes admin record console not showing the proper record entries when you select an entry filter (for filtering security, employment, or medical records)

## Requirements

- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the name that you would like to be credited as.
-->
ADMIN: the admin records console now actually lets you filter what records you want to look at again via record type