### PR TITLE
Human Horns

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/reptilian.yml
@@ -75,7 +75,7 @@
 - type: marking
   id: LizardHornsCurled
   bodyPart: HeadTop
-  groupWhitelist: [Reptilian]
+  groupWhitelist: [Reptilian, Human] #CD: Add humans
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_curled
@@ -83,7 +83,7 @@
 - type: marking
   id: LizardHornsRam
   bodyPart: HeadTop
-  groupWhitelist: [Reptilian]
+  groupWhitelist: [Reptilian, Human] #CD: Add humans
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_ram
@@ -91,7 +91,7 @@
 - type: marking
   id: LizardHornsShort
   bodyPart: HeadTop
-  groupWhitelist: [Reptilian]
+  groupWhitelist: [Reptilian, Human] #CD: Add humans
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_short
@@ -99,7 +99,7 @@
 - type: marking
   id: LizardHornsSimple
   bodyPart: HeadTop
-  groupWhitelist: [Reptilian]
+  groupWhitelist: [Reptilian, Human] #CD: Add humans
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_simple
@@ -107,7 +107,7 @@
 - type: marking
   id: LizardHornsDouble
   bodyPart: HeadTop
-  groupWhitelist: [Reptilian]
+  groupWhitelist: [Reptilian, Human] #CD: Add humans
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_double
@@ -257,7 +257,7 @@
 - type: marking
   id: LizardHornsArgali
   bodyPart: HeadTop
-  groupWhitelist: [Reptilian]
+  groupWhitelist: [Reptilian, Human] #CD: Add humans
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_argali
@@ -265,7 +265,7 @@
 - type: marking
   id: LizardHornsAyrshire
   bodyPart: HeadTop
-  groupWhitelist: [Reptilian]
+  groupWhitelist: [Reptilian, Human] #CD: Add humans
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_ayrshire
@@ -273,7 +273,7 @@
 - type: marking
   id: LizardHornsMyrsore
   bodyPart: HeadTop
-  groupWhitelist: [Reptilian]
+  groupWhitelist: [Reptilian, Human] #CD: Add humans
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_myrsore
@@ -281,7 +281,7 @@
 - type: marking
   id: LizardHornsBighorn
   bodyPart: HeadTop
-  groupWhitelist: [Reptilian]
+  groupWhitelist: [Reptilian, Human] #CD: Add humans
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_bighorn
@@ -289,7 +289,7 @@
 - type: marking
   id: LizardHornsDemonic
   bodyPart: HeadTop
-  groupWhitelist: [Reptilian]
+  groupWhitelist: [Reptilian, Human] #CD: Add humans
   sprites:
   - sprite: Mobs/Customization/reptilian_parts.rsi
     state: horns_demonic


### PR DESCRIPTION
## About the PR
Gives humans access to the reptile horns. It seems mostly harmless and in line with all the cat/dog parts they also have access to. Primarily came to mind because people have wanted to make Onis and this is a step in that direction.

## Media
<img width="1511" height="725" alt="image" src="https://github.com/user-attachments/assets/b96e99a2-79e8-4fc2-ac9d-1d4e68cf2768" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
Humans now have access to reptilian horn markings.