### PR TITLE
Disable lizard hardsuit bodies and hide hair

### DIFF
--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -165,11 +165,14 @@ public sealed class ClientClothingSystem : ClothingSystem
         if (clothing.EquippedState != null)
             state = $"{clothing.EquippedState}";
 
-        // species specific
-        if (speciesId != null && rsi.TryGetState($"{state}-{speciesId}", out _))
-            state = $"{state}-{speciesId}";
-        else if (!rsi.TryGetState(state, out _))
-            return false;
+        // CD: Shitcode W (hide lizard hardsuit sprites)
+        //     Done like this to avoid 2 billion merge conflicts when wizden adds more hardsuit sprites
+        if (!(slot == "OUTERSLOT" && speciesId == "reptilian"))
+            // species specific
+            if (speciesId != null && rsi.TryGetState($"{state}-{speciesId}", out _))
+                state = $"{state}-{speciesId}";
+            else if (!rsi.TryGetState(state, out _))
+                return false;
 
         var layer = new PrototypeLayerData();
         layer.RsiPath = rsi.Path.ToString();

--- a/Content.Shared/Clothing/EntitySystems/HideLayerClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/HideLayerClothingSystem.cs
@@ -69,6 +69,11 @@ public sealed class HideLayerClothingSystem : EntitySystem
             if (!hideable.Contains(layer))
                 continue;
 
+            // CD: Skip hiding tails because it makes less sense compared to leaving the tails exposed
+            //     Done like this to avoid 2 billion merge conflicts when wizden adds more hardsuit sprites
+            if (layer == HumanoidVisualLayers.Tail)
+                continue;
+
             // Only update this layer if we are currently equipped to the relevant slot.
             if (validSlots.HasFlag(inSlot))
                 _humanoid.SetLayerVisibility(user!, layer, !hideLayers, inSlot, ref dirty);
@@ -82,6 +87,10 @@ public sealed class HideLayerClothingSystem : EntitySystem
         {
             foreach (var layer in slots)
             {
+                // CD: See above. If it does not exist you can probably remove this.
+                if (layer == HumanoidVisualLayers.Tail)
+                    continue;
+
                 if (hideable.Contains(layer))
                     _humanoid.SetLayerVisibility(user!, layer, !hideLayers, inSlot, ref dirty);
             }

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -9,6 +9,7 @@
     species: Moth
     hideLayersOnEquip:
     - HeadTop
+    - Hair
   - type: Hunger
   - type: Thirst
   - type: Icon

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -8,6 +8,7 @@
   - type: HumanoidAppearance
     species: Reptilian
     hideLayersOnEquip:
+    - Hair
     - Snout
     - HeadTop
     - HeadSide


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->

Disables lizard hardsuit body sprites.

While the sprites created in https://github.com/space-wizards/space-station-14/pull/35842 look great, they kind of break continuity with lizards that have large tails (from wizden), or the tails added in #527 (which are a fairly popular option).

Sooner or later, I wager somebody will code a proper hardsuit marking system which would fix this issue.

Disabled using a few wads of shitcode rather than editing the meta files to prevent merge conflicts.

I also went and made Moth and Lizard hair get hidden upon using a hardsuit helmet. Probably should have been a separate PR but too late now.

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summary of your changes to be
listed in #progress-reports. If you would like to be credited as something other then your Github username please include the name that you would like to be credited as.
-->
- Temporarily (possibly permanently) disable the lizard hardsuit sprites until a more robust hardsuit marking sprite system is created.
- Moth and Lizard hair is now properly hidden when you put on a helmet. This is the same behavior as humans *et al*.
