### PR TITLE
Re-enable cargo slips

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -942,7 +942,7 @@
     account: Engineering
     announcementChannel: Engineering
     removeLimitAccess: [ "ChiefEngineer" ]
-    mode: SendToPrimary
+    mode: PrintSlip # CD: Print slips
   - type: ActiveRadio
     channels:
     - Engineering
@@ -975,7 +975,7 @@
     account: Medical
     announcementChannel: Medical
     removeLimitAccess: [ "ChiefMedicalOfficer" ]
-    mode: SendToPrimary
+    mode: PrintSlip # CD: Print slips
   - type: ActiveRadio
     channels:
     - Medical
@@ -1008,7 +1008,7 @@
     account: Science
     announcementChannel: Science
     removeLimitAccess: [ "ResearchDirector" ]
-    mode: SendToPrimary
+    mode: PrintSlip # CD: Print slips
   - type: ActiveRadio
     channels:
     - Science
@@ -1041,7 +1041,7 @@
     account: Security
     announcementChannel: Security
     removeLimitAccess: [ "HeadOfSecurity" ]
-    mode: SendToPrimary
+    mode: PrintSlip # CD: Print slips
   - type: ActiveRadio
     channels:
     - Security
@@ -1074,7 +1074,7 @@
     account: Service
     announcementChannel: Service
     removeLimitAccess: [ "HeadOfPersonnel" ]
-    mode: SendToPrimary
+    mode: PrintSlip # CD: Print slips
   - type: ActiveRadio
     channels:
     - Service


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->
I personally think the cargo slips are better for RP compared to the current system. It turns out upstream left that functionality in the code, so we can just turn it back on.

## Requirements

- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summery of your changes to be
listed in #progress-reports. If you would like to be credited as something other then you github username please include the name that you would like to be credited as.
-->
Cargo slips have been re-enabled, so you will have to bring the slip to cargo for your departmental orders to be fulfilled.
