### PR TITLE
Headset Loadouts

### DIFF
--- a/Resources/Locale/en-US/_CD/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_CD/preferences/loadout-groups.ftl
@@ -1,4 +1,5 @@
 # Command
+loadout-group-command-headset = Command headset
 loadout-group-formal-shoes = Formal Shoes
 
 # Civilian
@@ -10,21 +11,26 @@ loadout-group-private-investigator-glasses = Private Investigator glasses
 loadout-group-passenger-id = Passenger ID
 
 # Cargo
+loadout-group-quartermaster-headset = Quartermaster headset
 loadout-group-salvage-specialist-jumpsuit = Salvage Specialist jumpsuit
 
 # Engineering
+loadout-group-chief-engineer-headset = Chief Engineer headset
 loadout-group-senior-engineer-jumpsuit = Senior Engineer jumpsuit
 loadout-group-engineering-goggles = Engineering Goggles
 
 # Science
+loadout-group-research-director-headset = Research Director headset
 loadout-group-senior-researcher-jumpsuit = Senior Researcher jumpsuit
 loadout-group-senior-researcher-outerclothing = Senior Researcher outer clothing
 
 # Security
+loadout-group-head-of-security-headset = Head of Security headset
 loadout-group-senior-officer-jumpsuit = Senior Officer jumpsuit
 loadout-group-security-glasses-or-hud = Security Glasses
 
 # Medical
+loadout-group-chief-medical-officer-headset = Chief Medical Officer Headset
 loadout-group-senior-physician-head = Senior Physician head
 loadout-group-senior-physician-jumpsuit = Senior Physician jumpsuit
 loadout-group-senior-physician-outerclothing = Senior Physician outer clothing

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -3,6 +3,7 @@
   id: JobCaptain
   groups:
   - CaptainHead
+  - CommandHeadset #CD
   - CaptainNeck
   - CaptainJumpsuit
   - CaptainBackpack
@@ -17,6 +18,7 @@
   groups:
   - GroupTankHarness
   - HoPHead
+  - CommandHeadset #CD
   - HoPNeck
   - HoPJumpsuit
   - HoPBackpack
@@ -214,6 +216,7 @@
   groups:
   - GroupTankHarness
   - QuartermasterHead
+  - QuartermasterHeadset #CD
   - QuartermasterNeck
   - QuartermasterJumpsuit
   - CargoTechnicianBackpack
@@ -258,6 +261,7 @@
   groups:
   - GroupTankHarness
   - ChiefEngineerHead
+  - ChiefEngineerHeadset #CD
   - EngineeringEyewear # CD
   - ChiefEngineerJumpsuit
   - StationEngineerBackpack
@@ -312,6 +316,7 @@
   groups:
   - GroupTankHarness
   - ResearchDirectorHead
+  - ResearchDirectorHeadset #CD
   - ResearchDirectorNeck
   - ResearchDirectorJumpsuit
   - ScientistBackpack
@@ -356,6 +361,7 @@
   id: JobHeadOfSecurity
   groups:
   - HeadofSecurityHead
+  - HeadofSecurityHeadset #CD
   - HeadofSecurityNeck
   - HeadofSecurityJumpsuit
   - SecurityBackpack
@@ -430,6 +436,7 @@
   groups:
   - GroupTankHarness
   - ChiefMedicalOfficerHead
+  - ChiefMedicalOfficerHeadset #CD
   - MedicalMask
   - ChiefMedicalOfficerJumpsuit
   - MedicalGloves

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -31,7 +31,7 @@
   id: QuartermasterGear
   equipment:
     id: QuartermasterPDA
-    ears: ClothingHeadsetQM
+    # ears: ClothingHeadsetQM #CD: Loadouts
     belt: BoxFolderClipboardThreePapers
     pocket1: AppraisalTool
   storage:

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -28,7 +28,7 @@
     eyes: ClothingEyesGlassesCommand
     gloves: ClothingHandsGlovesCaptain
     id: CaptainPDA
