### PR TITLE
Cosmetic Drip 4.3 ~ Derespriting Engineering

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/atmosdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/atmosdrobe.yml
@@ -5,7 +5,9 @@
     ClothingBackpackSatchelAtmospherics: 2
     ClothingBackpackAtmospherics: 2
     ClothingUniformJumpsuitAtmos: 3
+    ClothingUniformJumpsuitAtmosModern: 3 # CD
     ClothingUniformJumpskirtAtmos: 3
+    ClothingUniformJumpskirtAtmosModern: 3 # CD
     ClothingUniformJumpsuitAtmosCasual: 3
     ClothingUniformJumpsuitAtmosHazard: 3 # CD
     ClothingUniformJumpsuitEngineeringPants: 3 # CD

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engidrobe.yml
@@ -5,8 +5,11 @@
     ClothingBackpackSatchelEngineering: 3
     ClothingBackpackEngineering: 3
     ClothingUniformJumpsuitEngineering: 3
+    ClothingUniformJumpsuitEngineeringModern: 3 # CD
     ClothingUniformJumpskirtEngineering: 3
+    ClothingUniformJumpskirtEngineeringModern: 3 # CD
     ClothingUniformJumpsuitEngineeringHazard: 3
+    ClothingUniformJumpsuitEngineeringHazardModern: 3 # CD
     ClothingUniformJumpsuitEngineeringCasual: 3 # CD
     ClothingUniformJumpsuitEngineeringPants: 3 # CD
     ClothingShoesColorBlack: 3

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -159,9 +159,9 @@
   description: If this suit was non-conductive, maybe engineers would actually do their damn job.
   components:
   - type: Sprite
-    sprite: _CD/Clothing/Uniforms/Jumpskirt/engineering.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/engineering.rsi
   - type: Clothing
-    sprite: _CD/Clothing/Uniforms/Jumpskirt/engineering.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/engineering.rsi
 
 - type: entity
   parent: [ClothingUniformSkirtBase, BaseCommandContraband]

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -543,9 +543,9 @@
   description: I am at work. I can't leave work. Work is breathing. I am testing air quality.
   components:
   - type: Sprite
-    sprite: Clothing/Uniforms/Jumpskirt/atmos.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/atmosf.rsi
   - type: Clothing
-    sprite: Clothing/Uniforms/Jumpskirt/atmos.rsi
+    sprite: Clothing/Uniforms/Jumpskirt/atmosf.rsi
 
 - type: entity
   parent: ClothingUniformSkirtBase

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -159,9 +159,9 @@
   description: If this suit was non-conductive, maybe engineers would actually do their damn job.
   components:
   - type: Sprite
-    sprite: _CD/Clothing/Uniforms/Jumpskirt/engineering.rsi # CD drip 4
+    sprite: _CD/Clothing/Uniforms/Jumpskirt/engineering.rsi
   - type: Clothing
-    sprite: _CD/Clothing/Uniforms/Jumpskirt/engineering.rsi # CD drip 4
+    sprite: _CD/Clothing/Uniforms/Jumpskirt/engineering.rsi
 
 - type: entity
   parent: [ClothingUniformSkirtBase, BaseCommandContraband]
@@ -543,9 +543,9 @@
   description: I am at work. I can't leave work. Work is breathing. I am testing air quality.
   components:
   - type: Sprite
-    sprite: _CD/Clothing/Uniforms/Jumpskirt/atmos.rsi # CD drip 4
+    sprite: Clothing/Uniforms/Jumpskirt/atmos.rsi
   - type: Clothing
-    sprite: _CD/Clothing/Uniforms/Jumpskirt/atmos.rsi # CD drip 4
+    sprite: Clothing/Uniforms/Jumpskirt/atmos.rsi
 
 - type: entity
   parent: ClothingUniformSkirtBase

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -303,9 +303,9 @@
   description: If this suit was non-conductive, maybe engineers would actually do their damn job.
   components:
   - type: Sprite
-    sprite: _CD/Clothing/Uniforms/Jumpsuit/engineering.rsi # CD drip 4
+    sprite: Clothing/Uniforms/Jumpsuit/engineering.rsi
   - type: Clothing
