### PR TITLE
Fix backwards compatibility for CD char imports

### DIFF
--- a/Content.IntegrationTests/Tests/_CD/CharacterImportTest.cs
+++ b/Content.IntegrationTests/Tests/_CD/CharacterImportTest.cs
@@ -1,0 +1,178 @@
+using System.Diagnostics.Contracts;
+using System.IO;
+using Content.Client.Humanoid;
+using Content.Shared.Preferences;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests._CD;
+
+[TestFixture]
+public sealed class CharacterImportTest
+{
+    [Test]
+    public static async Task RoundTrip()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
+        var server = pair.Server;
+        await pair.Client.WaitIdleAsync();
+        var entityManager = pair.Client.ResolveDependency<IEntityManager>();
+
+
+        await server.WaitAssertion(() =>
+        {
+            var system = entityManager.System<HumanoidAppearanceSystem>();
+            var profile = HumanoidCharacterProfile.Random();
+            var stream = new MemoryStream();
+
+            var dataNode = system.ToDataNode(profile);
+            using var writer = new StreamWriter(stream);
+            dataNode.Write(writer);
+            writer.Flush();
+            stream.Position = 0;
+
+            var newProfile = system.FromStream(stream, pair.Client.Session!);
+            Assert.That(newProfile.MemberwiseEquals(profile));
+        });
+        await pair.CleanReturnAsync();
+    }
+
+    [TestCase(OldCDCharacterYaml, TestName = "OldCDCharacter")]
+    [TestCase(CDCharacterWithMissingFieldsYaml, TestName = "CDCharacterWithMissingFields")]
+    [TestCase(WizdenCharacterYaml, TestName = "WizdenCharacter")]
+    public static async Task CanImportCharacter(string character)
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
+        var server = pair.Server;
+        await pair.Client.WaitIdleAsync();
+        var entityManager = pair.Client.ResolveDependency<IEntityManager>();
+
+
+        await server.WaitAssertion(() =>
+        {
+            var system = entityManager.System<HumanoidAppearanceSystem>();
+            using var ss = StringStreamFrom(character);
+            _ = system.FromStream(ss, pair.Client.Session!);
+        });
+        await pair.CleanReturnAsync();
+    }
+
+    [Pure]
+    private static Stream StringStreamFrom(string s)
+    {
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream);
+        writer.Write(s);
+        writer.Flush();
+        stream.Position = 0;
+        return stream;
+    }
+
+    private const string CDCharacterWithMissingFieldsYaml = """
+        profile:
+          preferenceUnavailable: SpawnAsOverflow
+          spawnPriority: None
+          appearance:
+            markings: []
+            skinColor: '#663614FF'
+            eyeColor: '#808080FF'
+            facialHairColor: '#001C23FF'
+            facialHair: HumanFacialHairChaplin
+            hairColor: '#001C23FF'
+            hair: HumanHairHighfade
+          gender: Male
+          sex: Male
+          species: Dwarf
+          flavorText: ""
+          name: Warner Coldsmith
+          cosmaticDriftCustomSpeciesName: null
+          cosmaticDriftCharacterRecords:
+            employmentEntries: []
+            securityEntries: []
+            postmortemInstructions: Return home
+            drugAllergies: None
+            identifyingFeatures: ""
+            hasWorkAuthorization: True
+            emergencyContactName: ""
+            weight: 70
+            height: 170
+          cosmaticDriftCharacterHeight: 0.8
+          _loadouts: {}
+          _traitPreferences: []
+          _antagPreferences: []
+          _jobPriorities:
+            Passenger: High
+        version: 1
+        forkId: CD14
+        ...
+        """;
+
+    private const string OldCDCharacterYaml = """
+        profile:
+          preferenceUnavailable: SpawnAsOverflow
+          spawnPriority: None
+          appearance:
+            markings: []
+            skinColor: '#663614FF'
+            eyeColor: '#808080FF'
+            facialHairColor: '#001C23FF'
+            facialHair: HumanFacialHairChaplin
+            hairColor: '#001C23FF'
+            hair: HumanHairHighfade
+          gender: Male
+          sex: Male
+          age: 43
+          species: Dwarf
+          flavorText: ""
+          name: Warner Coldsmith
+          cosmaticDriftCustomSpeciesName: null
+          cosmaticDriftCharacterRecords:
+            employmentEntries: []
+            securityEntries: []
+            medicalEntries: []
+            postmortemInstructions: Return home
+            drugAllergies: None
+            allergies: None
+            identifyingFeatures: ""
+            hasWorkAuthorization: True
+            emergencyContactName: ""
+            weight: 70
+            height: 170
+          cosmaticDriftCharacterHeight: 0.8
+          _loadouts: {}
+          _traitPreferences: []
+          _antagPreferences: []
+          _jobPriorities:
+            Passenger: High
+        version: 1
+        forkId: CD14
+        ...
+        """;
+
+    private const string WizdenCharacterYaml = """
+        profile:
+          preferenceUnavailable: SpawnAsOverflow
+          spawnPriority: None
+          appearance:
+            markings: []
+            skinColor: '#B3F2E9FF'
+            eyeColor: '#808080FF'
+            facialHairColor: '#F5ED94FF'
+            facialHair: FacialHairShaved
+            hairColor: '#F5ED94FF'
+            hair: HairBald
+          gender: Epicene
+          sex: Unsexed
+          age: 52
+          species: Arachnid
+          flavorText: ""
+          name: Phoneutria Thoracica
+          _loadouts: {}
+          _traitPreferences: []
+          _antagPreferences: []
+          _jobPriorities:
+            Passenger: High
+        version: 1
+        forkId: wizards
+        ...
+        """;
+}

--- a/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
+++ b/Content.Shared/_CD/Records/PlayerProvidedCharacterRecords.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Text.Json.Serialization;
 using Robust.Shared.Serialization;
@@ -196,8 +197,12 @@ public sealed partial class PlayerProvidedCharacterRecords
         return true;
     }
 
-    private static string ClampString(string str, int maxLen)
+    [Pure]
+    private static string ClampString(string? str, int maxLen)
     {
+        // When importing old characters these values may be null
+        if (str == null)
+            return "";
         if (str.Length > maxLen)
         {
             return str[..maxLen];
@@ -226,6 +231,15 @@ public sealed partial class PlayerProvidedCharacterRecords
         Allergies = ClampString(Allergies, TextMedLen);
         DrugAllergies = ClampString(DrugAllergies, TextMedLen);
         PostmortemInstructions = ClampString(PostmortemInstructions, TextMedLen);
+
+        // When importing old CD characters these may be null
+        // ReSharper disable block NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
+        {
+            EmploymentEntries ??= [];
+            MedicalEntries ??= [];
+            SecurityEntries ??= [];
+            AdminEntries ??= [];
+        }
 
         EnsureValidEntries(EmploymentEntries);
         EnsureValidEntries(MedicalEntries);


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->
Added null checks for values that can end up as null when importing old characters. I also added a regression test (90% of the PR lol).


**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the name that you would like to be credited as.
-->
Importing old CD characters should be fixed.
