### PR TITLE
Vulpkanin Marking Improvements

### DIFF
--- a/Resources/Locale/en-US/_CD/markings/vulpkanin.ftl
+++ b/Resources/Locale/en-US/_CD/markings/vulpkanin.ftl
@@ -24,7 +24,7 @@ marking-VulpEarWolf = Vulpkanin Wolf
 
 marking-VulpEarFennec-fennec = Fennec ears (base)
 marking-VulpEarFennec-fennec-inner = Fennec ears (inner)
-marking-VulpEarFennec = Vulpkanin Fennec
+marking-VulpEarFennec = Vulpkanin Fennec (No Wag)
 
 marking-VulpEarFox-fox = Fox ears
 marking-VulpEarFox = Vulpkanin Fox
@@ -104,11 +104,11 @@ marking-VulpTailTip = Vulpkanin (tip)
 
 marking-VulpTailAlt-vulp_alt = Vulpkanin tail (base)
 marking-VulpTailAlt-vulp_alt-fade = Vulpkanin tail (fade)
-marking-VulpTailAlt = Vulpkanin (alt)
+marking-VulpTailAlt = Vulpkanin (alt, No Wag)
 
 marking-VulpTailAltTip-vulp_alt = Vulpkanin tail (base)
 marking-VulpTailAltTip-vulp_alt-tip = Vulpkanin tail (tip)
-marking-VulpTailAltTip = Vulpkanin (alt, tip)
+marking-VulpTailAltTip = Vulpkanin (alt, tip, No Wag)
 
 marking-VulpTailLong-long = Long tail (base)
 marking-VulpTailLong-long-tip = Long tail (tip)
@@ -130,13 +130,13 @@ marking-VulpTailCoyote = Vulpkanin Coyote
 
 marking-VulpTailHusky-husky-inner = Husky tail (inner)
 marking-VulpTailHusky-husky-outer = Husky tail (outer)
-marking-VulpTailHusky = Vulpkanin Husky
+marking-VulpTailHusky = Vulpkanin Husky (No Wag)
 
 marking-VulpTailHuskyAlt-husky = Husky tail
-marking-VulpTailHuskyAlt = Vulpkanin Husky (alt)
+marking-VulpTailHuskyAlt = Vulpkanin Husky (alt, No Wag)
 
 marking-VulpTailFox2-fox2 = Fox tail
-marking-VulpTailFox2 = Vulpkanin Fox 2
+marking-VulpTailFox2 = Vulpkanin Fox 2 (No Wag)
 
 marking-VulpTailFox3-fox3 = Fox tail (base)
 marking-VulpTailFox3-fox3-tip = Fox tail (tip)
@@ -146,12 +146,12 @@ marking-VulpTailFennec-fennec = Fennec tail
 marking-VulpTailFennec = Vulpkanin Fennec
 
 marking-VulpTailOtie-otie = Otie tail
-marking-VulpTailOtie = Vulpkanin Otie
+marking-VulpTailOtie = Vulpkanin Otie (No Wag)
 
 marking-VulpTailFluffy-fluffy = Fluffy tail
-marking-VulpTailFluffy = Vulpkanin Fluffy
+marking-VulpTailFluffy = Vulpkanin Fluffy (No Wag)
 
-marking-VulpTailDalmation = Dalmation
+marking-VulpTailDalmation = Dalmation (No Wag)
 
 marking-VulpTailCorgi = Corgi
 

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/scars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/scars.yml
@@ -2,7 +2,7 @@
   id: ScarEyeRight
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Human, Dwarf, Rodentia]
+  speciesRestriction: [Human, Dwarf, Rodentia, Vulpkanin] # CD: Add Vulps.
   followSkinColor: true
   sprites:
   - sprite: Mobs/Customization/scars.rsi
@@ -12,7 +12,7 @@
   id: ScarEyeLeft
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Human, Dwarf, Rodentia]
+  speciesRestriction: [Human, Dwarf, Rodentia, Vulpkanin] # CD: Add Vulps.
   followSkinColor: true
   sprites:
   - sprite: Mobs/Customization/scars.rsi
@@ -22,7 +22,7 @@
   id: ScarTopSurgeryShort
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human, Dwarf]
+  speciesRestriction: [Human, Dwarf, Vulpkanin] # CD: Add Vulps.
   sexRestriction: [Male]
   followSkinColor: true
   sprites:
@@ -33,7 +33,7 @@
   id: ScarTopSurgeryLong
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human, Dwarf]
+  speciesRestriction: [Human, Dwarf, Vulpkanin] # CD: Add Vulps.
   sexRestriction: [Male]
   followSkinColor: true
   sprites:
@@ -44,7 +44,7 @@
   id: ScarChest
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human, Dwarf]
+  speciesRestriction: [Human, Dwarf, Vulpkanin] # CD: Add Vulps.
   followSkinColor: true
   sprites:
   - sprite: Mobs/Customization/scars.rsi
@@ -54,7 +54,7 @@
   id: ScarNeck
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Human, Dwarf]
+  speciesRestriction: [Human, Dwarf, Vulpkanin] # CD: Add Vulps.
   followSkinColor: true
   sprites:
   - sprite: Mobs/Customization/scars.rsi
@@ -64,7 +64,7 @@
   id: ScarChestBullets
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human, Dwarf]
+  speciesRestriction: [Human, Dwarf, Vulpkanin] # CD: Add Vulps.
   followSkinColor: true
   sprites:
   - sprite: Mobs/Customization/scars.rsi
