### PR TITLE
Fix missing prompt when marking someone as Hostile

### DIFF
--- a/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
+++ b/Content.Client/_CD/Records/UI/CharacterRecordViewer.xaml.cs
@@ -129,7 +129,7 @@ public sealed partial class CharacterRecordViewer : FancyWindow
         {
             var status = (SecurityStatus)args.Id;
             // This should reflect SetStatus in CriminalRecordsConsoleWindow.xaml.cs
-            if (status == SecurityStatus.Wanted || status == SecurityStatus.Suspected)
+            if (status == SecurityStatus.Wanted || status == SecurityStatus.Suspected || status == SecurityStatus.Hostile)
                 SetStatusWithReason(status);
             else
                 OnSetSecurityStatus?.Invoke(status, null);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- PRs may be closed by maintainers if we think they are not a good fit for Cosmatic Drift. If you are unsure if a feature
is a good fit please ask a @Maintainer on discord before starting work -->

## About the PR
<!-- What did you change? and why? Note any major architectural decisions if this is a large C# PR. If there are player
facing breaking changes please note it very clearly. -->
Setting someone as hostile previously did not bring up the reason input window, which caused minor errors.

## Media
<!-- Attach media if the PR makes in-game changes.
Small fixes/refactors are exempt. Media may be used in progress reports with credit.

You also don't need to include media if the effects of the PR can easily be
surmised by reading the code.
-->

Hostile status being set without a reason, before fix:
<img width="506" height="82" alt="SS14 Loader_hNUiJZRNSq" src="https://github.com/user-attachments/assets/7caaac96-6bf7-49d2-aefc-791e791063bd" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!--
CD does not have the changelog bot. If your changes are player facing, please
write a short summery of your changes to be posted to #progress-reports.
-->
