### PR TITLE
allow AIs to freeform emote through holopads

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.PrivateAPI.cs
@@ -207,6 +207,11 @@ public sealed partial class ChatSystem
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Emote from {source} as {name}: {action}");
             else
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Emote from {source}: {action}");
+
+        // CD - allow us to listen to any emotes
+        var ev = new CDEntityEmotedEvent(source, action);
+        RaiseLocalEvent(source, ref ev, true);
+        // end CD
     }
 
     // ReSharper disable once InconsistentNaming

--- a/Content.Server/Speech/EntitySystems/ListeningSystem.cs
+++ b/Content.Server/Speech/EntitySystems/ListeningSystem.cs
@@ -16,6 +16,7 @@ public sealed partial class ListeningSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<EntitySpokeEvent>(OnSpeak);
+        SubscribeLocalEvent<CDEntityEmotedEvent>(OnEmote); // CD
     }
 
     private void OnSpeak(EntitySpokeEvent ev)

--- a/Content.Server/Telephone/TelephoneSystem.cs
+++ b/Content.Server/Telephone/TelephoneSystem.cs
@@ -88,7 +88,7 @@ public sealed partial class TelephoneSystem : SharedTelephoneSystem
         if (!_recentChatMessages.Add((args.Source, args.Message, entity)))
             return;
 
-        SendTelephoneMessage(args.Source, args.Message, entity);
+        SendTelephoneMessage(args.Source, args.Message, entity, args.ChatType); // Cd - added chat type
     }
 
     private void OnTelephoneMessageReceived(Entity<TelephoneComponent> entity, ref TelephoneMessageReceivedEvent args)
@@ -114,7 +114,14 @@ public sealed partial class TelephoneSystem : SharedTelephoneSystem
             ("speaker", Name(speaker)));
 
         var range = args.TelephoneSource.Comp.LinkedTelephones.Count > 1 ? ChatTransmitRange.HideChat : ChatTransmitRange.GhostRangeLimit;
-        var volume = entity.Comp.SpeakerVolume == TelephoneVolume.Speak ? InGameICChatType.Speak : InGameICChatType.Whisper;
+        // CD modification -
+        var volume = args.ChatMsg.Message.Channel switch
+        {
+            ChatChannel.Local => entity.Comp.SpeakerVolume == TelephoneVolume.Speak
+                ? InGameICChatType.Speak
+                : InGameICChatType.Whisper,
+            ChatChannel.Emotes => InGameICChatType.Emote,
+        };
 
         _chat.TrySendInGameICMessage(speaker, args.Message, volume, range, nameOverride: name, checkRadioPrefix: false);
     }
@@ -352,7 +359,8 @@ public sealed partial class TelephoneSystem : SharedTelephoneSystem
         SetTelephoneMicrophoneState(entity, false);
     }
 
-    private void SendTelephoneMessage(EntityUid messageSource, string message, Entity<TelephoneComponent> source, bool escapeMarkup = true)
+    // CD - chat type parameter
+    private void SendTelephoneMessage(EntityUid messageSource, string message, Entity<TelephoneComponent> source, ChatChannel chatType = ChatChannel.Local, bool escapeMarkup = true)
     {
         // This method assumes that you've already checked that this
         // telephone is able to transmit messages and that it can
@@ -382,8 +390,7 @@ public sealed partial class TelephoneSystem : SharedTelephoneSystem
             ("name", name),
             ("message", content));
 