@@ -74,7 +74,7 @@
   id: ScarStomachBullets
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human, Dwarf]
+  speciesRestriction: [Human, Dwarf, Vulpkanin] # CD: Add Vulps.
   followSkinColor: true
   sprites:
   - sprite: Mobs/Customization/scars.rsi
@@ -84,7 +84,7 @@
   id: ScarFace1
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Human, Dwarf]
+  speciesRestriction: [Human, Dwarf, Vulpkanin] # CD: Add Vulps.
   followSkinColor: true
   sprites:
   - sprite: Mobs/Customization/scars.rsi
@@ -94,7 +94,7 @@
   id: ScarFace2
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Human, Dwarf]
+  speciesRestriction: [Human, Dwarf, Vulpkanin] # CD: Add Vulps.
   followSkinColor: true
   sprites:
   - sprite: Mobs/Customization/scars.rsi

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
@@ -114,7 +114,7 @@
   id: TattooEyeRight
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Rodentia]
+  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Rodentia, Vulpkanin] # CD: Add Vulps.
   coloring:
     default:
       type:
@@ -128,7 +128,7 @@
   id: TattooEyeLeft
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Rodentia]
+  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Rodentia, Vulpkanin] # CD: Add Vulps.
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
@@ -1,5 +1,5 @@
 # These options are kept very sparse to not put emphasis on nudity, and to provide a base for players to feel comfortable with.
-# It's unlikely more will be added to upstream for cosmetic reasons. 
+# It's unlikely more will be added to upstream for cosmetic reasons.
 
 - type: marking
   id: UndergarmentBottomBoxers

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
@@ -5,7 +5,7 @@
   id: UndergarmentBottomBoxers
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson, Vulpkanin] # CD: Add Vulps,
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson, Vulpkanin] # CD: Add Vulps.
   coloring:
     default:
       type: null
@@ -18,7 +18,7 @@
   id: UndergarmentBottomBriefs
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson, Vulpkanin] # CD: Add Vulps,
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson, Vulpkanin] # CD: Add Vulps.
   coloring:
     default:
       type: null
@@ -31,7 +31,7 @@
   id: UndergarmentBottomSatin
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson, Vulpkanin] # CD: Add Vulps,
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson, Vulpkanin] # CD: Add Vulps.
   coloring:
     default:
       type: null
@@ -44,7 +44,7 @@
   id: UndergarmentTopBra
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Vulpkanin] # CD: Add Vulps,
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Vulpkanin] # CD: Add Vulps.
   coloring:
     default:
       type: null
@@ -57,7 +57,7 @@
   id: UndergarmentTopSportsbra
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Vulpkanin] # CD: Add Vulps,
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Vulpkanin] # CD: Add Vulps.
   coloring:
     default:
       type: null
@@ -70,7 +70,7 @@
   id: UndergarmentTopBinder
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Vulpkanin] # CD: Add Vulps,
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Vulpkanin] # CD: Add Vulps.
   coloring:
     default:
       type: null
@@ -83,7 +83,7 @@
   id: UndergarmentTopTanktop
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Vulpkanin] # CD: Add Vulps,
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Vulpkanin] # CD: Add Vulps.
   coloring:
     default:
       type: null

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
@@ -5,7 +5,7 @@
   id: UndergarmentBottomBoxers
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson, Vulpkanin] # CD: Add Vulps,
   coloring:
     default:
       type: null
@@ -18,7 +18,7 @@
   id: UndergarmentBottomBriefs
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson, Vulpkanin] # CD: Add Vulps,
   coloring:
     default:
       type: null
@@ -31,7 +31,7 @@
   id: UndergarmentBottomSatin
   bodyPart: UndergarmentBottom
   markingCategory: UndergarmentBottom
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, SlimePerson, Vulpkanin] # CD: Add Vulps,
   coloring:
     default:
       type: null
@@ -44,7 +44,7 @@
   id: UndergarmentTopBra
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Vulpkanin] # CD: Add Vulps,
   coloring:
     default:
       type: null
@@ -57,7 +57,7 @@
   id: UndergarmentTopSportsbra
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Vulpkanin] # CD: Add Vulps,
   coloring:
     default:
       type: null
@@ -70,7 +70,7 @@
   id: UndergarmentTopBinder
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Vulpkanin] # CD: Add Vulps,
   coloring:
     default:
       type: null
@@ -83,7 +83,7 @@
   id: UndergarmentTopTanktop
   bodyPart: UndergarmentTop
   markingCategory: UndergarmentTop
-  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson]
+  speciesRestriction: [Arachnid, Diona, Human, Dwarf, Moth, Reptilian, SlimePerson, Vulpkanin] # CD: Add Vulps,
   coloring:
     default:
       type: null

--- a/Resources/Prototypes/_CD/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_CD/Species/vulpkanin.yml
@@ -63,7 +63,7 @@
       required: true
       defaultMarkings: [ VulpEar ]
     Overlay:
-      points: 2
+      points: 6
       required: false
 
 - type: humanoidBaseSprite


### PR DESCRIPTION
## About the PR
Fixes a lot of weird marking issues from vulps.
Vulps now have access to: The Undergarment markings, the left/right eye markings (heterochromia), the human scars, their overlay marking limit has been increased from 2 -> 6, and the tails without wagging animations now have (No Wag) in their locale, to help with confusion.

Chips away at the vulpkanin improvement issue.

## Requirements

- [x] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [x] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Vulpkanins now have access to a broader set of options as markings and the tails without wagging animations have been marked as such.