### PR TITLE
More Radio Keys in PTech

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -10,11 +10,13 @@
     Paper: 10
     Envelope: 10
     HandLabeler: 2
-    EncryptionKeyCargo: 2
-    EncryptionKeyEngineering: 2
-    EncryptionKeyMedical: 2
-    EncryptionKeyScience: 2
-    EncryptionKeySecurity: 1
+    EncryptionKeyCargo: 3 #CD change from 2 to 3.
+    EncryptionKeyCommand: 3 #CD addition.
+    EncryptionKeyEngineering: 3 #CD change from 2 to 3.
+    EncryptionKeyHailing: 3 #CD addition.
+    EncryptionKeyMedical: 3 #CD change from 2 to 3.
+    EncryptionKeyScience: 3 #CD change from 2 to 3.
+    EncryptionKeySecurity: 3 #CD change from 1 to 3.
     EncryptionKeyService: 3
   contrabandInventory:
     BalloonNT: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -12,6 +12,7 @@
     HandLabeler: 2
     EncryptionKeyCargo: 3 #CD change from 2 to 3.
     EncryptionKeyCommand: 3 #CD addition.
+    EncryptionKeyCommon: 3 #CD addition.
     EncryptionKeyEngineering: 3 #CD change from 2 to 3.
     EncryptionKeyHailing: 3 #CD addition.
     EncryptionKeyMedical: 3 #CD change from 2 to 3.


### PR DESCRIPTION
## About the PR
- Adds common, command, and hailing encryption keys in the PTech vendor.
- Increases all encryption key amounts to 3.
---
- Having a way to get more command and hailing keys feels important. Hailing especially for giving high command greater ability to delegate hailing matters to other heads or just keeping them in the know directly if desired.
- We shouldn't have to worry too much about the potential abuse from having a few more encryption keys in the vendor, it kind of bothered me that there were so few for things like security.

## Media
![image](https://github.com/user-attachments/assets/986ae666-9369-460a-9835-fe8cdffc5087)

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
The HoP now has access to spare common, command, and hailing radio encryption keys in their PTech vendor.