### PR TITLE
2 hour clown playtime requirement

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -6,6 +6,9 @@
   startingGear: ClownGear
   icon: "JobIconClown"
   supervisors: job-supervisors-hop
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 7200 #2 hrs
   access:
   - Theatre
   - Maintenance


### PR DESCRIPTION
Standard anti-greif timer.

**Changelog**
<!--
CD does not have the changelog bot. If your changes are player facing, please
write a short summery of your changes to be posted to #progress-reports.
-->
Clowns now have a 2 hour playtime requirement
