### PR TITLE
Fix Candy Cigs

### DIFF
--- a/Resources/Prototypes/_CD/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/_CD/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -16,28 +16,28 @@
             Quantity: 5
 
 - type: entity
-  parent: [ Cigarette, FoodBase ]
+  parent: Cigarette
   id: CigaretteCandy
   name: cigarette
   suffix: candy
   description: Sugar sticks designed to look like a roll of nicotine and tobacco.
   components:
-  - type: Appearance
   - type: Edible
   - type: Tag
     tags:
       - FoodSnack
+      - Cigarette
+      - Trash
   - type: FlavorProfile
     flavors:
       - sweet
-  - type: Sprite
-    sprite: Objects/Consumable/Smokeables/Cigarettes/cigarette.rsi
-    state: unlit-icon
-  - type: Clothing
-    sprite: Objects/Consumable/Smokeables/Cigarettes/cigarette.rsi
-    slots: [ mask ]
   - type: SolutionContainerManager
     solutions:
+      smokable:
+        maxVol: 20
+        reagents:
+          - ReagentId: Sugar
+            Quantity: 10
       food:
         maxVol: 10
         reagents:


### PR DESCRIPTION
## About the PR
Makes it so the sugar rush candy cigarettes don't immediately extinguish and error upon trying to light them.
Does light clean-up work on the prototype file as well.

## Media
I don't know what the actual desired direction for these is, I just don't want them to be showing up as errors.
<img width="415" height="146" alt="image" src="https://github.com/user-attachments/assets/ef6654f5-2966-4f65-bcb8-f2991c93132e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
Sugar Rush candy cigarettes will no longer error upon lighting them.