### PR TITLE
Med Tracking Implants

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -34,7 +34,7 @@
     sprite: Objects/Specific/Medical/implanter.rsi
     state: implanter0
   product: CrateTrackingImplants
-  cost: 1000
+  cost: 2500 #CD edit from 1000 to 2500
   category: cargoproduct-category-name-armory
   group: market
 

--- a/Resources/Prototypes/_CD/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/_CD/Catalog/Cargo/cargo_medical.yml
@@ -1,14 +1,4 @@
 - type: cargoProduct
-  id: MedicalSupplies
-  icon:
-    sprite: Objects/Specific/Medical/firstaidkits.rsi
-    state: firstaid
-  product: CrateMedicalSupplies
-  cost: 2400
-  category: cargoproduct-category-name-medical
-  group: market
-
-- type: cargoProduct
   id: MedicalTrackingImplant
   icon:
     sprite: Objects/Specific/Medical/implanter.rsi

--- a/Resources/Prototypes/_CD/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/_CD/Catalog/Cargo/cargo_medical.yml
@@ -1,0 +1,19 @@
+- type: cargoProduct
+  id: MedicalSupplies
+  icon:
+    sprite: Objects/Specific/Medical/firstaidkits.rsi
+    state: firstaid
+  product: CrateMedicalSupplies
+  cost: 2400
+  category: cargoproduct-category-name-medical
+  group: market
+
+- type: cargoProduct
+  id: MedicalTrackingImplant
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateMedicalTrackingImplants
+  cost: 1000
+  category: cargoproduct-category-name-medical
+  group: market

--- a/Resources/Prototypes/_CD/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/_CD/Catalog/Cargo/cargo_medical.yml
@@ -4,6 +4,6 @@
     sprite: Objects/Specific/Medical/implanter.rsi
     state: implanter0
   product: CrateMedicalTrackingImplants
-  cost: 1000
+  cost: 2500
   category: cargoproduct-category-name-medical
   group: market

--- a/Resources/Prototypes/_CD/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/_CD/Catalog/Fills/Crates/medical.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: CrateMedicalTrackingImplants
+  parent: CrateMedicalSecure
+  name: medical tracking implants
+  description: Contains a handful of medical tracking implanters. Good for people who perish alone often.
+  components:
+  - type: StorageFill
+    contents:
+      - id: MedicalTrackingImplanter
+        amount: 5

--- a/Resources/Prototypes/_CD/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_CD/Entities/Objects/Misc/implanters.yml
@@ -1,0 +1,7 @@
+- type: entity
+  id: MedicalTrackingImplanter
+  suffix: medical tracking
+  parent: BaseImplantOnlyImplanter
+  components:
+    - type: Implanter
+      implant: MedicalTrackingImplant

--- a/Resources/Prototypes/_CD/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_CD/Entities/Objects/Misc/subdermal_implants.yml
@@ -1,0 +1,12 @@
+- type: entity
+  parent: TrackingImplant
+  id: MedicalTrackingImplant
+  name: medical tracking implant
+  description: This implant has a tracking device attached to the suit sensor network, as well as a condition monitor for the Medical radio channel. Only rattles on the full death of the user.
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: TriggerOnMobstateChange
+      mobState:
+      - Dead
+    - type: Rattle
+      radioChannel: "Medical"


### PR DESCRIPTION
## About the PR
Adds a crate of medical tracking implants, entirely identical to security tracking implants apart from three factors;
- They come in a secure medical crate.
- They transmit over the medical channel.
- They only rattle off when the user experiences full death opposed to entering critical condition.

Also increases the price of security trackers to 2500 from 1000. Med trackers cost the same as well.

## Media
![image](https://github.com/user-attachments/assets/1c810939-89ed-425c-b650-a0577f38ad13)

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
You can now order medical tracking implants from cargo as an alternative to security tracking implants. Security tracking implants also cost $2500, upped from $1000.