### PR TITLE
fix synth blood starting at 1

### DIFF
--- a/Content.Server/_CD/Traits/SynthComponent.cs
+++ b/Content.Server/_CD/Traits/SynthComponent.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Chemistry.Components;
+
 namespace Content.Server._CD.Traits;
 
 /// <summary>
@@ -11,4 +13,7 @@ public sealed partial class SynthComponent : Component
     /// </summary>
     [DataField]
     public float AlertChance = 0.3f;
+
+    [DataField]
+    public Solution BloodReferenceSolution = new([new("SynthBlood", 300)]);
 }

--- a/Content.Server/_CD/Traits/SynthSystem.cs
+++ b/Content.Server/_CD/Traits/SynthSystem.cs
@@ -24,6 +24,6 @@ public sealed class SynthSystem : EntitySystem
         }
 
         // Give them synth blood. Ion storm notif is handled in that system
-        _bloodstream.ChangeBloodReagent(uid, "SynthBlood");
+        _bloodstream.ChangeBloodReagents(uid, component.BloodReferenceSolution);
     }
 }

--- a/Resources/Prototypes/_CD/Traits/traits.yml
+++ b/Resources/Prototypes/_CD/Traits/traits.yml
@@ -5,6 +5,10 @@
   category: Quirks
   components:
     - type: Synth
+      bloodReferenceSolution:
+        reagents:
+        - ReagentId: SynthBlood
+          Quantity: 300
 
 - type: trait
   id: ScaleItem


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- PRs may be closed by maintainers if we think they are not a good fit for Cosmatic Drift. If you are unsure if a feature
is a good fit please ask a @Maintainer on discord before starting work -->

## About the PR
<!-- What did you change? and why? Note any major architectural decisions if this is a large C# PR. If there are player
facing breaking changes please note it very clearly. -->
fixes synth blood only starting with 1u of synthblood in their bloodstream because of an obsolete method

synths arriving on the station like a used up juice box is only funny once, probably

<img width="364" height="443" alt="image" src="https://github.com/user-attachments/assets/8a6ff0b0-471f-4d40-adc1-04abbec349ac" />

Fixes #818

## Media
<!-- Attach media if the PR makes in-game changes.
Small fixes/refactors are exempt. Media may be used in progress reports with credit.

You also don't need to include media if the effects of the PR can easily be
surmised by reading the code.
-->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!--
CD does not have the changelog bot. If your changes are player facing, please
write a short summery of your changes to be posted to #progress-reports.
-->

Fixed synths arriving on the station with less than the recommended amount of blood in their bloodstream.