### PR TITLE
Fixes missing underwear FTLs

### DIFF
--- a/Resources/Locale/en-US/markings/undergarment.ftl
+++ b/Resources/Locale/en-US/markings/undergarment.ftl
@@ -1,21 +1,21 @@
-marking-UndergarmentTopTanktop-tanktop = Tanktop
-marking-UndergarmentTopBinder-binder = Binder
-marking-UndergarmentTopBra-classic = Classic Bra
-marking-UndergarmentTopSportsbra-sports = Sports Bra
+marking-UndergarmentTopTanktop = Tanktop
+marking-UndergarmentTopBinder = Binder
+marking-UndergarmentTopBra = Classic Bra
+marking-UndergarmentTopSportsbra = Sports Bra
 
-marking-UndergarmentBottomBoxers-boxers = Boxers
-marking-UndergarmentBottomBriefs-briefs = Briefs
-marking-UndergarmentBottomSatin-satin = Satin
+marking-UndergarmentBottomBoxers = Boxers
+marking-UndergarmentBottomBriefs = Briefs
+marking-UndergarmentBottomSatin = Satin
 
-marking-UndergarmentTopTanktopVox-tanktop_vox = Tanktop
-marking-UndergarmentTopBinderVox-binder_vox = Binder
-marking-UndergarmentTopBraVox-classic_vox = Classic Bra
-marking-UndergarmentTopSportsbraVox-sports_vox = Sports Bra
+marking-UndergarmentTopTanktopVox = Tanktop
+marking-UndergarmentTopBinderVox = Binder
+marking-UndergarmentTopBraVox = Classic Bra
+marking-UndergarmentTopSportsbraVox = Sports Bra
 
-marking-UndergarmentBottomBoxersVox-boxers_vox = Boxers
-marking-UndergarmentBottomBriefsVox-briefs_vox = Briefs
-marking-UndergarmentBottomSatinVox-satin_vox = Satin
+marking-UndergarmentBottomBoxersVox = Boxers
+marking-UndergarmentBottomBriefsVox = Briefs
+marking-UndergarmentBottomSatinVox = Satin
 
-marking-UndergarmentBottomBoxersReptilian-boxers_reptilian = Boxers
-marking-UndergarmentBottomBriefsReptilian-briefs_reptilian = Briefs
-marking-UndergarmentBottomSatinReptilian-satin_reptilian = Satin
+marking-UndergarmentBottomBoxersReptilian = Boxers
+marking-UndergarmentBottomBriefsReptilian = Briefs
+marking-UndergarmentBottomSatinReptilian = Satin


### PR DESCRIPTION
## About the PR
This PR fixes the missing underwear FTLs by trimming off the extra bit at the end of each of them.

## Media
![image](https://github.com/user-attachments/assets/a8d0646a-315b-4052-a039-1675f77d2717)

![image](https://github.com/user-attachments/assets/e56972f1-1fba-4342-bfcb-b28f9ecd932a)

![image](https://github.com/user-attachments/assets/18fef89f-146b-48c2-ae7b-f0975ab53134)

(just take my word for the other tab)

## Requirements

- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
