### PR TITLE
Disable Xenoborg Modes. 

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -24,8 +24,8 @@
       prob: 0.5
     - id: SubWizard
       prob: 0.05
-    - id: Xenoborgs
-      prob: 0.05
+    # - id: Xenoborgs
+    #   prob: 0.05
 
 - type: entity
   parent: BaseGameRule
@@ -35,8 +35,8 @@
     rules:
     - id: Thief
       prob: 0.5
-    - id: Xenoborgs
-      prob: 0.05
+    # - id: Xenoborgs
+    #   prob: 0.05
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -217,21 +217,21 @@
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
 
-- type: gamePreset
-  id: Xenoborgs
-  alias:
-    - xenoborgs
-  name: xenoborgs-title
-  description: xenoborgs-description
-  showInVote: false
-  rules:
-  - Xenoborgs
-  - DummyNonAntagChance
-  - SubGamemodesRuleNoXenoborg # no two motherships
-  - BasicStationEventScheduler
-  - MeteorSwarmScheduler
-  - SpaceTrafficControlEventScheduler
-  - BasicRoundstartVariation
+# - type: gamePreset
+#   id: Xenoborgs
+#   alias:
+#     - xenoborgs
+#   name: xenoborgs-title
+#   description: xenoborgs-description
+#   showInVote: false
+#   rules:
+#   - Xenoborgs
+#   - DummyNonAntagChance
+#   - SubGamemodesRuleNoXenoborg # no two motherships
+#   - BasicStationEventScheduler
+#   - MeteorSwarmScheduler
+#   - SpaceTrafficControlEventScheduler
+#   - BasicRoundstartVariation
 
 - type: gamePreset
   id: Zombie


### PR DESCRIPTION
Leaving in the gamerule in case an admin wanted to run this for some ungodly reason (thief and wizard are still in as well). 