### PR TITLE
fix cd ai customizations not showing up

### DIFF
--- a/Resources/Prototypes/AppearanceCustomization/station_ai.yml
+++ b/Resources/Prototypes/AppearanceCustomization/station_ai.yml
@@ -11,7 +11,35 @@
   - StationAiIconDorf
   - StationAiIconHeartline
   - StationAiIconSmiley
-
+  # CD changes from here
+  - StationAiIconAlien
+  - StationAiIconThinking
+  - StationAiIconDatabase
+  - StationAiIconFirewall
+  - StationAiIconFuzzy
+  - StationAiIconGentoo
+  - StationAiIconGlitchman
+  - StationAiIconGoon
+  - StationAiIconHades
+  - StationAiIconHelios
+  - StationAiIconInverted
+  - StationAiIconMatrix
+  - StationAiIconMonochrome
+  - StationAiIconMurica
+  - StationAiIconNanoTrasen
+  - StationAiIconNotMalf
+  - StationAiIconPresident
+  - StationAiIconRainbow
+  - StationAiIconRed
+  - StationAiIconRedOctober
+  - StationAiIconStatic
+  - StationAiIconMeow
+  - StationAiIconText
+  - StationAiIconTooDeep
+  - StationAiIconTriumvirate
+  - StationAiIconWeird
+  - StationAiIconEvilDot
+  # end of CD changes
 - type: stationAiCustomizationGroup
   id: StationAiHolograms
   name: station-ai-customization-hologram
@@ -22,6 +50,18 @@
   - StationAiHologramFace
   - StationAiHologramCat
   - StationAiHologramDog
+  # CD holograms below
+  - StationAiHologramAlien
+  - StationAiHologramBees
+  - StationAiHologramBigMoth
+  - StationAiHologramGhost
+  - StationAiHologramHorror
+  - StationAiHologramLeaves
+  - StationAiHologramNarsie
+  - StationAiHologramRatvar
+  - StationAiHologramSemi
+  - StationAiHologramCy
+  # end of CD holograms
 
 # Iconography
 - type: stationAiCustomization


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- PRs may be closed by maintainers if we think they are not a good fit for Cosmatic Drift. If you are unsure if a feature
is a good fit please ask a @Maintainer on discord before starting work -->

## About the PR
<!-- What did you change? and why? Note any major architectural decisions if this is a large C# PR. If there are player
facing breaking changes please note it very clearly. -->
fixes #835 

our prototype changes to the customization groups were nuked in the rebase, this adds them back and makes our custom screens and holograms pickable again

no media no fun

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!--
CD does not have the changelog bot. If your changes are player facing, please
write a short summery of your changes to be posted to #progress-reports.
-->
fixed CD ai customizations not showing up for players