### PR TITLE
Balancing the Heavy Weight Trait

### DIFF
--- a/Resources/Prototypes/_CD/Traits/traits.yml
+++ b/Resources/Prototypes/_CD/Traits/traits.yml
@@ -34,7 +34,7 @@
   cost: 1
   components:
   - type: LightweightDrunk
-    boozeStrengthMultiplier: 0.5
+    boozeStrengthMultiplier: 0.75
 
 - type: trait
   id: HideFromRoundEndScreen


### PR DESCRIPTION
## About the PR
_This PR has been moved from https://github.com/Sector-Umbra/Sector-Umbra/pull/391. I would rather this fix for more servers than just Umbra._

Ethanol currently is the only main source to making people drunk in SS14. Currently, it has booze power of 2. This means that for every tick it runs in your system, it gives you about 2 seconds worth to a status effect for Drunk. 

The issue with Heavy weight, is that it halfs this to 1 seconds. The issue with this, is that it calculates when you are drunk based on how much of timer you have compared to the current time. So no matter how much ethanol you have in your system, you should feasibly never be able to get drunk.

This changes it so instead of halfing this time, it only does 0.75x. So therefore, if someone were to remain with ethanol in their system for a much longer period of time, they can still finally get drunk.

## Why / Balance
It always felt wrong, that even alcohol like Absinthe, Vodka and straight up ethanol, can't ever make you drunk. Your character only starts vomiting after 15u, but never because they were drunk.

_Please let me know if you want me to maybe tweak this value. I was considering more 0.6, but I like to have a bit more round numbers so just doing a quarter instead seems to be nice._

## Technical details
Changed LightweightDrunk's boozeStrengthMultiplier for HeavyWeight to be 0.75 instead of 0.5

## Media
N/A

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature OR this PR does not add a feature OR you are alright with this PR being closed at a maintainer's discression.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
The Heavy Weight Trait now allows a user to be drunk but is still resistant to it significantly when injecting Ethanol from alcoholic beverages. It now currently turns 1 ethanol from giving 1 second of drunk, to now giving 0.5 (due to a second being used to metabolise being accounted for).