### PR TITLE
Fix Title PDAs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -189,7 +189,7 @@
   description: Why isn't it yellow?
   components:
   - type: Pda
-    id: TechnicalAssistantIDCard
+    id: EngineeringIDCard #CD change
   - type: Appearance
     appearanceDataInit:
      enum.PdaVisuals.PdaType:
@@ -210,7 +210,7 @@
   description: Why isn't it white?
   components:
   - type: Pda
-    id: MedicalInternIDCard
+    id: MedicalIDCard #CD change
   - type: Appearance
     appearanceDataInit:
      enum.PdaVisuals.PdaType:
@@ -234,7 +234,7 @@
   description: Why isn't it red?
   components:
   - type: Pda
-    id: SecurityCadetIDCard
+    id: SecurityIDCard #CD change
   - type: Appearance
     appearanceDataInit:
      enum.PdaVisuals.PdaType:
@@ -255,7 +255,7 @@
   description: Why isn't it purple?
   components:
   - type: Pda
-    id: ResearchAssistantIDCard
+    id: ResearchIDCard #CD change
   - type: Appearance
     appearanceDataInit:
      enum.PdaVisuals.PdaType:

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -972,6 +972,7 @@
   loadouts:
   - ScientistPDA
   - ResearchAssistantPDA #CD addition
+  - RoboticistPDA #CD addition
   # - SeniorResearcherPDA
 
 - type: loadoutGroup

--- a/Resources/Prototypes/_CD/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_CD/Loadouts/loadout_groups.yml
@@ -98,15 +98,7 @@
   - RoboticistLabCoat
   - RoboticistWintercoat
 
-- type: loadoutGroup
-  id: ScientistTitles
-  name: loadout-group-scientist-id
-  loadouts:
-  - ScientistPDA
-  - RoboticistPDA
-
 # Security
-
 - type: loadoutGroup
   id: SeniorOfficerHead
   name: loadout-group-security-head


### PR DESCRIPTION
## About the PR
- Fixes Interns not showing up in their departments on crew monitoring.
- Fixes roboticist PDA not being selectable.
- Cleans up some no longer used code related to the roboticist PDA.

## Media
![image](https://github.com/user-attachments/assets/ea887c13-1e46-4917-a7f0-231eba549d48)

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Interns show up properly on the crew monitor and the roboticist PDA can be selected again.