-    ears: ClothingHeadsetAltCommand
+    # ears: ClothingHeadsetAltCommand #CD: Loadouts
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -51,7 +51,7 @@
     # shoes: ClothingShoesColorBrown | CD, removed due to loadout addtion.
     id: HoPPDA
     gloves: ClothingHandsGlovesHop
-    ears: ClothingHeadsetAltCommand
+    # ears: ClothingHeadsetAltCommand #CD: Loadouts
     belt: BoxFolderClipboardThreePapers
     eyes: ClothingEyesHudCommand
   storage:

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -32,7 +32,7 @@
   equipment:
     id: CEPDA
 #    eyes: ClothingEyesGlassesMeson # CD
-    ears: ClothingHeadsetCE
+    # ears: ClothingHeadsetCE #CD: Loadouts
     belt: ClothingBeltUtilityEngineering
   storage:
     back:

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -33,7 +33,7 @@
   id: CMOGear
   equipment:
     id: CMOPDA
-    ears: ClothingHeadsetCMO
+    # ears: ClothingHeadsetCMO #CD: Loadouts
     belt: ClothingBeltMedicalFilled
   storage:
     back:

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -30,7 +30,7 @@
   id: ResearchDirectorGear
   equipment:
     id: RnDPDA
-    ears: ClothingHeadsetRD
+    # ears: ClothingHeadsetRD #CD: Loadouts
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -35,7 +35,7 @@
     # eyes: ClothingEyesGlassesSecurity  CD: Secglasses selector fix
     id: HoSPDA
     gloves: ClothingHandsGlovesCombat
-    ears: ClothingHeadsetAltSecurity
+    # ears: ClothingHeadsetAltSecurity #CD: Loadouts
     pocket1: WeaponPistolMk58
   storage:
     back:

--- a/Resources/Prototypes/_CD/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_CD/Entities/Clothing/Ears/headsets.yml
@@ -1,4 +1,17 @@
 - type: entity
+  parent: [ClothingHeadsetSecurity, BaseCommandContraband]
+  id: ClothingHeadsetHoS
+  name: hos headset
+  description: A headset used by the HoS.
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeySecurity
+      - EncryptionKeyCommand
+      - EncryptionKeyCommon
+
+- type: entity
   parent: ClothingHeadset
   id: ClothingHeadsetLongRange
   name: long range headset

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Cargo/quartermaster.yml
@@ -9,3 +9,14 @@
   id: ForemanCoat
   equipment:
     outerClothing: ClothingOuterCoatCargoForeman
+
+# Headset
+- type: loadout
+  id: QuartermasterHeadset
+  equipment:
+    ears: ClothingHeadsetQM
+
+- type: loadout
+  id: QuartermasterHeadsetAlt
+  equipment:
+    ears: ClothingHeadsetAltCargo

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Command/captain.yml
@@ -1,0 +1,10 @@
+# Headset
+- type: loadout
+  id: CommandHeadset
+  equipment:
+    ears: ClothingHeadsetCommand
+
+- type: loadout
+  id: CommandHeadsetAlt
+  equipment:
+    ears: ClothingHeadsetAltCommand

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Engineering/chief_engineer.yml
@@ -13,3 +13,14 @@
   id: ChiefEngineerJumpsuitFormal
   equipment:
     jumpsuit: ClothingUniformJumpsuitChiefEngineerFormal
+
+# Headset
+- type: loadout
+  id: ChiefEngineerHeadset
+  equipment:
+    ears: ClothingHeadsetCE
+
+- type: loadout
+  id: ChiefEngineerHeadsetAlt
+  equipment:
+    ears: ClothingHeadsetAltEngineering

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Medical/chief_medical_officer.yml
@@ -9,3 +9,14 @@
   id: ChiefMedicalOfficerFormalsuit
   equipment: 
     jumpsuit: ClothingUniformCMOFormal
+
+# Headset
+- type: loadout
+  id: ChiefMedicalOfficerHeadset
+  equipment:
+    ears: ClothingHeadsetCMO
+
+- type: loadout
+  id: ChiefMedicalOfficerHeadsetAlt
+  equipment:
+    ears: ClothingHeadsetAltMedical

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Science/research_director.yml
@@ -1,0 +1,10 @@
+# Headset
+- type: loadout
+  id: ResearchDirectorHeadset
+  equipment:
+    ears: ClothingHeadsetRD
+
+- type: loadout
+  id: ResearchDirectorHeadsetAlt
+  equipment:
+    ears: ClothingHeadsetAltScience

