### PR TITLE
add mantle to quickthreads

### DIFF
--- a/Resources/Prototypes/_CD/Catalog/VendingMachines/Inventories/quickthreads.yml
+++ b/Resources/Prototypes/_CD/Catalog/VendingMachines/Inventories/quickthreads.yml
@@ -113,3 +113,4 @@
     ClothingUniformJumpskirtGreenStripedDress: 4
     ClothingUniformJumpskirtPinkStripedDress: 4
     ClothingUniformJumpskirtOrangeStripedDress: 4
+    ClothingNeckMantle: 2


### PR DESCRIPTION

## About the PR
This PR adds 2 basic mantles to the quickthreads vendor.
This is because I like mantles. Player expression.
## Media
![image](https://github.com/user-attachments/assets/73516d52-580a-4b26-b717-abb1ece8beab)
## Requirements

- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the name that you would like to be credited as.
-->
Added mantles to quickthreads