### PR TITLE
Head of Staff Externals Access

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -21,6 +21,7 @@
   - ChiefMedicalOfficer
   - Brig
   - Cryogenics
+  - External #CD addition.
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -18,6 +18,7 @@
   - ResearchDirector
   - Brig
   - Cryogenics
+  - External #CD addition.
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
## About the PR
- Gives the RD and CMO externals access like the rest of command.
---
- RD has a valid use for externals due to #570 and needing to access the AI core without harming themself if it's not an emergency.
- CMO is given it because they'd become the only head without externals which is a bit weird, but it has some merit if search and rescue needs to be conducted with no paramedics. We should be able to handle CMOs who step on the toes of their own paramedics or abuse this access.
- In general I think it makes sense that the heads of staff on a space station all can be trusted to have access to the front doors.

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
CMO and RD now have externals access.