### PR TITLE
change HandStripDelay from 4 seconds to 2, decreasing the time it takes to take an item from or give a item to someone.

### DIFF
--- a/Content.Shared/Strip/Components/StrippableComponent.cs
+++ b/Content.Shared/Strip/Components/StrippableComponent.cs
@@ -12,7 +12,7 @@ namespace Content.Shared.Strip.Components
         ///     The strip delay for hands.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite), DataField("handDelay")]
-        public TimeSpan HandStripDelay = TimeSpan.FromSeconds(4f);
+        public TimeSpan HandStripDelay = TimeSpan.FromSeconds(2f);
     }
 
     [NetSerializable, Serializable]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This PR changes the HandStripDelay variable from 4 seconds to 2 seconds, decreasing the amount of time it takes to give or take items from other players. I believe the original reason for it being 4 seconds was due to antag balancing, something that isn't really needed on this fork. 
<!-- What did you change in this PR and why did you do it? -->

## Requirements

- [x] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [x] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
The amount of time it takes for you to take items from or give items to another player has been decreased.
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the name that you would like to be credited as.
-->
