### PR TITLE
Make Crime Pay / Make Bake Profitable

### DIFF
--- a/Resources/Prototypes/_CD/Entities/Objects/Misc/contraband.yml
+++ b/Resources/Prototypes/_CD/Entities/Objects/Misc/contraband.yml
@@ -31,7 +31,7 @@
     defaultTarget: bakeWrapped
 
 - type: entity
-  parent: [BaseItem, BaseMinorContraband]
+  parent: [BaseItem, BaseMajorContraband]
   id: WrappedBakePackage
   name: sealed narcotic packet
   description: Worth a pretty penny, the powder inside looks chalky.

--- a/Resources/Prototypes/_CD/Reactions/narcotics.yml
+++ b/Resources/Prototypes/_CD/Reactions/narcotics.yml
@@ -34,7 +34,7 @@
   id: Rust
   minTemp: 423
   reactants:
-    TranexamicAcid:
+    SulfuricAcid:
       amount: 2
     Breakout:
       amount: 1
@@ -48,7 +48,7 @@
   reactants:
     Rust:
       amount: 1
-    Ultravasculine:
+    Diethylamine:
       amount: 2
     Diphenylmethylamine:
       amount: 2

--- a/Resources/Prototypes/_CD/Recipes/Crafting/Graphs/narcotics.yml
+++ b/Resources/Prototypes/_CD/Recipes/Crafting/Graphs/narcotics.yml
@@ -21,6 +21,6 @@
         solution: drink
         reagent:
           ReagentId: Bake
-        quantity: 30
+        quantity: 10
   - node: bakeWrapped
     entity: WrappedBakePackage


### PR DESCRIPTION
## About the PR
When I made the Mindleaf chain, I didn't actually test making Bake very much.
Turns out, it fucking _sucks_, so this fixes that, as well as reducing the amount needed in order to export the stuff.

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
Bake is now easier to create, as well as needing less to fill a packet. Security best keep their eyes out for potentially smugglers.
