### PR TITLE
Remove hardsuit lizard tails for real

### DIFF
--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -167,12 +167,18 @@ public sealed class ClientClothingSystem : ClothingSystem
 
         // CD: Shitcode W (hide lizard hardsuit sprites)
         //     Done like this to avoid 2 billion merge conflicts when wizden adds more hardsuit sprites
-        if (!(slot == "OUTERSLOT" && speciesId == "reptilian"))
+        if (!(correctedSlot == "OUTERCLOTHING" && speciesId == "reptilian"))
+        {
             // species specific
             if (speciesId != null && rsi.TryGetState($"{state}-{speciesId}", out _))
                 state = $"{state}-{speciesId}";
             else if (!rsi.TryGetState(state, out _))
                 return false;
+        }
+        else if (!rsi.TryGetState(state, out _))
+        {
+            return false;
+        }
 
         var layer = new PrototypeLayerData();
         layer.RsiPath = rsi.Path.ToString();


### PR DESCRIPTION
A few issues with my logic. Who would have known correctedSlot was different from slot.

Fix #755 

**Changelog**
<!--
We do not have the bot upstream uses to automatically create changelogs. Simply write a summary of your changes to be
listed in #progress-reports. If you would like to be credited as something other then your Github username please include the name that you would like to be credited as.
-->
The lizard hardsuit tail sprites have been removed for real this time.
