### PR TITLE
added two periods and a comma

### DIFF
--- a/Resources/Locale/en-US/tips.ftl
+++ b/Resources/Locale/en-US/tips.ftl
@@ -46,8 +46,8 @@ tips-dataset-29 = As a ghost, you can use the Verb Menu to orbit around and foll
 # tips-dataset-43 = As a Nuclear Operative, remember that stealth is an option. It'll be hard for the captain to fight back if he gets caught off guard by what he thinks is just a regular passenger!
 # tips-dataset-44 = As an antagonist, be mindful of the power of destroying telecommunications. It'll be a lot harder for people to call you out if they can't do so effectively!
 
-tips-dataset-30 = Upon entering cryosleep your items will be transferred to the lost and found locker in the HoP's office
-tips-dataset-31 = It is possible to return to arrivals using the arrivals shuttle. This can be used for easy access to cryosleep pods
+tips-dataset-30 = Upon entering cryosleep, your items will be transferred to the lost and found locker in the HoP's office.
+tips-dataset-31 = It is possible to return to arrivals using the arrivals shuttle. This can be used for easy access to cryosleep pods.
 tips-dataset-32 = Everyone is permitted to commit minor crimes. However, it is strongly reccomended that you ask over ahelp before doing so.
 tips-dataset-33 = Do not be afraid to ahelp. The worst the admins can say is no. The admins regularly grant requests such as minor items or events.
 tips-dataset-34 = Character records are a great place to include information about your characters backstory.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
I added two periods and a comma in the tip menu. this is because they should have periods.

## Media
like. its two periods. and one comma

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
The benevolent SpaceLizard graced the SS14 fork "Cosmatic Drift" with a correction to a mistake that has been subtly plaguing the community for months. 
