### PR TITLE
Minor rewording for two CD-specific guidebook entries

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayExpectations/Rule3-8.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayExpectations/Rule3-8.xml
@@ -5,6 +5,6 @@
   - Silicon roles should not violate their laws without extreme reason. If a silicon has no laws they do not need to follow this rule.
   - Be thoughtful about your actions; letting someone into atmos could cause crew harm because they're not qualified or may have malicious intent.
   - The term 'crew' when seen in a law refers to any person who has an ID on your HUD unless specified otherwise by another law.
-  - You may choose how to deal with law conflicts how you see best fit, as long as you stay consistant with it.
+  - You may choose how to deal with law conflicts how you see best fit, as long as you stay consistent with your interpretation.
   - You do not need to follow clearly ridiculous commands such as destroying yourself because the person who ordered you to do so disagreed with you.
 </Document>

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/CDSpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/CDSpaceLaw.xml
@@ -1,5 +1,5 @@
 <Document>
   # Space Law
 
-  We currently do not have our own space law for Cosmatic Dirft. Until this is implemented we utilize [bold]the old version of wizden space law[/bold]. You can find a link to this pinned in the #questions channel on discord. Sorry for the inconvenience
+  We currently do not have our own space law for Cosmatic Drift. Until this is implemented we utilize [bold]the old version of Wizden space law[/bold]. You can find a link to this pinned in the #questions channel on discord. Sorry for the inconvenience.
 </Document>


### PR DESCRIPTION
## About the PR
- Clarification (and primarily a single typo fix) for Rule 3-8
- Changes "Cosmatic Dirft" in the space law entry to "Cosmatic Drift". Also capitalizes "Wizden" in the same file. Also ends the entry with a period for consistency with other guidebook entries

## Requirements

- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase