### PR TITLE
make the lizard synth tail not arbitrarily uncolorable (again)

### DIFF
--- a/Resources/Prototypes/_CD/Entities/Mobs/Customization/Markings/synthetic.yml
+++ b/Resources/Prototypes/_CD/Entities/Mobs/Customization/Markings/synthetic.yml
@@ -47,7 +47,6 @@
   id: LizardTailSynth
   bodyPart: Tail
   markingCategory: Tail
-  forcedColoring: true
   speciesRestriction: [ Reptilian ]
   sprites:
   - sprite: _CD/Mobs/Customization/Synthliz/tails.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->
why was this flag even set in the first place? coloring the synth tail works perfectly fine, why not allow it? what's the worst that can happen?
the whole tail should really be resprited to have top and underbelly color zones like the rest of the but that's above my paygrade so have this band aid instead
(reposted because i'm so good at git, i think this is right now)

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
![tail done have color](https://github.com/user-attachments/assets/6380ff6c-6093-413f-a8d4-f93ee07ac4f5)

## Requirements

- [ X ] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [ X ] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [ X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the name that you would like to be credited as.
-->
Made Lizard Tail (Synth-Lizard) recolorable.