-    sprite: _CD/Clothing/Uniforms/Jumpsuit/engineering.rsi # CD drip 4
+    sprite: Clothing/Uniforms/Jumpsuit/engineering.rsi
 
 - type: entity
   parent: ClothingUniformBase
@@ -314,9 +314,9 @@
   description: Woven in a grungy, warm orange. Lets others around you know that you really mean business when it comes to work.
   components:
   - type: Sprite
-    sprite: _CD/Clothing/Uniforms/Jumpsuit/engineering_hazard.rsi # CD drip 4
+    sprite: Clothing/Uniforms/Jumpsuit/engineering_hazard.rsi
   - type: Clothing
-    sprite: _CD/Clothing/Uniforms/Jumpsuit/engineering_hazard.rsi # CD drip 4
+    sprite: Clothing/Uniforms/Jumpsuit/engineering_hazard.rsi
 
 - type: entity
   parent: [ClothingUniformBase, BaseCommandContraband]
@@ -899,9 +899,9 @@
   description: I am at work. I can't leave work. Work is breathing. I am testing air quality.
   components:
   - type: Sprite
-    sprite: _CD/Clothing/Uniforms/Jumpsuit/atmos.rsi # CD drip 4
+    sprite: Clothing/Uniforms/Jumpsuit/atmos.rsi 
   - type: Clothing
-    sprite: _CD/Clothing/Uniforms/Jumpsuit/atmos.rsi # CD drip 4
+    sprite: Clothing/Uniforms/Jumpsuit/atmos.rsi 
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -790,6 +790,9 @@
   - StationEngineerJumpsuit
   - StationEngineerJumpskirt
   - StationEngineerHazardsuit
+  - StationEngineerJumpsuitModern # CD
+  - StationEngineerJumpskirtModern # CD
+  - StationEngineerHazardsuitModern # CD
   - StationEngineerCasualsuit # CD
   - StationEngineerPants # CD
   # - SeniorEngineerJumpsuit
@@ -832,6 +835,8 @@
   loadouts:
   - AtmosphericTechnicianJumpsuit
   - AtmosphericTechnicianJumpskirt
+  - AtmosphericTechnicianJumpsuitModern # CD
+  - AtmosphericTechnicianJumpskirtModern # CD
   - AtmosphericTechnicianHazardsuit # CD
   - AtmosphericTechnicianJumpsuitCasual
 

--- a/Resources/Prototypes/_CD/Entities/Clothing/Uniforms/jumpskirt.yml
+++ b/Resources/Prototypes/_CD/Entities/Clothing/Uniforms/jumpskirt.yml
@@ -106,6 +106,8 @@
 
 # Non-casual drip below
 
+# Engineering Garments
+
 - type: entity
   parent: [ClothingUniformSkirtBase, BaseCommandContraband]
   id: ClothingUniformJumpskirtChiefEngineerModern
@@ -117,7 +119,6 @@
   - type: Clothing
     sprite: _CD/Clothing/Uniforms/Jumpskirt/ce.rsi
 
-
 - type: entity
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtSeniorEngineerModern
@@ -128,3 +129,25 @@
     sprite: _CD/Clothing/Uniforms/Jumpskirt/senior_engineer.rsi
   - type: Clothing
     sprite: _CD/Clothing/Uniforms/Jumpskirt/senior_engineer.rsi
+
+- type: entity
+  parent: ClothingUniformSkirtBase
+  id: ClothingUniformJumpskirtEngineeringModern
+  name: engineering jumpskirt
+  description: If this suit was non-conductive, maybe engineers would actually do their damn job.
+  components:
+  - type: Sprite
+    sprite: _CD/Clothing/Uniforms/Jumpskirt/engineering.rsi
+  - type: Clothing
+    sprite: _CD/Clothing/Uniforms/Jumpskirt/engineering.rsi
+
+- type: entity
+  parent: ClothingUniformSkirtBase
+  id: ClothingUniformJumpskirtAtmosModern
+  name: atmospheric technician jumpskirt
+  description: I am at work. I can't leave work. Work is breathing. I am testing air quality.
+  components:
+  - type: Sprite
+    sprite: _CD/Clothing/Uniforms/Jumpskirt/atmos.rsi
+  - type: Clothing
+    sprite: _CD/Clothing/Uniforms/Jumpskirt/atmos.rsi

