### PR TITLE
make AI ion storm vulnerable

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -269,6 +269,7 @@
   - type: SiliconLawProvider
     laws: Crewsimov
   - type: SiliconLawBound
+  - type: IonStormTarget # CD change
   - type: ActionGrant
     actions:
     - ActionViewLaws


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->
gave the AI the ability to be hit by ion storms

apparently it was something that was wanting to be done but was simply never done? this hopefully remedies that, and means more interaction with the AI in the future by using the boards in the upload (and probably having some conflict)

do note that this uses the default ion chance of being affected (which is 80%) so if it is too much, it should probably be lowered at a future point

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

![image](https://github.com/user-attachments/assets/ad6149b3-2a56-4e47-8b57-128a67a1fba8)

## Requirements

- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the name that you would like to be credited as.
-->

AI cores can now be affected by ion storms, hurray!
