### PR TITLE
Make Rings able to be engraved

### DIFF
--- a/Resources/Locale/en-US/_CD/engraving/engraving.ftl
+++ b/Resources/Locale/en-US/_CD/engraving/engraving.ftl
@@ -4,3 +4,7 @@ engraving-popup-ui-message = Description
 engraving-dogtags-no-message = The dogtags don't seem to have any kind of engraving.
 engraving-dogtags-has-message = The dogtags are engraved with a message that reads:{" "}
 engraving-dogtags-succeed = You successfully engrave the dogtags with your message.
+
+engraving-ring-no-message = The ring doesn't seem to have any kind of engraving.
+engraving-ring-has-message = The ring is engraved with a message that reads:{" "}
+engraving-ring-succeed = You successfully engrave the ring with your message.

--- a/Resources/Prototypes/Entities/Clothing/Hands/base_clothinghands.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/base_clothinghands.yml
@@ -61,6 +61,10 @@
   - type: Tag
     tags:
     - Ring
+  - type: Engraveable #Start CD changes
+    noEngravingText: "engraving-ring-no-message"
+    engraveSuccessMessage: "engraving-ring-succeed"
+    hasEngravingText: "engraving-ring-has-message" # End CD changes
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->
Rings can now be engraved like dog tags!
Why?
I think it's neat, and it's a harmless change, can add more flavor to rings! 
## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
![image](https://github.com/user-attachments/assets/05494dc3-74d4-4d47-be9e-243da130716b)
![image](https://github.com/user-attachments/assets/a0b9d275-c24e-4eb3-8908-8eef71c9fc71)
![image](https://github.com/user-attachments/assets/840510b2-ca25-40b3-96bd-6c739a4ccf06)

## Requirements

- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the name that you would like to be credited as.
-->
Rings can now be engraved like dog tags.