--- a/Resources/Prototypes/_CD/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_CD/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -364,6 +364,28 @@
 
 - type: entity
   parent: ClothingUniformBase
+  id: ClothingUniformJumpsuitEngineeringModern
+  name: engineering jumpsuit
+  description: If this suit was non-conductive, maybe engineers would actually do their damn job.
+  components:
+  - type: Sprite
+    sprite: _CD/Clothing/Uniforms/Jumpsuit/engineering.rsi
+  - type: Clothing
+    sprite: _CD/Clothing/Uniforms/Jumpsuit/engineering.rsi
+
+- type: entity
+  parent: ClothingUniformBase
+  id: ClothingUniformJumpsuitEngineeringHazardModern
+  name: hazard jumpsuit
+  description: Woven in a grungy, warm orange. Lets others around you know that you really mean business when it comes to work.
+  components:
+  - type: Sprite
+    sprite: _CD/Clothing/Uniforms/Jumpsuit/engineering_hazard.rsi
+  - type: Clothing
+    sprite: _CD/Clothing/Uniforms/Jumpsuit/engineering_hazard.rsi
+
+- type: entity
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitAtmosHazard
   name: atmospherics hazard jumpsuit
   description: Woven from black fire-retardant material. Lets you act where others might falter during emergencies.
@@ -372,6 +394,17 @@
     sprite: _CD/Clothing/Uniforms/Jumpsuit/atmos_hazard.rsi
   - type: Clothing
     sprite: _CD/Clothing/Uniforms/Jumpsuit/atmos_hazard.rsi
+
+- type: entity
+  parent: ClothingUniformBase
+  id: ClothingUniformJumpsuitAtmosModern
+  name: atmospheric technician jumpsuit
+  description: I am at work. I can't leave work. Work is breathing. I am testing air quality.
+  components:
+  - type: Sprite
+    sprite: _CD/Clothing/Uniforms/Jumpsuit/atmos.rsi 
+  - type: Clothing
+    sprite: _CD/Clothing/Uniforms/Jumpsuit/atmos.rsi 
 
 # Suits
 

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Engineering/atmospheric_technician.yml
@@ -4,6 +4,16 @@
   equipment: 
     jumpsuit: ClothingUniformJumpsuitAtmosHazard
 
+- type: loadout
+  id: AtmosphericTechnicianJumpsuitModern
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitAtmosModern
+
+- type: loadout
+  id: AtmosphericTechnicianJumpskirtModern
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtAtmosModern
+
 # OuterClothing
 - type: loadout
   id: AtmosphericTechnicianOveralls

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -9,6 +9,21 @@
   equipment: 
     jumpsuit: ClothingUniformJumpsuitEngineeringPants
 
+- type: loadout
+  id: StationEngineerJumpsuitModern
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitEngineeringModern
+
+- type: loadout
+  id: StationEngineerHazardModern
+  equipment: 
+    jumpsuit: ClothingUniformJumpsuitEngineeringHazardModern
+
+- type: loadout
+  id: StationEngineerJumpskirtModern
+  equipment: 
+    jumpsuit: ClothingUniformJumpskirtEngineeringModern
+
 # OuterClothing
 - type: loadout
   id: StationEngineerJacket

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -15,7 +15,7 @@
     jumpsuit: ClothingUniformJumpsuitEngineeringModern
 
 - type: loadout
-  id: StationEngineerHazardModern
+  id: StationEngineerHazardsuitModern
   equipment: 
     jumpsuit: ClothingUniformJumpsuitEngineeringHazardModern
 


### PR DESCRIPTION
## About the PR
Made duplicated versions of the Engineering uniforms to let people use both the original and redesigned versions

## Requirements

- [x] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [x] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Gave back the older engineering uniforms, don't forget to pick your preference in the loadout!