### PR TITLE
Anonymize observers with the hidden name trait

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -559,11 +559,20 @@ namespace Content.Server.GameTicking
 
                 if (TryGetEntity(mind.OriginalOwnedEntity, out var entity) && pvsOverride)
                 {
-                    // CD: Round End Redacting
+                    // CD: Redact player characters
                     if (HasComp<HideFromRoundEndScreenComponent>(entity))
                         continue;
                     _pvsOverride.AddGlobalOverride(entity.Value);
                 }
+
+                // CD: Redact observers
+                if (_playerManager.TryGetSessionById(mind.UserId, out var session))
+                {
+                    var profile = GetPlayerProfile(session);
+                    if (profile.TraitPreferences.Contains(HideFromRoundEndScreenComponent.TraitName))
+                        continue;
+                }
+                // end CD
 
                 var roles = _roles.MindGetAllRoleInfo(mindId);
 

--- a/Content.Server/_CD/Traits/HideFromRoundEndScreenComponent.cs
+++ b/Content.Server/_CD/Traits/HideFromRoundEndScreenComponent.cs
@@ -1,4 +1,10 @@
+using Content.Shared.Traits;
+using Robust.Shared.Prototypes;
+
 namespace Content.Server._CD.Traits;
 
 [RegisterComponent]
-public sealed partial class HideFromRoundEndScreenComponent : Component;
+public sealed partial class HideFromRoundEndScreenComponent : Component
+{
+    public static readonly ProtoId<TraitPrototype> TraitName = "HideFromRoundEndScreen";
+}


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->

Added an additional check for observers this also covers admin spawned characters.

Closes: #719

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summary of your changes to be
listed in #progress-reports. If you would like to be credited as something other then your Github username please include the name that you would like to be credited as.
-->
Observers and admin spawned characters with the Hide OOC Name trait will no longer be listed in the round end screen.
