### PR TITLE
CD Exo Update

### DIFF
--- a/Resources/CDMapPatches/exo.yml
+++ b/Resources/CDMapPatches/exo.yml
@@ -1,0 +1,19 @@
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -48.208332,-50.61883
+  id: LockerLostAndFound
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -54.208332,-42.61883
+  id: ComputerTabletopStationRecords
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 14.617237,-57.63881
+  id: JobSlotsComputerFlatpack
+- !type:CDSpawnEntityMapPatch
+  worldRotation: 3.141592653589793 rad
+  worldPosition: 49.791668,-100.61883
+  id: ComputerShuttleSalvage
+- !type:CDSpawnEntityMapPatch
+  worldPosition: -19.208334,-24.618832
+  id: SpawnMobPebble
+- !type:CDSpawnEntityMapPatch
+  worldPosition: 17.791666,-69.61883
+  id: ComputerMedicalRecords

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -14,4 +14,4 @@
   - Plasma
   - Reach
   - Ferrous
-  # - Exo
+  - Exo

--- a/Resources/Prototypes/Maps/exo.yml
+++ b/Resources/Prototypes/Maps/exo.yml
@@ -2,8 +2,9 @@
   id: Exo
   mapName: 'Exo'
   mapPath: /Maps/exo.yml
-  minPlayers: 30
-  maxPlayers: 70
+  minPlayers: 25 #CD change from 30 to 25.
+  maxPlayers: 55 #CD change from 70 to 55.
+  patchfile: /CDMapPatches/exo.yml # CD Edit: Apply map patch
   stations:
     Exo:
       stationProto: StandardNanotrasenStation
@@ -22,7 +23,7 @@
             #service
             Captain: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            Bartender: [ 2, 2 ]
+            Bartender: [ 1, 1 ] #CD change from 2-2 to 1-1.
             Botanist: [ 2, 2 ]
             Chef: [ 2, 2 ]
             Janitor: [ 1, 2 ]
@@ -31,25 +32,29 @@
             ServiceWorker: [ 2, 2 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
+            SeniorEngineer: [ 1, 1 ] #CD addition.
             AtmosphericTechnician: [ 3, 3 ]
-            StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 3, 3 ]
+            StationEngineer: [ 5, 5 ] #CD change from 4-4 to 5-5.
+            # TechnicalAssistant: [ 3, 3 ] #CD disabled.
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
+            SeniorPhysician: [ 1, 1 ] #CD addition.
             Chemist: [ 2, 2 ]
             MedicalDoctor: [ 4, 4 ]
-            MedicalIntern: [ 3, 3 ]
+            # MedicalIntern: [ 3, 3 ] #CD disabled.
             Paramedic: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 3, 3 ]
+            SeniorResearcher: [ 1, 1 ] #CD addition.
+            Scientist: [ 5, 5 ] #CD change from 4-4 to 5-5.
+            # ResearchAssistant: [ 3, 3 ] #CD disabled.
             #security
             HeadOfSecurity: [ 1, 1 ]
+            SeniorOfficer: [ 1, 1 ] #CD addition.
             Warden: [ 1, 1 ]
             SecurityOfficer: [ 4, 4 ]
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            # SecurityCadet: [ 4, 4 ] #CD disabled.
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
@@ -64,3 +69,5 @@
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]
+            #misc
+            Prisoner: [ 1, 1 ] #CD addition.


### PR DESCRIPTION
## About the PR
-Adds the Exo map patch for CD stuffs.
-Adds all the CD stuff to Exo. Including a prisoner slot.
-Removes the intern roles and adjusts the base department job slots accordingly.
-Sets the map at Marathon and Bagel pop; 25-55. Something I'm conflicted about due to a whole series of reasons but I went with my gut here.

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
Exo Station has been updated to fit CD standards and is now in rotation.