### PR TITLE
Fix a Couple Intern Issues

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -211,7 +211,7 @@
       offset: *icon-offset
       state: TechnicalAssistant
   - type: PresetIdCard
-    job: TechnicalAssistant
+    job: StationEngineer #CD
 
 - type: entity
   parent: IDCardStandard
@@ -284,7 +284,7 @@
       offset: *icon-offset
       state: MedicalIntern
   - type: PresetIdCard
-    job: MedicalIntern
+    job: MedicalDoctor #CD
 
 - type: entity
   parent: IDCardStandard
@@ -393,7 +393,7 @@
       offset: *icon-offset
       state: ResearchAssistant
   - type: PresetIdCard
-    job: ResearchAssistant
+    job: Scientist #CD
 
 - type: entity
   parent: IDCardStandard
@@ -448,7 +448,7 @@
       offset: *icon-offset
       state: SecurityCadet
   - type: PresetIdCard
-    job: SecurityCadet
+    job: SecurityOfficer #CD
 
 - type: entity
   parent: IDCardStandard

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -34,26 +34,26 @@
             SeniorEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 3, 3 ]
             StationEngineer: [ 4, 4 ]
-            TechnicalAssistant: [ 4, 4 ]
+            # TechnicalAssistant: [ 4, 4 ] #CD disabled.
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             SeniorPhysician: [ 1, 1 ]
             Chemist: [ 3, 3 ]
             MedicalDoctor: [ 5, 5 ]
             Paramedic: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ]
+            # MedicalIntern: [ 4, 4 ] #CD disabled.
             #science
             ResearchDirector: [ 1, 1 ]
             SeniorResearcher: [ 1, 1 ]        
             Scientist: [ 4, 4 ]
-            ResearchAssistant: [ 6, 6 ]
+            # ResearchAssistant: [ 6, 6 ] #CD disabled.
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
             SecurityOfficer: [ 7, 7 ]
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 6, 6 ]
+            # SecurityCadet: [ 6, 6 ] #CD disabled.
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/relic.yml
+++ b/Resources/Prototypes/Maps/relic.yml
@@ -44,23 +44,23 @@
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 2, 2 ]
             StationEngineer: [ 2, 2 ]
-            TechnicalAssistant: [ 2, 2 ]
+            # TechnicalAssistant: [ 2, 2 ] #CD disabled.
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 1, 1 ]
             MedicalDoctor: [ 2, 2 ]
             Paramedic: [ 1, 1 ]
-            MedicalIntern: [ 2, 2 ]
+            # MedicalIntern: [ 2, 2 ] #CD disabled.
             #science
             ResearchDirector: [ 1, 1 ]
             Scientist: [ 1, 3 ]
-            ResearchAssistant: [ 2, 2 ]
+            # ResearchAssistant: [ 2, 2 ] #CD disabled.
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
             SecurityOfficer: [ 1, 2 ]
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 2, 2 ]
+            # SecurityCadet: [ 2, 2 ] #CD disabled.
             Lawyer: [ 1, 1 ]
             #supply (0)
             #civilian (0+)

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -31,19 +31,19 @@
             AtmosphericTechnician: [ 2, 2 ]
             SeniorEngineer: [1, 1 ]
             StationEngineer: [ 3, 3 ]
-            TechnicalAssistant: [ 4, 4 ]
+            # TechnicalAssistant: [ 4, 4 ] #CD disabled.
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             SeniorPhysician: [ 1, 1 ]
             Chemist: [ 2, 2 ]
             MedicalDoctor: [ 2, 2 ]
-            MedicalIntern: [ 4, 4 ]
+            # MedicalIntern: [ 4, 4 ] #CD disabled.
             Paramedic: [ 1, 1 ]
             #science
             ResearchDirector: [ 1, 1 ]
             SeniorResearcher: [1, 1 ]
             Scientist: [ 3, 3 ]
-            ResearchAssistant: [ 2, 2 ]
+            # ResearchAssistant: [ 2, 2 ] #CD disabled.
             Borg: [ 2, 2 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
@@ -51,7 +51,7 @@
             SeniorOfficer: [ 1, 1 ]
             SecurityOfficer: [ 3, 3 ]
             Detective: [ 1, 1 ]
-            SecurityCadet: [ 4, 4 ]
+            # SecurityCadet: [ 4, 4 ] #CD disabled.
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 1, 3 ]

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -3,6 +3,7 @@
   name: job-name-technical-assistant
   description: job-description-technical-assistant
   playTimeTracker: JobTechnicalAssistant
+  setPreference: false #CD
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 7200 #2 hrs

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -3,6 +3,7 @@
   name: job-name-intern
   description: job-description-intern
   playTimeTracker: JobMedicalIntern
+  setPreference: false #CD
   startingGear: MedicalInternGear
   icon: "JobIconMedicalIntern"
   supervisors: job-supervisors-medicine

--- a/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
@@ -3,6 +3,7 @@
   name: job-name-research-assistant
   description: job-description-research-assistant
   playTimeTracker: JobResearchAssistant
+  setPreference: false #CD
   startingGear: ResearchAssistantGear
   icon: "JobIconResearchAssistant"
   supervisors: job-supervisors-science

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -3,6 +3,7 @@
   name: job-name-cadet
   description: job-description-cadet
   playTimeTracker: JobSecurityCadet
+  setPreference: false #CD
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 7200 #2 hrs

--- a/Resources/Prototypes/_CD/StatusIcon/job.yml
+++ b/Resources/Prototypes/_CD/StatusIcon/job.yml
@@ -4,7 +4,7 @@
   icon:
     sprite: /Textures/_CD/Interface/Misc/job_icons.rsi
     state: PrivateInvestigator
-  jobName: job-name-prisoner
+  jobName: job-name-private-investigator
 
 - type: jobIcon
   parent: JobIcon
@@ -12,3 +12,4 @@
   icon:
     sprite: /Textures/_CD/Interface/Misc/job_icons.rsi
     state: Courier
+  jobName: cd-job-title-courier


### PR DESCRIPTION
## About the PR
- Fixes interns showing up as unknown on the crew manifest.
- Removes the ability to assign people to intern roles using the ID computer (because they weren't showing up on the manifest. This isn't the best solution but it's the only one that seemed possible without complicated coding.)
- Fixes two lines on the PI and Courier job icon prototypes so they show up properly when using a chameleon ID card.
- Due to test fails also removes intern roles from _all_ maps that had them. This will have to be maintained for future maps which could make this an undesirable solution.


## Media
<img width="1870" height="881" alt="image" src="https://github.com/user-attachments/assets/6c41a2bd-aa1d-447a-9113-6733543e970e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->