-        var chat = new ChatMessage(
-            ChatChannel.Local,
+        var chat = new ChatMessage(chatType, // CD chat type modification
             message,
             wrappedMessage,
             NetEntity.Invalid,

--- a/Content.Server/Telephone/TelephoneSystem.cs
+++ b/Content.Server/Telephone/TelephoneSystem.cs
@@ -21,6 +21,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Replays;
 using System.Linq;
+using Content.Shared._CD.Speech.Components;
 
 namespace Content.Server.Telephone;
 
@@ -448,6 +449,21 @@ public sealed partial class TelephoneSystem : SharedTelephoneSystem
         {
             RemComp<ActiveListenerComponent>(entity);
         }
+
+        // CD - emote listening
+        if (!entity.Comp.ListenToEmotes)
+            return;
+
+        if (microphoneOn)
+        {
+            EnsureComp(entity, out CDActiveEmoteListenerComponent comp);
+            comp.Range = entity.Comp.ListeningRange;
+        }
+        else
+        {
+            RemComp<CDActiveEmoteListenerComponent>(entity);
+        }
+        // CD end
     }
 
     public void SetSpeakerForTelephone(Entity<TelephoneComponent> entity, Entity<SpeechComponent>? speaker)

--- a/Content.Server/Telephone/TelephoneSystem.cs
+++ b/Content.Server/Telephone/TelephoneSystem.cs
@@ -118,10 +118,13 @@ public sealed partial class TelephoneSystem : SharedTelephoneSystem
         // CD modification - add check for emote channel to properly send message; Local check uses original behaviour
         var volume = args.ChatMsg.Message.Channel switch
         {
-            ChatChannel.Local => entity.Comp.SpeakerVolume == TelephoneVolume.Speak
+            // originally this was hard coded to be one or the other without taking into consideration
+            // the chat type, now we only make that assumption if it is anything *but* emote (to appease the tests
+            // when not all cases are covered)
+            ChatChannel.Emotes => InGameICChatType.Emote,
+            _ => entity.Comp.SpeakerVolume == TelephoneVolume.Speak
                 ? InGameICChatType.Speak
                 : InGameICChatType.Whisper,
-            ChatChannel.Emotes => InGameICChatType.Emote,
         };
         // end CD
         _chat.TrySendInGameICMessage(speaker, args.Message, volume, range, nameOverride: name, checkRadioPrefix: false);

--- a/Content.Server/Telephone/TelephoneSystem.cs
+++ b/Content.Server/Telephone/TelephoneSystem.cs
@@ -115,7 +115,7 @@ public sealed partial class TelephoneSystem : SharedTelephoneSystem
             ("speaker", Name(speaker)));
 
         var range = args.TelephoneSource.Comp.LinkedTelephones.Count > 1 ? ChatTransmitRange.HideChat : ChatTransmitRange.GhostRangeLimit;
-        // CD modification -
+        // CD modification - add check for emote channel to properly send message; Local check uses original behaviour
         var volume = args.ChatMsg.Message.Channel switch
         {
             ChatChannel.Local => entity.Comp.SpeakerVolume == TelephoneVolume.Speak
@@ -123,7 +123,7 @@ public sealed partial class TelephoneSystem : SharedTelephoneSystem
                 : InGameICChatType.Whisper,
             ChatChannel.Emotes => InGameICChatType.Emote,
         };
-
+        // end CD
         _chat.TrySendInGameICMessage(speaker, args.Message, volume, range, nameOverride: name, checkRadioPrefix: false);
     }
 

--- a/Content.Server/_CD/Chat/Systems/ChatSystem.CD.cs
+++ b/Content.Server/_CD/Chat/Systems/ChatSystem.CD.cs
@@ -1,0 +1,5 @@
+// ReSharper disable once CheckNamespace
+namespace Content.Server.Chat.Systems;
+
+[ByRefEvent]
+public record struct CDEntityEmotedEvent(EntityUid Source, string Action);

--- a/Content.Server/_CD/Speech/EntitySystems/ListeningSystem.CD.cs
+++ b/Content.Server/_CD/Speech/EntitySystems/ListeningSystem.CD.cs
@@ -13,6 +13,11 @@ public sealed partial class ListeningSystem
         PingEmoteListeners(ev.Source, ev.Action);
     }
 
