### PR TITLE
Catatonic and Soulless description changes

### DIFF
--- a/Resources/Locale/en-US/mind/components/mind-component.ftl
+++ b/Resources/Locale/en-US/mind/components/mind-component.ftl
@@ -4,8 +4,8 @@ comp-mind-ghosting-prevented = You are not able to ghost right now.
 
 ## Messages displayed when a body is examined and in a certain state
 
-comp-mind-examined-catatonic = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } totally catatonic. The stresses of life in deep-space must have been too much for { OBJECT($ent) }. Any recovery is impossible.
+comp-mind-examined-catatonic = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } totally catatonic. { CAPITALIZE(SUBJECT($ent)) } will not recover without specalized treatment, available at Central Command. 
 comp-mind-examined-dead = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } dead.
 comp-mind-examined-ssd = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-HAVE($ent) } a blank, absent-minded stare and appears completely unresponsive to anything. { CAPITALIZE(SUBJECT($ent)) } may snap out of it soon.
 comp-mind-examined-dead-and-ssd = { CAPITALIZE(POSS-ADJ($ent)) } soul lies dormant and may return soon.
-comp-mind-examined-dead-and-irrecoverable = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed and moved on. Any recovery is impossible.
+comp-mind-examined-dead-and-irrecoverable = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed and moved on. { CAPITALIZE(SUBJECT($ent)) } will need specalized treatment if revived, available at Central Command.

--- a/Resources/Locale/en-US/mind/components/mind-component.ftl
+++ b/Resources/Locale/en-US/mind/components/mind-component.ftl
@@ -4,8 +4,8 @@ comp-mind-ghosting-prevented = You are not able to ghost right now.
 
 ## Messages displayed when a body is examined and in a certain state
 
-comp-mind-examined-catatonic = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } totally catatonic. { CAPITALIZE(SUBJECT($ent)) } will not recover without specalized treatment, available at Central Command. 
+comp-mind-examined-catatonic = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } totally catatonic. { CAPITALIZE(SUBJECT($ent)) } will need many days to recover.
 comp-mind-examined-dead = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } dead.
 comp-mind-examined-ssd = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-HAVE($ent) } a blank, absent-minded stare and appears completely unresponsive to anything. { CAPITALIZE(SUBJECT($ent)) } may snap out of it soon.
 comp-mind-examined-dead-and-ssd = { CAPITALIZE(POSS-ADJ($ent)) } soul lies dormant and may return soon.
-comp-mind-examined-dead-and-irrecoverable = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed and moved on. { CAPITALIZE(SUBJECT($ent)) } will need specalized treatment if revived, available at Central Command.
+comp-mind-examined-dead-and-irrecoverable = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed and moved on. { CAPITALIZE(SUBJECT($ent)) } will need many days to recover if revived.

--- a/Resources/Locale/en-US/mind/components/mind-component.ftl
+++ b/Resources/Locale/en-US/mind/components/mind-component.ftl
@@ -4,8 +4,8 @@ comp-mind-ghosting-prevented = You are not able to ghost right now.
 
 ## Messages displayed when a body is examined and in a certain state
 
-comp-mind-examined-catatonic = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } totally catatonic. { CAPITALIZE(SUBJECT($ent)) } will need many days to recover.
+comp-mind-examined-catatonic = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } totally catatonic. { CAPITALIZE(SUBJECT($ent)) } may need many days to recover.
 comp-mind-examined-dead = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } dead.
 comp-mind-examined-ssd = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-HAVE($ent) } a blank, absent-minded stare and appears completely unresponsive to anything. { CAPITALIZE(SUBJECT($ent)) } may snap out of it soon.
 comp-mind-examined-dead-and-ssd = { CAPITALIZE(POSS-ADJ($ent)) } soul lies dormant and may return soon.
-comp-mind-examined-dead-and-irrecoverable = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed and moved on. { CAPITALIZE(SUBJECT($ent)) } will need many days to recover if revived.
+comp-mind-examined-dead-and-irrecoverable = { CAPITALIZE(POSS-ADJ($ent)) } soul has departed and moved on. { CAPITALIZE(SUBJECT($ent)) } may need many days to recover if revived.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Changed the descriptions for soulless and catatonic players to explain that they will recover, just not on the station. This is so that ~~i can get contrib role :3~~ players don't get confused about how to deal with catatonic and soulless players. 

Changes are below. CC having the magic, catatonic revival medicine or treatment seems fine enough. Cryopods probably bring you to CC or could be brought to CC, and obviously the evac shuttle brings you to CC. 

Encouraging players to revive soulless people seems like the right thing to do. It's probably easier to wake up an alive but catatonic person, rather than cloning someone from scratch, because the players didn't know they needed to be revived.

## Media
<img width="707" height="707" alt="image" src="https://github.com/user-attachments/assets/75f1a8aa-da83-45d0-9e5a-e8fa09f1ff3b" />
<img width="672" height="433" alt="image" src="https://github.com/user-attachments/assets/0d6e9e23-0010-4f83-a5dd-111966ca13b2" />


## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
Changed the description of catatonic and soulless players.
