### PR TITLE
Readd Crew Monitors to Paramed Lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -130,6 +130,8 @@
       - id: EmergencyRollerBedSpawnFolded
     - id: PlushieLizardJobParamedic
       prob: 0.02
+    #CD Addions
+    - id: HandheldCrewMonitor
 
 - type: entity
   parent: LockerParamedic


### PR DESCRIPTION
## About the PR
Readd the first half of #507 since the latter half still existed.

## Media
<img width="441" height="393" alt="image" src="https://github.com/user-attachments/assets/258a8092-5578-46b7-bd9e-e994732af5ef" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
Handheld crew monitors will once again appear in paramedic lockers.
