### PR TITLE
Decrease Thirst Decay

### DIFF
--- a/Content.Shared/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Shared/Nutrition/Components/ThirstComponent.cs
@@ -14,7 +14,8 @@ public sealed partial class ThirstComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("baseDecayRate")]
     [AutoNetworkedField]
-    public float BaseDecayRate = 0.1f;
+    public float BaseDecayRate = 0.05f;
+	// CD change from 0.1 to 0.05
 
     [ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]


### PR DESCRIPTION
## About the PR
Returns the halved thirst decay in #246, but keeps the hunger value the same because it feels fine as it is right now. At least to me. It can be added into this if desired.

## Media
<img width="648" height="199" alt="image" src="https://github.com/user-attachments/assets/f7be4fa4-03c6-4e6b-916f-02ca6f07141e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
Thirst will once again decay at half the rate like before.