### PR TITLE
Added Salvage Corpse Equipment Varity

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Corpses/corpses.yml
+++ b/Resources/Prototypes/Entities/Mobs/Corpses/corpses.yml
@@ -5,7 +5,7 @@
   components:
   - type: Loadout
     prototypes:
-      - HoPGear
+      # - HoPGear #CD: Why does HoP appear here but no other heads of staff are in their own departments?
       - ClownGear
       - MimeGear
       - JanitorGear
@@ -15,6 +15,41 @@
       - ChefGear
       - ChaplainGear
       - PassengerGear
+      - PrivateInvestigatorGear #CD
+      - PrisonerGear #CD
+      - VisitorClown #CD
+      - VisitorMime #CD
+      - VisitorMimeAlt #CD
+      - VisitorJanitor #CD
+      - VisitorJanitorAlt #CD
+      - VisitorServiceWorker #CD
+      - VisitorServiceWorkerAlt #CD
+      - VisitorMusicianRelaxedAltF #CD
+      - VisitorMusicianMariachi #CD
+      - VisitorBotanist #CD
+      - VisitorBotanistAlt #CD
+      - VisitorChef #CD
+      - VisitorChefAlt #CD
+      - VisitorChaplain #CD
+      - VisitorChaplainAlt #CD
+      - BartenderGear #CD
+      - VisitorBartender #CD
+      - VisitorBartenderAlt #CD
+      - LawyerGear #CD
+      - VisitorLawyerAltD #CD
+      - VisitorLawyerAltE #CD
+      - LibrarianGear #CD
+      - VisitorLibrarian #CD
+      - VisitorLibrarianAlt #CD
+      - BoxerGear #CD
+      - VisitorBoxer #CD
+      - VisitorBoxerAlt #CD
+      - ReporterGear #CD
+      - VisitorReporter #CD
+      - VisitorReporterAlt #CD
+      - ZookeeperGear #CD
+      - VisitorZookeeper #CD
+      - VisitorZookeeperAlt #CD
 
 - type: entity
   parent: SalvageHumanCorpse
@@ -26,6 +61,13 @@
     - TechnicalAssistantGear
     - AtmosphericTechnicianGear
     - StationEngineerGear
+    - SeniorEngineerGear #CD
+    - VisitorTechnicalAssistant #CD
+    - VisitorTechnicalAssistantAlt #CD
+    - VisitorAtmosTech #CD
+    - VisitorAtmosTechAlt #CD
+    - VisitorEngineer #CD
+    - VisitorEngineerAlt #CD
 
 - type: entity
   parent: SalvageHumanCorpse
@@ -36,6 +78,10 @@
     prototypes:
     - CargoTechGear
     - SalvageSpecialistGear
+    - VisitorCargoTech #CD
+    - VisitorCargoTechAlt #CD
+    - VisitorSalvageSpecialist #CD
+    - VisitorSalvageSpecialistAlt #CD
 
 - type: entity
   parent: SalvageHumanCorpse
@@ -48,6 +94,26 @@
     - PsychologistGear
     - ChemistGear
     - DoctorGear
+    - SeniorPhysicianGear #CD
+    - VisitorMedicalIntern #CD
+    - VisitorMedicalInternAlt #CD
+    - VisitorPsychologist #CD
+    - VisitorPsychologistAlt #CD
+    - VisitorChemist #CD
+    - VisitorChemistAlt #CD
+    - VisitorMedicalDoctor #CD
+    - VisitorMedicalDoctorAlt #CD
+    - VisitorScrubsBlue #CD
+    - VisitorScrubsGreen #CD
+    - VisitorScrubsPurple #CD
+    - VisitorVirologist #CD
+    - VisitorVirologistAlt #CD
+    - VisitorGeneticist #CD
+    - VisitorGeneticistAlt #CD
+    - ParamedicGear #CD
+    - VisitorParamedic #CD
+    - VisitorParamedicAlt #CD
+    - VisitorDentist #CD
 
 - type: entity
   parent: SalvageHumanCorpse
@@ -58,6 +124,11 @@
     prototypes:
     - ResearchAssistantGear
     - ScientistGear
+    - SeniorResearcherGear #CD
+    - VisitorResearchAssistant #CD
+    - VisitorResearchAssistantAlt #CD
+    - VisitorScientist #CD
+    - VisitorScientistAlt #CD
 
 - type: entity
   parent: SalvageHumanCorpse
@@ -70,6 +141,15 @@
     - SecurityOfficerGear
     - DetectiveGear
     - WardenGear
+    - SeniorOfficerGear #CD
+    - VisitorSecurityCadet #CD
+    - VisitorSecurityCadetAlt #CD
+    - VisitorSecurityOfficer #CD
+    - VisitorSecurityOfficerAlt #CD
+    - VisitorDetective #CD
+    - VisitorDetectiveAlt #CD
+    - VisitorWarden #CD
+    - VisitorWardenAlt #CD
 
 - type: entity
   parent: SalvageHumanCorpse
@@ -86,3 +166,18 @@
     - CMOGear
     - ChiefEngineerGear
     - QuartermasterGear
+    - VisitorHOP #CD
+    - VisitorHOPAlt #CD
+    - VisitorLawyerCentcom #CD
+    - VisitorCaptain #CD
+    - VisitorCaptainAlt #CD
+    - VisitorHOS #CD
+    - VisitorHOSAlt #CD
+    - VisitorRD #CD
+    - VisitorRDAlt #CD
+    - VisitorCMO #CD
+    - VisitorCMOAlt #CD
+    - VisitorCE #CD
+    - VisitorCEAlt #CD
+    - VisitorQM #CD
+    - VisitorQMAlt #CD


### PR DESCRIPTION
## About the PR
Rolls (most) visitor loadouts into the salvage corpse equipment table.
Future proofs the list by adding CD roles plus a couple seemingly forgotten roles' basic loadouts into the list.
Removes the HoP spawn from the service group of corpses.

Hopefully this'll make the salvage corpses a fair bit more interesting, and well, they're supposed to actually have stuff like this but haven't ever since loadouts were added because those split starting equipments off into their own groups.

There's a decent bit of uhhh, questionable loot in here. Notable instances include: Filled CE toolbelts, loaded krammers, loaded WTs, helmets, and disablers. If any of these things feel a bit too much (cough, cough, CE belts), some can be replaced with the "challenge" versions which have less equipment, or just removed.

## Media
<img width="926" height="545" alt="image" src="https://github.com/user-attachments/assets/20135017-515c-4dff-8b54-f18ed72992cd" />

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
Salvage corpses should now spawn with a much wider variety of equipment.