### PR TITLE
Fix latejoin text

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -33,8 +33,10 @@ player-first-join-message = Player {$name} joined for the first time.
 # Displayed in chat to admins when a player leaves
 player-leave-message = Player {$name} left.
 
-latejoin-arrival-announcement = {$character} ({$job}) has arrived at the station!
-latejoin-arrival-announcement-special = {$job} {$character} on deck!
+# CD: assigned to the station
+latejoin-arrival-announcement = {$character} ({$job}) has been assigned to the shift.
+latejoin-arrival-announcement-special = {$job} {$character} has been assigned to the shift.
+# end CD
 latejoin-arrival-sender = Station
 latejoin-arrivals-direction = A shuttle transferring you to your station will arrive at the southern docks shortly.
 latejoin-arrivals-direction-time = A shuttle transferring you to your station will arrive at the southern docks in {$time}.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->

Set's the latejoin text back to what it used to be.

100% untested
