### PR TITLE
Re-add Arcryox

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -133,8 +133,9 @@ reagent-desc-insuzine = Rapidly repairs dead tissue caused by electrocution, but
 reagent-name-opporozidone = opporozidone
 reagent-desc-opporozidone= A difficult to synthesize cryogenic drug used to regenerate rotting tissue and brain matter.
 
+# CD: Slightly changed the description.
 reagent-name-arcryox = arcryox
-reagent-desc-arcryox = A sickeningly blue cryogenics chemical that is able to heal extreme wounds even on the dead. It has trouble stabilizing patients however.
+reagent-desc-arcryox = A sickeningly blue cryogenics chemical that is able to heal extreme wounds on the dead.
 
 reagent-name-aloxadone = aloxadone
 reagent-desc-aloxadone = A cryogenics chemical. Used to treat severe burns and frostbite via regeneration of the affected tissue. Works regardless of the patient being alive or dead.

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1331,9 +1331,11 @@
         conditions:
         - !type:TemperatureCondition
           max: 213.0
+        - !type:MobStateCondition
+          mobstate: Dead
         damage:
-          Brute: -3
-          Burn: -3
+          Brute: -4
+          Burn: -4
 
 - type: reagent
   id : Aloxadone

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1331,11 +1331,11 @@
         conditions:
         - !type:TemperatureCondition
           max: 213.0
-        - !type:MobStateCondition
+        - !type:MobStateCondition #CD addition
           mobstate: Dead
         damage:
-          Brute: -4
-          Burn: -4
+          Brute: -4 #CD change from -3 to -4
+          Burn: -4 #CD change from -3 to -4
 
 - type: reagent
   id : Aloxadone

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -570,19 +570,18 @@
 #   products:
 #     Opporozidone: 3
 
-# CD Change: removed necrosol
-#- type: reaction
-#  id: Arcryox
-#  minTemp: 370
-#  reactants:
-#    Lithium:
-#      amount: 1
-#    Tricordrazine:
-#      amount: 1
-#    Cryoxadone:
-#      amount: 1
-#  products:
-#    Arcryox: 3
+- type: reaction
+  id: Arcryox
+  minTemp: 370
+  reactants:
+    Lithium:
+      amount: 1
+    Tricordrazine:
+      amount: 1
+    Cryoxadone:
+      amount: 1
+  products:
+    Arcryox: 3
 
 - type: reaction
   id: Aloxadone


### PR DESCRIPTION
## About the PR
Re-adds the recipe for Arcryox because it was accidently removed in a merge.

Also slightly rebalances it to be more similar to it's original design by making it only work on dead entities and buffing it's healing amount back to 4 from 3.

## Media
<img width="576" height="317" alt="image" src="https://github.com/user-attachments/assets/923a6ae2-56c9-4d02-8e22-98867144b96c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
Fixed Arcryox being unmakable. It also now only applies on dead entities and had it's healing amount buffed by 1.