### PR TITLE
Fix default cyborgs not having correct sprites

### DIFF
--- a/Content.Client/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Client/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -34,6 +34,10 @@ public sealed partial class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeS
 
     private void AfterStateHandler(Entity<BorgSwitchableTypeComponent> ent, ref AfterAutoHandleStateEvent args)
     {
+        // CD - for RSI errors when selecting a shell
+        if (!_timing.IsFirstTimePredicted)
+            return;
+
         UpdateEntityAppearance(ent);
     }
 
@@ -42,9 +46,6 @@ public sealed partial class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeS
         BorgTypePrototype prototype)
     {
         // CD - added checks to stop sprite state errors
-        if (!_timing.IsFirstTimePredicted)
-            return;
-
         if (!TryComp<BorgSwitchableSubtypeComponent>(entity, out var subtype) ||
             subtype.BorgSubtype != null)
         {
@@ -52,6 +53,7 @@ public sealed partial class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeS
             RaiseLocalEvent(entity, ref ev);
             return;
         }
+        // CD end
 
         if (TryComp(entity, out SpriteComponent? sprite))
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- PRs may be closed by maintainers if we think they are not a good fit for Cosmatic Drift. If you are unsure if a feature
is a good fit please ask a @Maintainer on discord before starting work -->

## About the PR
<!-- What did you change? and why? Note any major architectural decisions if this is a large C# PR. If there are player
facing breaking changes please note it very clearly. -->
moved prediction guard to only raise on auto handling comp state for BorgSwitchableTypeComponent since the issue was the sprite not updating due to it technically not being a first prediction when a borg enters view

also comment update

## Media
<!-- Attach media if the PR makes in-game changes.
Small fixes/refactors are exempt. Media may be used in progress reports with credit.

You also don't need to include media if the effects of the PR can easily be
surmised by reading the code.
-->

no media no fun

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!--
CD does not have the changelog bot. If your changes are player facing, please
write a short summery of your changes to be posted to #progress-reports.
-->

Fixed default cyborgs sometimes not properly showing the correct sprite.