--- a/Resources/Prototypes/_CD/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/_CD/Loadouts/Jobs/Security/head_of_security.yml
@@ -3,3 +3,14 @@
   id: HeadofSecuritySheriffHat
   equipment: 
     head: ClothingHeadHatHossheriffhat
+
+# Headset
+- type: loadout
+  id: HeadofSecurityHeadset
+  equipment:
+    ears: ClothingHeadsetHoS
+
+- type: loadout
+  id: HeadofSecurityHeadsetAlt
+  equipment:
+    ears: ClothingHeadsetAltSecurity

--- a/Resources/Prototypes/_CD/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_CD/Loadouts/loadout_groups.yml
@@ -1,5 +1,12 @@
 # Command
 - type: loadoutGroup
+  id: CommandHeadset
+  name: loadout-group-command-headset
+  loadouts:
+  - CommandHeadset
+  - CommandHeadsetAlt
+
+- type: loadoutGroup
   id: FormalShoes
   name: loadout-group-formal-shoes
   loadouts:
@@ -55,6 +62,13 @@
 
 # Cargo
 - type: loadoutGroup
+  id: QuartermasterHeadset
+  name: loadout-group-quartermaster-headset
+  loadouts:
+  - QuartermasterHeadset
+  - QuartermasterHeadsetAlt
+
+- type: loadoutGroup
   id: SalvageSpecialistJumpsuit
   name: loadout-group-salvage-specialist-jumpsuit
   loadouts:
@@ -62,6 +76,13 @@
   - SalvageSpecialistJumpsuitOperator
 
 # Engineering
+- type: loadoutGroup
+  id: ChiefEngineerHeadset
+  name: loadout-group-chief-engineer-headset
+  loadouts:
+  - ChiefEngineerHeadset
+  - ChiefEngineerHeadsetAlt
+
 - type: loadoutGroup
   id: SeniorEngineerJumpsuit
   name: loadout-group-senior-engineer-jumpsuit
@@ -86,6 +107,13 @@
 
 # Science
 - type: loadoutGroup
+  id: ResearchDirectorHeadset
+  name: loadout-group-research-director-headset
+  loadouts:
+  - ResearchDirectorHeadset
+  - ResearchDirectorHeadsetAlt
+
+- type: loadoutGroup
   id: SeniorResearcherJumpsuit
   name: loadout-group-senior-researcher-jumpsuit
   loadouts:
@@ -109,6 +137,13 @@
   - RoboticistWintercoat
 
 # Security
+- type: loadoutGroup
+  id: HeadofSecurityHeadset
+  name: loadout-group-head-of-security-headset
+  loadouts:
+  - HeadofSecurityHeadset
+  - HeadofSecurityHeadsetAlt
+
 - type: loadoutGroup
   id: SeniorOfficerHead
   name: loadout-group-security-head
@@ -147,6 +182,13 @@
   - EyesHudSecurity
 
 # Medical
+- type: loadoutGroup
+  id: ChiefMedicalOfficerHeadset
+  name: loadout-group-chief-medical-officer-headset
+  loadouts:
+  - ChiefMedicalOfficerHeadset
+  - ChiefMedicalOfficerHeadsetAlt
+
 - type: loadoutGroup
   id: SeniorPhysicianHead
   name: loadout-group-senior-physician-head


### PR DESCRIPTION
## About the PR
Adds a loadout entry for each command role to allow them to choose between starting with their regular headset or the alternate over-ear variant.

Also adds the HoS' regular headset because this didn't exist for some reason. Only the over-ear did.

## Media
<img width="799" height="357" alt="image" src="https://github.com/user-attachments/assets/e98bc27c-b4b5-4add-8852-14be428341ff" />

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
Heads of Staff can now select if they'd like to start with their regular style headset or the over-ear variant.