### PR TITLE
Ore Bag Storage Parity

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -14,9 +14,9 @@
     slots:
     - belt
   - type: Item
-    size: 241
+    size: 301 #CD change from 241 to 301
   - type: Storage
-    capacity: 240
+    capacity: 300 #CD change from 240 to 300
     quickInsert: true
     areaInsert: true
     whitelist:
@@ -32,4 +32,4 @@
   description: A large ore bag built into the frame of a mining cyborg.
   components:
     - type: Storage
-      capacity: 300
+      capacity: 450 #CD change from 300 to 450


### PR DESCRIPTION
## About the PR
The ore bag's storage has been increased from 8 (240) stacks to 10 (300) stacks.
The borg ore bag's storage has been increased from 10 (300) stacks to 15 (450) stacks.

This is in parity with the size of ore bags on Upstream.

## Media
<img width="515" height="598" alt="image" src="https://github.com/user-attachments/assets/53840644-7864-417f-82bc-fcc9642c719c" />

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
_Probably not notable enough for one?_
Ore bags can now hold as much as they can on Upstream, 8 -> 10 stacks for regular bags and 10 -> 15 stacks for borg bags.