### PR TITLE
Suit Storage For All (Rebased)

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -8,6 +8,7 @@
     - outerClothing
   - type: Sprite
     state: icon
+  - type: AllowSuitStorage #CD addition.
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/base_clothing.yml
+++ b/Resources/Prototypes/Entities/Clothing/base_clothing.yml
@@ -33,9 +33,9 @@
   id: AllowSuitStorageClothingGasTanks
   components:
   - type: AllowSuitStorage
-    whitelist:
-      components:
-      - GasTank
+    # whitelist: #CD disable tank whitelist.
+      # tags:
+      # - GasTank
 
 # for clothing that has a single item slot to insert and alt click out.
 # inheritors add a whitelisted slot named item


### PR DESCRIPTION
Rebase of #774 since it was still on the old pre-gridinv master.

## About the PR
Gives every outerwear clothing item suit storage. Removes the tank only whitelist part for items like tank harnesses.

Primarily, this is just for the drip. I really just want to be able to wear my PKA on my back without having to wear a hardsuit or vest, and without having to sacrifice my backpack or belt.

But, I think I can argue merit behind a good deal of this.

1, I think with some extrapolation, it's really not that unreasonable that every outerwear should be able to at least store tanks. Tank harnesses are fairly publicly accessible items, you make em in the autolathe, which no one's going to question you if you ask for one from cargo or sci, and voxes spawn with them. And these are just outerwear items that have no slowdown and allow you to store tanks. They don't come with pockets though, so sure yeah, it's fair to say that it's a buff in that category. But there's some outerwear out there that have suit storage, pockets, armor, and no slow down, like armored coats. So I'm not sure if you could say it's really that far out there. Besides, voxes being able to wear slightly more casual clothing may be nice for player expression.

2, most people who'd be carrying weapons on their back, probably already have access to an armor vest. And if they don't, they'd probably want to be hiding their weaponry in a bag instead of wearing it on their back in plain view of every security officer. Unless say, you're someone like the HoP, who gets a disabler but no armor vest, or salvage who get PKAs, but sometimes enter atmos safe areas where they could ditch the suit.

3, There's a good couple inconsistencies that piss me off like fire suits and rad suits being able to store either weapons or tanks, bio suits only being able to store tanks, but bombs suits being unable to store anything. Wizard robes being able to store tanks despite being regular maints loot last I checked. The carp suit (the autodrobe version) being able to store either weapons or tanks despite not being the one that makes carps friendly to you or space proof. The armored medical gown and samurai dogi being unable to store anything despite both being armors. Or maybe even chameleon gear being unable to store either, even if it's changed to something that should be able to.

NOW, this is the extreme version of the change, I figured doing the most impactful change first would be smart, so if required and requested, we can dial it back slowly instead of trying to hit some invisible middle ground that no one's decided on yet and potentially end up with less than we'd actually be fine with. The system is fully whitelistable, so there's a lot we can do here if desired.

## Media
<img width="865" height="464" alt="image" src="https://github.com/user-attachments/assets/cbcfe62c-f3fe-4961-8574-a8a3defdad2f" />

## Requirements
- [X] I have read and I am following the Cosmatic Drift [PR Guidelines](https://github.com/cosmatic-drift-14/cosmatic-drift/blob/master/CONTRIBUTING.md) (note that they may differ than what you find on other SS14 forks).
- [X] I have approval from a maintainer if this PR adds a feature **or** this PR does not add a feature **or** I am alright with this PR being closed at a maintainer's discretion.
- [X] I have added screenshots/videos to this PR showcasing its changes ingame **or** this PR does not require an ingame showcase.

**Changelog**
All outerwear now allows for suit storage of any kind.