### PR TITLE
Lore Friendly Salvage Corpses

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -68,6 +68,8 @@
   name: syndicate shuttle pilot
   parent: MobSyndicateFootsoldier
   id: MobSyndicateFootsoldierPilot
+  components:
+  - type: Unrevivable #CD addition.
 
 - type: entity
   parent: BaseMobHuman
@@ -88,6 +90,7 @@
         Blunt: 19
   - type: Inventory
     templateId: corpse
+  - type: Unrevivable #CD addition.
 
 - type: entity
   parent: MobHuman


### PR DESCRIPTION
## About the PR
Makes all the corpses found during salvaging unrevivable. Also makes the syndicate shuttle pilot unrevivable.

The former is way more lore friendly with how the Fissure is supposed to ruin the DNA of nearly all the corpses that spawn from it.  And as for the shuttle pilot and a bit of the corpses, there's just not really any reason to leave the option on the table, reviving either of these results in a soulless husk that kind of just stands around.

## Media
<img width="483" height="534" alt="image" src="https://github.com/user-attachments/assets/5bb10db5-8998-4dfb-a343-ad8e142a2e2e" />

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
The syndicate shuttle pilot and corpses from salvage wrecks are no longer revivable.