### PR TITLE
Add Aghost hands toggle

### DIFF
--- a/Content.Client/_CD/Admin/Aghost/InteractionToggleSystem.cs
+++ b/Content.Client/_CD/Admin/Aghost/InteractionToggleSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared._CD.Admin.Aghost;
+
+namespace Content.Client._CD.Admin.Aghost;
+
+public sealed class InteractionToggleSystem : SharedInteractionToggleSystem;

--- a/Content.Server/_CD/Admin/Aghost/InteractionToggleSystem.cs
+++ b/Content.Server/_CD/Admin/Aghost/InteractionToggleSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared._CD.Admin.Aghost;
+
+namespace Content.Server._CD.Admin.Aghost;
+
+public sealed class InteractionToggleSystem : SharedInteractionToggleSystem;

--- a/Content.Shared/_CD/Admin/Aghost/InteractionToggleableComponent.cs
+++ b/Content.Shared/_CD/Admin/Aghost/InteractionToggleableComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Alert;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CD.Admin.Aghost;
+
+/// <summary>
+/// Component that determines if aghosts should be able to interact with things
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class InteractionToggleableComponent : Component
+{
+    [DataField]
+    public ProtoId<AlertPrototype> ToggleAlertProtoId = "ToggleInteraction";
+
+    [DataField, AutoNetworkedField]
+    public bool BlockInteraction;
+}
+
+/// <summary>
+/// Event raised to toggle aghost interaction
+/// </summary>
+public sealed partial class ToggleInteractionEvent : BaseAlertEvent;

--- a/Content.Shared/_CD/Admin/Aghost/SharedInteractionToggleSystem.cs
+++ b/Content.Shared/_CD/Admin/Aghost/SharedInteractionToggleSystem.cs
@@ -1,0 +1,37 @@
+using Content.Shared.Alert;
+using Content.Shared.Interaction.Events;
+
+namespace Content.Shared._CD.Admin.Aghost;
+
+public abstract class SharedInteractionToggleSystem : EntitySystem
+{
+    [Dependency] private readonly AlertsSystem _alertsSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<InteractionToggleableComponent, InteractionAttemptEvent>(OnAttemptInteract);
+        SubscribeLocalEvent<InteractionToggleableComponent, ToggleInteractionEvent>(OnToggleInteraction);
+        SubscribeLocalEvent<InteractionToggleableComponent, ComponentInit>(OnCompInit);
+    }
+
+    private void OnAttemptInteract(Entity<InteractionToggleableComponent> ent, ref InteractionAttemptEvent args)
+    {
+        if (ent.Comp.BlockInteraction)
+            args.Cancelled = true;
+
+    }
+
+    private void OnToggleInteraction(Entity<InteractionToggleableComponent> ent, ref ToggleInteractionEvent args)
+    {
+        ent.Comp.BlockInteraction = !ent.Comp.BlockInteraction;
+        _alertsSystem.ShowAlert(ent.Owner, ent.Comp.ToggleAlertProtoId, (short)(ent.Comp.BlockInteraction ? 1 : 0));
+        Dirty(ent);
+    }
+
+    private void OnCompInit(Entity<InteractionToggleableComponent> entity, ref ComponentInit args)
+    {
+        _alertsSystem.ShowAlert(entity, entity.Comp.ToggleAlertProtoId, 0);
+    }
+}

--- a/Resources/Locale/en-US/_CD/admin/aghost.ftl
+++ b/Resources/Locale/en-US/_CD/admin/aghost.ftl
@@ -1,0 +1,2 @@
+cd-aghost-toggle-interaction = Toggle Interaction
+cd-aghost-toggle-interaction-desc = Toggles your ability to interact with the world.

--- a/Resources/Prototypes/Alerts/alerts.yml
+++ b/Resources/Prototypes/Alerts/alerts.yml
@@ -27,6 +27,7 @@
     - alertType: Rooted
     - alertType: Pacified
     - alertType: Stealthy
+    - alertType: ToggleInteraction # CD
 
 - type: entity
   id: AlertSpriteView

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -124,6 +124,7 @@
   - type: BypassInteractionChecks
   - type: ExplosionResistance
     damageCoefficient: 0
+  - type: InteractionToggleable # CD
 
 - type: entity
   id: ActionAGhostShowSolar

--- a/Resources/Prototypes/_CD/Alerts/alerts.yml
+++ b/Resources/Prototypes/_CD/Alerts/alerts.yml
@@ -1,0 +1,12 @@
+- type: alert
+  id: ToggleInteraction
+  clickEvent: !type:ToggleInteractionEvent
+  icons:
+  - sprite: _CD/Clothing/Hands/Gloves/etu_gauntlet.rsi
+    state: icon
+  - sprite: /Textures/Interface/Alerts/pacified.rsi
+    state: icon
+  name: cd-aghost-toggle-interaction
+  description: cd-aghost-toggle-interaction-desc
+  minSeverity: 0
+  maxSeverity: 1


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR

I want to stop hugging people by mistake while being able to still hold stuff in my hands.

Closes: #717

Add an alert for admins to toggle interaction in the same way toggling thieving gloves works.

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summary of your changes to be
listed in #progress-reports. If you would like to be credited as something other then your Github username please include the name that you would like to be credited as.
-->
Admin:
You can now toggle your hands using the alert below the stealth grabbing alert.
