### PR TITLE
Increase Ore Bag Pickup Range

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -5,6 +5,7 @@
   description: A robust bag for salvage specialists and miners alike to carry large amounts of ore. Magnetises any nearby ores when attached to a belt.
   components:
   - type: MagnetPickup
+    range: 1.5 #CD change from 1 to 1.5
   - type: Sprite
     sprite: Objects/Specific/Mining/ore_bag.rsi
     state: icon


### PR DESCRIPTION
## About the PR
Increases the magnet pickup range of ore bags from 1 to 1.5.

It kind of pissed me off that mining in a three wide tunnel would cause ores to disperse to the sides of the tunnel outside of the range of your ore bag. And with the system already so wonky with it's pickup, it just added increased frustration.

## Media
<img width="521" height="323" alt="image" src="https://github.com/user-attachments/assets/6e86385a-ecc6-478b-a81a-5c77338829e9" />

Showcase video: https://www.youtube.com/watch?v=UiVVieCNASY

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
Probably not required but; Ore bags now have slightly larger auto-pick up range.