### PR TITLE
Increased food cart capacity to 300

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
@@ -47,7 +47,7 @@
         enum.StorageUiKey.Key:
           type: StorageBoundUserInterface
     - type: Storage
-      capacity: 300 #CD
+      capacity: 300 #CD, our storage system is different and 30 isn't practical with it
     - type: TileFrictionModifier
       modifier: 0.4 # makes it slide 
     

--- a/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
@@ -47,7 +47,7 @@
         enum.StorageUiKey.Key:
           type: StorageBoundUserInterface
     - type: Storage
-      capacity: 300
+      capacity: 300 #CD
     - type: TileFrictionModifier
       modifier: 0.4 # makes it slide 
     

--- a/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Kitchen/foodcarts.yml
@@ -47,7 +47,7 @@
         enum.StorageUiKey.Key:
           type: StorageBoundUserInterface
     - type: Storage
-      capacity: 30
+      capacity: 300
     - type: TileFrictionModifier
       modifier: 0.4 # makes it slide 
     


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->
Increased the capacity of the food cart from 30 to 300, as per discussion here https://discord.com/channels/1163352113162768436/1364763014074728480, since it's kinda hard to practically use with such a low capacity. Left unwhitelisted to allow for traitor shenanigans (rolling up to the bridge with 'food' for command :3)


## Requirements

- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the name that you would like to be credited as.
-->
BlueNexa: Increased capacity of the food carts from 30 to 300.
