### PR TITLE
Add trait for redacting OOC names from round-end

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -25,6 +25,8 @@ using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
+using Content.Server._CD.Traits;
+
 namespace Content.Server.GameTicking
 {
     public sealed partial class GameTicker
@@ -555,8 +557,12 @@ namespace Content.Server.GameTicking
                 else if (mind.CurrentEntity != null && TryName(mind.CurrentEntity.Value, out var icName))
                     playerIcName = icName;
 
+                var playerOOCName = contentPlayerData?.Name ?? "(IMPOSSIBLE: REGISTERED MIND WITH NO OWNER)"; // CD: Round End Redacting
                 if (TryGetEntity(mind.OriginalOwnedEntity, out var entity) && pvsOverride)
                 {
+                    // CD: Round End Redacting
+                    if (HasComp<HideFromRoundEndScreenComponent>(entity))
+                        playerOOCName = Loc.GetString("cd-name-redacted-text");
                     _pvsOverride.AddGlobalOverride(entity.Value);
                 }
 
@@ -566,7 +572,7 @@ namespace Content.Server.GameTicking
                 {
                     // Note that contentPlayerData?.Name sticks around after the player is disconnected.
                     // This is as opposed to ply?.Name which doesn't.
-                    PlayerOOCName = contentPlayerData?.Name ?? "(IMPOSSIBLE: REGISTERED MIND WITH NO OWNER)",
+                    PlayerOOCName = playerOOCName, // CD: Round End Redacting
                     // Character name takes precedence over current entity name
                     PlayerICName = playerIcName,
                     PlayerGuid = userId,

--- a/Content.Server/_CD/Traits/HideFromRoundEndScreenComponent.cs
+++ b/Content.Server/_CD/Traits/HideFromRoundEndScreenComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Server._CD.Traits;
+
+[RegisterComponent]
+public sealed partial class HideFromRoundEndScreenComponent : Component;

--- a/Resources/Locale/en-US/_CD/traits/traits.ftl
+++ b/Resources/Locale/en-US/_CD/traits/traits.ftl
@@ -17,3 +17,10 @@ cd-trait-heavyweight-desc = Alcohol has a weaker effect on you.
 
 trait-russian-name = Russian accent
 trait-russian-desc = You seem to have come from a region of space that speaks Russian, da?
+
+cd-trait-category-meta = Meta
+
+cd-trait-hide-from-round-end-screen-name = Hide SS14 Username
+cd-trait-hide-from-round-end-screen-desc = Hides your ss14 username from the end screen. Admins will still be able to see that it is you.
+# This is unfiltered markup so the brackets need to be escaped
+cd-name-redacted-text = \[REDACTED\]

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -72,6 +72,7 @@
   id: WheelchairBound
   name: trait-wheelchair-bound-name
   description: trait-wheelchair-bound-desc
+  category: Disabilities
   blacklist:
     components:
       - BorgChassis
@@ -79,7 +80,7 @@
     - type: BuckleOnMapInit
       prototype: VehicleWheelchair
     - type: LegsParalyzed
-    
+
 - type: trait
   id: PainNumbness
   name: trait-painnumbness-name

--- a/Resources/Prototypes/_CD/Traits/categories.yml
+++ b/Resources/Prototypes/_CD/Traits/categories.yml
@@ -2,3 +2,7 @@
   id: DrinkingSkill
   name: cd-trait-category-drinking-skill
   maxTraitPoints: 1
+
+- type: traitCategory
+  id: Meta
+  name: cd-trait-category-meta

--- a/Resources/Prototypes/_CD/Traits/traits.yml
+++ b/Resources/Prototypes/_CD/Traits/traits.yml
@@ -2,6 +2,7 @@
   id: Synthetic
   name: trait-synth-name
   description: trait-synth-desc
+  category: Quirks
   components:
     - type: Synth
 
@@ -9,11 +10,12 @@
   id: ScaleItem
   name: trait-scale-item-name
   description: trait-scale-item-desc
+  category: Quirks
   components:
     - type: ScaleItem
       maxScale: 0.85
       size: 120
-      
+
 - type: trait
   id: VeryLightweightDrunk
   name: cd-trait-very-lightweight-name
@@ -33,3 +35,11 @@
   components:
   - type: LightweightDrunk
     boozeStrengthMultiplier: 0.5
+
+- type: trait
+  id: HideFromRoundEndScreen
+  name: cd-trait-hide-from-round-end-screen-name
+  description: cd-trait-hide-from-round-end-screen-desc
+  category: Meta
+  components:
+  - type: HideFromRoundEndScreen


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR and why did you do it? -->
Adds the ability to readact your OOC name round end.

While making this I took the liberty of putting all existing CD traits into categories. I know that probably should be a
separate PR but I am lazy.

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements

- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the name that you would like to be credited as.
-->
You can now redact your OOC name in the round end screen on a per-character basis by selecting the "Hide SS14 Username" trait.
