### PR TITLE
Fix RenameIdComponent defaulting to Blank ID

### DIFF
--- a/Content.Server/_CD/Loadouts/RenameIdComponent.cs
+++ b/Content.Server/_CD/Loadouts/RenameIdComponent.cs
@@ -1,6 +1,3 @@
-using Content.Shared.StatusIcon;
-using Robust.Shared.Prototypes;
-
 namespace Content.Server._CD.Loadouts;
 
 /// <summary>
@@ -12,6 +9,6 @@ public sealed partial class RenameIdComponent : Component
     [DataField(required: true)]
     public string Value;
 
-    [DataField("newIcon")]
-    public string? NewIcon = "JobIconUnknown";
+    [DataField]
+    public string? NewIcon;
 }


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->

This fixes the issue of passenger IDs showing up blank when off-duty staff was selected.

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summary of your changes to be
listed in #progress-reports. If you would like to be credited as something other then your Github username please include the name that you would like to be credited as.
-->

Off-Duty staff IDs once again have the passenger icon as intended.
