### PR TITLE
Replace Ion Storms notifying synths with Synth Storm event

### DIFF
--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -3,19 +3,12 @@ using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.Station.Components;
-// Used in CD's System
-using Content.Server._CD.Traits;
-using Content.Server.Chat.Managers;
-using Content.Shared.Chat;
-using Robust.Shared.Player;
-using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
 
 public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
 {
     [Dependency] private readonly IonStormSystem _ionStorm = default!;
-    [Dependency] private readonly IChatManager _chatManager = default!; // Used for CD's System
 
     protected override void Started(EntityUid uid, IonStormRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
@@ -23,22 +16,6 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
 
         if (!TryGetRandomStation(out var chosenStation))
             return;
-
-        // CD Change - Go through everyone with the SynthComponent and inform them a storm is happening.
-        var synthQuery = EntityQueryEnumerator<SynthComponent>();
-        while (synthQuery.MoveNext(out var ent, out var synthComp))
-        {
-            if (RobustRandom.Prob(synthComp.AlertChance))
-                continue;
-
-            if (!TryComp<ActorComponent>(ent, out var actor))
-                continue;
-
-            var msg = Loc.GetString("station-event-ion-storm-synth");
-            var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", msg));
-            _chatManager.ChatMessageToOne(ChatChannel.Server, msg, wrappedMessage, default, false, actor.PlayerSession.Channel, colorOverride: Color.Yellow);
-        }
-        // End of CD change
 
         var query = EntityQueryEnumerator<SiliconLawBoundComponent, TransformComponent, IonStormTargetComponent>();
         while (query.MoveNext(out var ent, out var lawBound, out var xform, out var target))

--- a/Content.Server/_CD/StationEvents/Components/SynthStormRuleComponent.cs
+++ b/Content.Server/_CD/StationEvents/Components/SynthStormRuleComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Audio;
+
+namespace Content.Server._CD.StationEvents.Components;
+
+/// <summary>
+/// Gamerule component to notify a random synth player when started.
+/// </summary>
+[RegisterComponent]
+public sealed partial class SynthStormRuleComponent : Component
+{
+    [DataField]
+    public SoundSpecifier? SynthStormSound = new SoundPathSpecifier("/Audio/Misc/cryo_warning.ogg");
+}

--- a/Content.Server/_CD/StationEvents/Events/SynthStormRule.cs
+++ b/Content.Server/_CD/StationEvents/Events/SynthStormRule.cs
@@ -1,0 +1,45 @@
+using Content.Server._CD.StationEvents.Components;
+using Content.Server._CD.Traits;
+using Content.Server.Chat.Managers;
+using Content.Server.StationEvents.Events;
+using Content.Shared.Chat;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Mind;
+using Content.Shared.Roles;
+using Robust.Shared.Player;
+using Robust.Shared.Random;
+
+namespace Content.Server._CD.StationEvents.Events;
+
+public sealed class SynthStormRule : StationEventSystem<SynthStormRuleComponent>
+{
+    [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly SharedRoleSystem _roles = default!;
+
+    protected override void Started(EntityUid uid, SynthStormRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, comp, gameRule, args);
+
+        var synthQuery = EntityQueryEnumerator<SynthComponent>();
+        var validSynths = new List<EntityUid>();
+        while (synthQuery.MoveNext(out var ent, out var synthComp))
+        {
+            if (!HasComp<ActorComponent>(ent)) // Ensure we aren't picking someone who doesn't have an actor
+                continue;
+
+            validSynths.Add(ent);
+        }
+
+        var chosen = RobustRandom.Pick(validSynths);
+        if (!TryComp<ActorComponent>(chosen, out var actor))
+            return; // This should never happen, so it's fine
+
+        if(comp.SynthStormSound != null && _mind.TryGetMind(chosen, out var mindId, out _))
+            _roles.MindPlaySound(mindId, comp.SynthStormSound);
+
+        var msg = Loc.GetString("station-event-ion-storm-synth");
+        var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", msg));
+        _chatManager.ChatMessageToOne(ChatChannel.Server, msg, wrappedMessage, default, false, actor.PlayerSession.Channel, colorOverride: Color.Yellow);
+    }
+}

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -24,6 +24,7 @@
     - id: SpiderClownSpawn
     - id: SpiderSpawn
     - id: VentClog
+    - id: SynthStorm # CD: Unique event for synths
 
 - type: entityTable
   id: BasicAntagEventsTable

--- a/Resources/Prototypes/_CD/GameRules/events.yml
+++ b/Resources/Prototypes/_CD/GameRules/events.yml
@@ -1,0 +1,9 @@
+- type: entity
+  parent: BaseGameRule
+  id: SynthStorm
+  components:
+  - type: StationEvent
+    weight: 8 # High but not too high
+    reoccurrenceDelay: 20
+    duration: 1
+  - type: SynthStormRule


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->
Replaced Ion Storms having a chance to notify synths with a new "synth storm" event, which runs seperately and will only notify one synth at a time. The notification may want / need to be changed but I'll leave that up to Nairod. Also added a sound to make it more obvious when it happens.
Ion Storms are incredibly common to spice up borg gameplay, but that also meant synths would frequently be going haywire which made them look unreliable from an IC standpoint and could cause a lot of headache for robotocists and the like for frequently having to put up with them. This should help mitigate that while also preventing synth players from metagaming that borgs have been ion stormed. 
