### PR TITLE
Added glow support for individual marking pieces

### DIFF
--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Content.Client.DisplacementMap;
 using Content.Shared.CCVar;
 using Content.Shared.Humanoid;
@@ -386,6 +387,15 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
                 // use spriteComponent's layersetshader function to set the layer's shader to that which is specified.
                 sprite.LayerSetShader(layerId, markingPrototype.Shader);
             }
+            // end CD Addition//
+
+            if (markingPrototype.Shaders != null && markingPrototype.Shaders.Count >= j)
+            {
+                string? layerShader = markingPrototype.Shaders[j];
+                if (layerShader != "default")
+                    sprite.LayerSetShader(layerId, layerShader);
+            }
+
             // end CD Addition
             _sprite.LayerSetVisible((entity.Owner, sprite), layerId, visible);
 

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -46,6 +46,9 @@ namespace Content.Shared.Humanoid.Markings
         [DataField("shader")]
         public string? Shader { get; private set; } = null;
 
+        [DataField("shaders")]
+        public List<string>? Shaders { get; private set; } = null;
+
         public Marking AsMarking()
         {
             return new Marking(ID, Sprites.Count);

--- a/Resources/Locale/en-US/_CD/markings/reptilian.ftl
+++ b/Resources/Locale/en-US/_CD/markings/reptilian.ftl
@@ -6,6 +6,11 @@ marking-LizardHeadLEDVisor-head_ledvisor_primary = Visor
 marking-LizardHeadLEDVisor-head_ledvisor_secondary = Trim
 marking-LizardHeadLEDVisor-head_ledvisor_tertiary = LED
 
+marking-LizardHeadLEDVisorGlow = LED Visor (Glowing)
+marking-LizardHeadLEDVisorGlow-head_ledvisor_primary = Visor
+marking-LizardHeadLEDVisorGlow-head_ledvisor_secondary = Trim
+marking-LizardHeadLEDVisorGlow-head_ledvisor_tertiary = LED
+
 marking-LizardTailSnake = Snake Tail
 marking-LizardTailSnake-tail_snaketail = Tone
 

--- a/Resources/Prototypes/_CD/Entities/Mobs/Customization/Markings/reptilian.yml
+++ b/Resources/Prototypes/_CD/Entities/Mobs/Customization/Markings/reptilian.yml
@@ -25,6 +25,24 @@
   - sprite: _CD/Mobs/Customization/reptilian_parts.rsi
     state: head_ledvisor_tertiary
 
+- type: marking
+  id: LizardHeadLEDVisorGlow
+  bodyPart: Eyes
+  markingCategory: Head
+  speciesRestriction: [ Reptilian ]
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#808080"
+  sprites:
+  - sprite: _CD/Mobs/Customization/reptilian_parts.rsi
+    state: head_ledvisor_primary
+  - sprite: _CD/Mobs/Customization/reptilian_parts.rsi
+    state: head_ledvisor_secondary
+  - sprite: _CD/Mobs/Customization/reptilian_parts.rsi
+    state: head_ledvisor_tertiary
+  shaders: ["unshaded","default","unshaded"]
 # Snake Tails
 
 - type: marking


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- PRs may be closed by maintainers if we think they are not a good fit for Cosmatic Drift. If you are unsure if a feature
is a good fit please ask a @Maintainer on discord before starting work -->

## About the PR
<!-- What did you change? and why? Note any major architectural decisions if this is a large C# PR. If there are player
facing breaking changes please note it very clearly. -->
Adds support for markings to pick individual shaders for pieces and added a glowing version to the LED screen as an example for future changes and PRs

## Media
<!-- Attach media if the PR makes in-game changes.
Small fixes/refactors are exempt. Media may be used in progress reports with credit.

You also don't need to include media if the effects of the PR can easily be
surmised by reading the code.
-->
<img width="203" height="221" alt="image" src="https://github.com/user-attachments/assets/4a31e06e-9358-43f7-b4d3-c8019d9919e9" />
<img width="156" height="214" alt="image" src="https://github.com/user-attachments/assets/b3b2ede1-9e0c-4ed9-8038-e74054170cd1" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!--
CD does not have the changelog bot. If your changes are player facing, please
write a short summery of your changes to be posted to #progress-reports.
-->
Added a glowing version of the LED faceplate marking for lizards
Adds Support for markings to have parts that glow
