### PR TITLE
Adminwho for all

### DIFF
--- a/Content.Server/Administration/Commands/AdminWhoCommand.cs
+++ b/Content.Server/Administration/Commands/AdminWhoCommand.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Server.Administration.Commands;
 
-[AdminCommand(AdminFlags.AdminWho)]
+[AnyCommand]
 public sealed class AdminWhoCommand : IConsoleCommand
 {
     public string Command => "adminwho";

--- a/Content.Server/Administration/Commands/AdminWhoCommand.cs
+++ b/Content.Server/Administration/Commands/AdminWhoCommand.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Server.Administration.Commands;
 
-[AnyCommand]
+[AnyCommand] // CD change from admin only to unrestricted.
 public sealed class AdminWhoCommand : IConsoleCommand
 {
     public string Command => "adminwho";

--- a/Content.Server/Administration/Commands/AdminWhoCommand.cs
+++ b/Content.Server/Administration/Commands/AdminWhoCommand.cs
@@ -44,8 +44,6 @@ public sealed class AdminWhoCommand : IConsoleCommand
             first = false;
 
             sb.Append(admin.Name);
-            if (adminData.Title is { } title)
-                sb.Append($": [{title}]");
 
             if (adminData.Stealth)
                 sb.Append(" (S)");
@@ -54,6 +52,9 @@ public sealed class AdminWhoCommand : IConsoleCommand
             {
                 if (afk.IsAfk(admin))
                     sb.Append(" [AFK]");
+
+                if (adminData.Title is { } title) // CD change to move titles to admin only.
+                    sb.Append($": [{title}]");
             }
         }
 


### PR DESCRIPTION
## About the PR
Unrestricted the `adminwho` command so that players have an easier time with event plans or other things.

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Everyone now has access to the adminwho command which allows you to see which admins are currently admining.