### PR TITLE
Remove crimelist from guidebook

### DIFF
--- a/Resources/Prototypes/Guidebook/rules.yml
+++ b/Resources/Prototypes/Guidebook/rules.yml
@@ -202,11 +202,12 @@
   priority: 1
   text: "/ServerInfo/Guidebook/ServerRules/SpaceLaw/CDSpaceLaw.xml"
 
-- type: guideEntry
-  id: SpaceLawCrimeList
-  name: guide-entry-rules-sl-crime-list
-  priority: 5
-  text: "/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml"
+# CD: Remove pending rework
+#- type: guideEntry
+#  id: SpaceLawCrimeList
+#  name: guide-entry-rules-sl-crime-list
+#  priority: 5
+#  text: "/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml"
 
 - type: guideEntry
   id: BanTypes


### PR DESCRIPTION
It uses new wizden space law. We should remove it to not confuse people.
