### PR TITLE
some simple mobs can drag again

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -65,6 +65,8 @@
   - type: MobPrice
     price: 1000 # Living critters are valuable in space.
   - type: Perishable
+  - type: Puller # CD: Is cute
+    needsHands: false
 
 - type: entity
   parent:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- PRs may be closed by maintainers if we think they are not a good fit for Cosmatic Drift. If you are unsure if a feature
is a good fit please ask a @Maintainer on discord before starting work -->

## About the PR
<!-- What did you change? and why? Note any major architectural decisions if this is a large C# PR. If there are player
facing breaking changes please note it very clearly. -->
fixes #829 

_breathing_  simple mobs like ian, mouse, etc. kept their ability to merge but ones that don't breathe like xeno, carp, etc. lost it in the rebase

this gives all children of `SimpleSpaceMobBase` have the inherent ability to pull again

good idea? maybe maybe not


no media no fun

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!--
CD does not have the changelog bot. If your changes are player facing, please
write a short summery of your changes to be posted to #progress-reports.
-->
some mobs can pull again