### PR TITLE
increase idle timeout from 1 to 10 minutes for holopads (and all things using TelephoneComponent)

### DIFF
--- a/Content.Shared/Telephone/TelephoneComponent.cs
+++ b/Content.Shared/Telephone/TelephoneComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class TelephoneComponent : Component
     /// Sets how long the telephone can remain idle in-call before it automatically hangs up
     /// </summary>
     [DataField]
-    public float IdlingTimeout = 60;
+    public float IdlingTimeout = 600; // CD change - 10 minutes
 
     /// <summary>
     /// Sets how long the telephone will stay in the hanging up state before return to idle


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->
increase the time it takes for a holopad to timeout from idleness from 1 minute to 10 minutes

(primarily as AI) it gets really annoying to constantly be hanged up automatically because you're listening to someone talk from the other end of the holopad and you don't want to interrupt

changes the default TelephoneComponent value for the timeout time to 10 minutes due it probably being something that we don't want to have issues with in the future should anything else that uses the component be merged

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

physically cannot attach a video that would show this due to the length

## Requirements

- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the name that you would like to be credited as.
-->

Holopads now take longer to kick you out of a call for being idle.