+    /// <summary>
+    /// A copy of <see cref="PingListeners"/> instead of integrating into the original method for the
+    /// sake of maintaining.
+    /// </summary>
+    // Above might be unwise?
     public void PingEmoteListeners(EntityUid source, string action)
     {
         var sourceXform = Transform(source);

--- a/Content.Server/_CD/Speech/EntitySystems/ListeningSystem.CD.cs
+++ b/Content.Server/_CD/Speech/EntitySystems/ListeningSystem.CD.cs
@@ -1,0 +1,46 @@
+using Content.Server.Chat.Systems;
+using Content.Shared._CD.Speech.Components;
+using Content.Shared.Chat;
+using Content.Shared.Speech;
+
+// ReSharper disable once CheckNamespace
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed partial class ListeningSystem
+{
+    private void OnEmote(ref CDEntityEmotedEvent ev)
+    {
+        PingEmoteListeners(ev.Source, ev.Action);
+    }
+
+    public void PingEmoteListeners(EntityUid source, string action)
+    {
+        var sourceXform = Transform(source);
+        var sourcePos = _xforms.GetWorldPosition(sourceXform);
+
+        var attemptEv = new ListenAttemptEvent(source);
+        var ev = new ListenEvent(action, source, ChatChannel.Emotes);
+        var query = EntityQueryEnumerator<CDActiveEmoteListenerComponent, TransformComponent>();
+
+        while (query.MoveNext(out var listenerUid, out var listener, out var xform))
+        {
+            if (xform.MapID != sourceXform.MapID)
+                continue;
+
+            // range checks
+            // TODO proper speech occlusion
+            var distance = (sourcePos - _xforms.GetWorldPosition(xform)).LengthSquared();
+            if (distance > listener.Range * listener.Range)
+                continue;
+
+            RaiseLocalEvent(listenerUid, attemptEv);
+            if (attemptEv.Cancelled)
+            {
+                attemptEv.Uncancel();
+                continue;
+            }
+
+            RaiseLocalEvent(listenerUid, ev);
+        }
+    }
+}

--- a/Content.Shared/Speech/ListenEvent.cs
+++ b/Content.Shared/Speech/ListenEvent.cs
@@ -1,14 +1,18 @@
+using Content.Shared.Chat;
+
 namespace Content.Shared.Speech;
 
 public sealed class ListenEvent : EntityEventArgs
 {
     public readonly string Message;
     public readonly EntityUid Source;
+    public readonly ChatChannel ChatType; // CD
 
-    public ListenEvent(string message, EntityUid source)
+    public ListenEvent(string message, EntityUid source, ChatChannel chatType = ChatChannel.Local) // CD chatType change
     {
         Message = message;
         Source = source;
+        ChatType = chatType; // CD
     }
 }
 

--- a/Content.Shared/_CD/Speech/Components/CDActiveEmoteListenerComponent.cs
+++ b/Content.Shared/_CD/Speech/Components/CDActiveEmoteListenerComponent.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Chat;
+using Content.Shared.Speech.Components;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CD.Speech.Components;
+
+/// <summary>
+/// Emote version of <see cref="ActiveListenerComponent"/>
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CDActiveEmoteListenerComponent : Component
+{
+    /// <summary>
+    /// The range in which to listen to speech.
+    /// </summary>
+    [DataField]
+    public float Range = SharedChatSystem.VoiceRange;
+}

--- a/Content.Shared/_CD/Telephone/TelephoneComponent.CD.cs
+++ b/Content.Shared/_CD/Telephone/TelephoneComponent.CD.cs
@@ -1,0 +1,12 @@
+// ReSharper disable once CheckNamespace
+namespace Content.Shared.Telephone;
+
+public sealed partial class TelephoneComponent
+{
+    /// <summary>
+    /// Specifies whether this telephone should be able to listen to emotes or not
+    /// </summary>
+    [DataField]
+    public bool ListenToEmotes;
+
+}

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -317,6 +317,7 @@
     listeningRange: 0
     speakerVolume: Speak
     unlistedNumber: true
+    listenToEmotes: true # CD
   - type: Holopad
   - type: StationAiWhitelist
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -178,6 +178,7 @@
   - type: Tag
     tags:
     - HideContextMenu
+  - type: Emoting # CD
 
 ## Mapping prototypes
 # General


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- PRs may be closed by maintainers if we think they are not a good fit for Cosmatic Drift. If you are unsure if a feature
is a good fit please ask a @Maintainer on discord before starting work -->

## About the PR
<!-- What did you change? and why? Note any major architectural decisions if this is a large C# PR. If there are player
facing breaking changes please note it very clearly. -->
what it says on the tin

this gives _only_ the AI the ability to emote through the holopads, holopads in use by anyone else act as normal

## Media
<!-- Attach media if the PR makes in-game changes.
Small fixes/refactors are exempt. Media may be used in progress reports with credit.

You also don't need to include media if the effects of the PR can easily be
surmised by reading the code.
-->
<img width="343" height="325" alt="image" src="https://github.com/user-attachments/assets/c2f5c21a-d528-4e96-9a13-7e59120fb144" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!--
CD does not have the changelog bot. If your changes are player facing, please
write a short summery of your changes to be posted to #progress-reports.
-->
AIs can now emote through holopads.