### PR TITLE
add creativity by increasing marking limits

### DIFF
--- a/Resources/Prototypes/Species/arachnid.yml
+++ b/Resources/Prototypes/Species/arachnid.yml
@@ -63,7 +63,7 @@
       required: true
       defaultMarkings: [ ArachnidCheliceraeDownwards ]
     Chest:
-      points: 3
+      points: 4 # CD
       required: false
     Legs:
       points: 6

--- a/Resources/Prototypes/Species/diona.yml
+++ b/Resources/Prototypes/Species/diona.yml
@@ -52,13 +52,13 @@
       points: 1
       required: false
     Chest:
-      points: 2
+      points: 4 # CD
       required: false
     Legs:
-      points: 2
+      points: 6 # CD
       required: false
     Arms:
-      points: 2
+      points: 6 # CD
       required: false
     Overlay:
       points: 1

--- a/Resources/Prototypes/Species/diona.yml
+++ b/Resources/Prototypes/Species/diona.yml
@@ -52,13 +52,13 @@
       points: 1
       required: false
     Chest:
-      points: 4 # CD
+      points: 3 # CD
       required: false
     Legs:
-      points: 6 # CD
+      points: 2
       required: false
     Arms:
-      points: 6 # CD
+      points: 2
       required: false
     Overlay:
       points: 1

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -65,13 +65,13 @@
       points: 1
       required: false
     Chest:
-      points: 1
+      points: 4 # CD
       required: false
     Legs:
-      points: 2
+      points: 6 # CD
       required: false
     Arms:
-      points: 2
+      points: 6 # CD
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -74,7 +74,7 @@
       points: 1
       required: false
     Chest:
-      points: 2
+      points: 4 # CD
       required: false
     Legs:
       points: 6

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -65,7 +65,7 @@
       points: 1
       required: false
     Chest:
-      points: 3
+      points: 4 # CD
       required: false
     Legs:
       points: 6

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -38,13 +38,13 @@
       points: 1
       required: false
     Chest:
-      points: 1
+      points: 4 # CD
       required: false
     Legs:
-      points: 4
+      points: 6 # CD
       required: false
     Arms:
-      points: 4
+      points: 6 # CD
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -53,11 +53,11 @@
       required: true
       defaultMarkings: [ VoxBeak ]
     Arms:
-      points: 4
+      points: 6 # CD
       required: true
       defaultMarkings: [ VoxLArmScales, VoxRArmScales, VoxRHandScales, VoxLHandScales ]
     Legs:
-      points: 4
+      points: 6 # CD
       required: true
       defaultMarkings: [ VoxLLegScales, VoxRLegScales, VoxRFootScales, VoxLFootScales ]
     UndergarmentTop:
@@ -67,7 +67,7 @@
       points: 1
       required: false
     Chest:
-      points: 1
+      points: 4 # CD
       required: false
     Tail:
       points: 1

--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -53,11 +53,11 @@
       required: true
       defaultMarkings: [ VoxBeak ]
     Arms:
-      points: 6 # CD
+      points: 4
       required: true
       defaultMarkings: [ VoxLArmScales, VoxRArmScales, VoxRHandScales, VoxLHandScales ]
     Legs:
-      points: 4 # CD
+      points: 4
       required: true
       defaultMarkings: [ VoxLLegScales, VoxRLegScales, VoxRFootScales, VoxLFootScales ]
     UndergarmentTop:
@@ -67,7 +67,7 @@
       points: 1
       required: false
     Chest:
-      points: 2 # CD
+      points: 1
       required: false
     Tail:
       points: 1

--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -57,7 +57,7 @@
       required: true
       defaultMarkings: [ VoxLArmScales, VoxRArmScales, VoxRHandScales, VoxLHandScales ]
     Legs:
-      points: 6 # CD
+      points: 4 # CD
       required: true
       defaultMarkings: [ VoxLLegScales, VoxRLegScales, VoxRFootScales, VoxLFootScales ]
     UndergarmentTop:
@@ -67,7 +67,7 @@
       points: 1
       required: false
     Chest:
-      points: 4 # CD
+      points: 2 # CD
       required: false
     Tail:
       points: 1

--- a/Resources/Prototypes/_CD/Species/avali.yml
+++ b/Resources/Prototypes/_CD/Species/avali.yml
@@ -61,10 +61,10 @@
       required: true
       defaultMarkings: [ AvaliEarsBase ]
     Chest:
-      points: 1
+      points: 3
       required: false
     Legs:
-      points: 2
+      points: 4
       required: false
     Arms:
       points: 4

--- a/Resources/Prototypes/_CD/Species/rodentia.yml
+++ b/Resources/Prototypes/_CD/Species/rodentia.yml
@@ -48,7 +48,7 @@
       required: true
       defaultMarkings: [ RodentiaTailDefault ]
     Legs:
-      points: 4
+      points: 6
       required: false
     Arms:
       points: 4
@@ -64,7 +64,7 @@
       points: 1
       required: false
     Chest:
-      points: 2
+      points: 3
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/_CD/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_CD/Species/vulpkanin.yml
@@ -50,10 +50,10 @@
       points: 1
       required: false
     Legs:
-      points: 1
+      points: 3 # CD
       required: false
     Arms:
-      points: 1
+      points: 3 # CD
       required: false
     Snout:
       points: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->
Increased the marking limits of all roundstart species to 4 for chest and 6 for arms and legs except for species that don't have enough markings to reach this number because the tests were crying. 
Vox don't get any extra because they don't have that many markings anyways and whenever I touch them they explode.
If we can have lizard hair we can have more markings.
Player expression etc.
## Requirements

- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the name that you would like to be credited as.
-->
Many species can now choose more chest, arms, and legs markings. 