### PR TITLE
fix ghost respawn button timer

### DIFF
--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -53,7 +53,7 @@ public sealed partial class GhostComponent : Component
     /// May not reflect actual time of death if this entity has been paused,
     /// but will give an accurate length of time <i>since</i> death.
     /// </remarks>
-    [DataField, AutoPausedField]
+    [DataField, AutoPausedField, AutoNetworkedField] // CD: Add AutoNetworkedField
     public TimeSpan TimeOfDeath = TimeSpan.Zero;
 
     /// <summary>


### PR DESCRIPTION
Simply accidentally removed AutoNetworkedField during the (2nd) last upstream merge. 