### PR TITLE
Rework Medical item economy and uses

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/darts.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/darts.yml
@@ -85,6 +85,9 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: BalloonPopper
+  - type: Tag #Cosmatic Drift Syringe Gun Change
+    tags:
+    - SyringeGunAmmo
 
 - type: entity
   parent: Dart
@@ -94,7 +97,7 @@
     sprite: Objects/Fun/Darts/dart_blue.rsi
   - type: Item
     sprite: Objects/Fun/Darts/dart_blue.rsi
-     
+
 - type: entity
   parent: Dart
   id: DartPurple
@@ -103,7 +106,7 @@
     sprite: Objects/Fun/Darts/dart_purple.rsi
   - type: Item
     sprite: Objects/Fun/Darts/dart_purple.rsi
-     
+
 - type: entity
   parent: Dart
   id: DartYellow

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -422,6 +422,9 @@
       injector:
         maxVol: 5
   - type: Injector
+    delay: 2
+    delayPerVolume: 0
+    movementThreshold: 0.5
     transferAmounts:
     - 1
     - 2
@@ -507,6 +510,11 @@
   - type: Injector
     delay: 2.5
     injectOnly: false
+    transferAmounts:
+    - 1
+    - 5
+    - 10
+    - 15
   - type: SolutionContainerVisuals
     maxFillLevels: 2
     fillBaseName: syringe
@@ -519,7 +527,7 @@
   id: SyringeCryostasis
   parent: BaseSyringe
   name: cryostasis syringe
-  description: A syringe used to contain chemicals or solutions without reactions. 
+  description: A syringe used to contain chemicals or solutions without reactions.
   components:
   - type: Sprite
     layers:
@@ -600,7 +608,7 @@
   name: pill canister
   id: PillCanister
   parent: BaseStorageItem
-  description: Holds up to 9 pills.
+  description: Holds up to 10 pills.
   components:
   - type: Sprite
     sprite: Objects/Specific/Chemistry/pills_canister.rsi
@@ -611,7 +619,7 @@
     tags:
       - PillCanister
   - type: Storage
-    capacity: 9
+    capacity: 10
     quickInsert: true
     areaInsert: true
     areaInsertRadius: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
@@ -133,7 +133,7 @@
   - type: AmmoCounter
   - type: Item
     size: 50
-        
+
 - type: entity
   name: syringe gun
   parent: BaseStorageItem
@@ -145,7 +145,7 @@
     layers:
     - state: syringe_gun
   - type: Storage
-    capacity: 20
+    capacity: 18
     whitelist:
       tags:
       - SyringeGunAmmo
@@ -178,7 +178,7 @@
   - type: PneumaticCannon
     throwItems: false
 
-# doesn't need gas, extra capacity  
+# doesn't need gas, extra capacity
 - type: entity
   parent: WeaponImprovisedPneumaticCannonGun
   id: WeaponImprovisedPneumaticCannonAdmeme

--- a/Resources/Prototypes/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/Recipes/Lathes/chemistry.yml
@@ -33,7 +33,7 @@
   result: Dropper
   completetime: 2
   materials:
-    Glass: 200
+    Glass: 150
     Plastic: 100
 
 - type: latheRecipe
@@ -70,7 +70,7 @@
   result: PillCanister
   completetime: 2
   materials:
-    Plastic: 100
+    Plastic: 20
 
 - type: latheRecipe
   id: ChemistryEmptyBottle01

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -256,7 +256,7 @@
   result: MiniSyringe
   completetime: 2
   materials:
-    Steel: 200
-    Glass: 100
-    Plastic: 100
+    Steel: 50
+    Glass: 25
+    Plastic: 50
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR and why did you do it? -->
The Syringe Gun's storage was at 20, meaning it fits 6 and 2/3rds of a mini syringe. Now it's just 6, flat, plain and simple.
Additionally, darts now fit in it, allowing up to 9 (Because 18/2=9)! I think that matches the mini-syringe count, it being multiples of 3.

Additionally, Mini-Syringes now inject faster with more leeway for moving patients, making it good for treating people on-site with smaller doses (maybe to stave them off until they reach medbay) or cure minor injuries.
Paramedics might like this.

Also! If a vial can cost 0.5 glass and 0.2 wood, then mini-syringes and pill bottles can be cheaper to print. Previously they cost more PER SYRINGE than regulars, despite being "mini". Now the cost is equal, taking all 3 basic sheets, but only 1.25 total of them to make.
Pill bottles now also fit 10 pills, to make chemmaster pill ratios multiples of 20 instead of 18, which is much harder to calculate for and leaves the buffer a mess. 

All in all, the hope is that the Medical Techfab will see more use than just resupplies for the medical department, as it is usually forgotten about since any good medical team can get by without it.
## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
<img width="672" height="456" alt="image" src="https://github.com/user-attachments/assets/ec71a5b6-df2b-4000-b581-9b8580c50681" />

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summary of your changes to be
listed in #progress-reports. If you would like to be credited as something other then your Github username please include the name that you would like to be credited as.
-->
Adjusted Mini/Bluespace Syringes and Syringe gun uses, and medical techfab printing costs.
