### PR TITLE
Remove SO Service Access

### DIFF
--- a/Resources/Prototypes/_CD/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/_CD/Roles/Jobs/Security/senior_officer.yml
@@ -14,8 +14,10 @@
   - Security
   - Brig
   - Maintenance
-  - Service
   - External
+  - Cryogenics
+  - GenpopEnter
+  - GenpopLeave
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
## About the PR
In preparation of https://github.com/space-wizards/space-station-14/pull/41411, which 99% sure isn't merged to CD as of writing but, again, in preparation.

Also adds genpop leave/enter and cryo access because all other security IDs have those, even if they're virtually unused.

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
Nada.