### PR TITLE
Rodentia Hair

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/human_hair.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/human_hair.yml
@@ -1,1393 +1,1414 @@
 - type: marking
   id: HumanHairAfro
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: afro
 - type: marking
   id: HumanHairAfro2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: afro2
 - type: marking
   id: HumanHairBaby
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: baby
 - type: marking
   id: HumanHairBigafro
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bigafro
 - type: marking
   id: HumanHairAntenna
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: antenna
 - type: marking
   id: HumanHairBalding
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: e
 - type: marking
   id: HumanHairBedhead
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bedhead
 - type: marking
   id: HumanHairBedheadv2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bedheadv2
 - type: marking
   id: HumanHairBedheadv3
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bedheadv3
 - type: marking
   id: HumanHairCube
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: cube
 - type: marking
   id: HumanHairPulato
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: pulato
 - type: marking
   id: HumanHairLongBedhead
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: long_bedhead
 - type: marking
   id: HumanHairLongBedhead2
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: long_bedhead2
 - type: marking
   id: HumanHairFloorlengthBedhead
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: floorlength_bedhead
 - type: marking
   id: HumanHairBeehive
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: beehive
 - type: marking
   id: HumanHairBeehivev2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: beehivev2
 - type: marking
   id: HumanHairBob
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bob
 - type: marking
   id: HumanHairBob2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bob2
 - type: marking
   id: HumanHairBobcut
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bobcut
 - type: marking
   id: HumanHairBob4
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bob4
 - type: marking
   id: HumanHairBob5
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bob5
 - type: marking
   id: HumanHairBobcurl
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bobcurl
 - type: marking
   id: HumanHairBoddicker
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: boddicker
 - type: marking
   id: HumanHairBowlcut
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bowlcut
 - type: marking
   id: HumanHairBowlcut2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bowlcut2
 - type: marking
   id: HumanHairBraid
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: braid
 - type: marking
   id: HumanHairBraided
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: braided
 - type: marking
   id: HumanHairBraidfront
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: braidfront
 - type: marking
   id: HumanHairBraid2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: braid2
 - type: marking
   id: HumanHairHbraid
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: hbraid
 - type: marking
   id: HumanHairShortbraid
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shortbraid
 - type: marking
   id: HumanHairBraidtail
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: braidtail
 - type: marking
   id: HumanHairBun
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bun
 - type: marking
   id: HumanHairBunhead2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bunhead2
 - type: marking
   id: HumanHairBun3
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bun3
 - type: marking
   id: HumanHairLargebun
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: largebun
 - type: marking
   id: HumanHairManbun
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: manbun
 - type: marking
   id: HumanHairTightbun
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: tightbun
 - type: marking
   id: HumanHairBusiness
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: business
 - type: marking
   id: HumanHairBusiness2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: business2
 - type: marking
   id: HumanHairBusiness3
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: business3
 - type: marking
   id: HumanHairBusiness4
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: business4
 - type: marking
   id: HumanHairBuzzcut
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: buzzcut
 - type: marking
   id: HumanHairCia
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: cia
 - type: marking
   id: HumanHairClassicAfro
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classicafro
 - type: marking
   id: HumanHairClassicBigAfro
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classicbigafro
 - type: marking
   id: HumanHairClassicBusiness
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classicbusiness
 - type: marking
   id: HumanHairClassicCia
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classiccia
 - type: marking
   id: HumanHairClassicCornrows2
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classiccornrows2
 - type: marking
   id: HumanHairClassicFloorlengthBedhead
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classicfloorlength_bedhead
 - type: marking
   id: HumanHairClassicModern
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classicmodern
 - type: marking
   id: HumanHairClassicMulder
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classicmulder
 - type: marking
   id: HumanHairClassicWisp
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classicwisp
 - type: marking
   id: HumanHairCoffeehouse
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: coffeehouse
 - type: marking
   id: HumanHairCombover
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: combover
 - type: marking
   id: HumanHairCornrows
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: cornrows
 - type: marking
   id: HumanHairCornrows2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: cornrows2
 - type: marking
   id: HumanHairCornrowbun
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: cornrowbun
 - type: marking
   id: HumanHairCornrowbraid
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: cornrowbraid
 - type: marking
   id: HumanHairCornrowtail
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: cornrowtail
 - type: marking
   id: HumanHairCrewcut
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: crewcut
 - type: marking
   id: HumanHairCrewcut2
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: crewcut2
 - type: marking
   id: HumanHairCurls
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: curls
 - type: marking
   id: HumanHairC
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: c
 - type: marking
   id: HumanHairDandypompadour
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: dandypompadour
 - type: marking
   id: HumanHairDevilock
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: devilock
 - type: marking
   id: HumanHairDoublebun
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: doublebun
 - type: marking
   id: HumanHairDoublebunLong
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
   - sprite: Mobs/Customization/human_hair.rsi
     state: doublebun_long
 - type: marking
   id: HumanHairDreads
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: dreads
 - type: marking
   id: HumanHairDrillruru
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: drillruru
 - type: marking
   id: HumanHairDrillhairextended
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: drillhairextended
 - type: marking
   id: HumanHairEmo
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: emo
 - type: marking
   id: HumanHairEmofringe
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: emofringe
 - type: marking
   id: HumanHairNofade
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: nofade
 - type: marking
   id: HumanHairHighfade
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: highfade
 - type: marking
   id: HumanHairMedfade
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: medfade
 - type: marking
   id: HumanHairLowfade
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: lowfade
 - type: marking
   id: HumanHairBaldfade
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: baldfade
 - type: marking
   id: HumanHairFeather
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: feather
 - type: marking
   id: HumanHairFather
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: father
 - type: marking
   id: HumanHairSargeant
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: sargeant
 - type: marking
   id: HumanHairFlair
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: flair
 - type: marking
   id: HumanHairBigflattop
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bigflattop
 - type: marking
   id: HumanHairFlow
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: f
 - type: marking
   id: HumanHairGelled
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: gelled
 - type: marking
   id: HumanHairGentle
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: gentle
 - type: marking
   id: HumanHairHalfbang
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: halfbang
 - type: marking
   id: HumanHairHalfbang2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: halfbang2
 - type: marking
   id: HumanHairHalfshaved
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: halfshaved
 - type: marking
   id: HumanHairHedgehog
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: hedgehog
 - type: marking
   id: HumanHairHimecut
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: himecut
 - type: marking
   id: HumanHairHimecut2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: himecut2
 - type: marking
   id: HumanHairShorthime
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shorthime
 - type: marking
   id: HumanHairHimeup
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: himeup
 - type: marking
   id: HumanHairHitop
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: hitop
 - type: marking
   id: HumanHairJade
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: jade
 - type: marking
   id: HumanHairJensen
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: jensen
 - type: marking
   id: HumanHairJoestar
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: joestar
 - type: marking
   id: HumanHairKeanu
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: keanu
 - type: marking
   id: HumanHairKusanagi
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: kusanagi
 - type: marking
   id: HumanHairLong
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: long
 - type: marking
   id: HumanHairLong2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: long2
 - type: marking
   id: HumanHairLong3
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: long3
 - type: marking
   id: HumanHairLongWithBundles
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longbundled
 - type: marking
   id: HumanHairLongovereye
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longovereye
 - type: marking
   id: HumanHairLbangs
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: lbangs
 - type: marking
   id: HumanHairLongemo
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longemo
 - type: marking
   id: HumanHairLongfringe
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longfringe
 - type: marking
   id: HumanHairLongsidepart
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longsidepart
 - type: marking
   id: HumanHairMegaeyebrows
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: megaeyebrows
 - type: marking
   id: HumanHairMessy
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: messy
 - type: marking
   id: HumanHairModern
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: modern
 - type: marking
   id: HumanHairMohawk
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: d
 - type: marking
   id: HumanHairNitori
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: nitori
 - type: marking
   id: HumanHairReversemohawk
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: reversemohawk
 - type: marking
   id: HumanHairUnshavenMohawk
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: unshaven_mohawk
 - type: marking
   id: HumanHairMulder
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: mulder
 - type: marking
   id: HumanHairOdango
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: odango
 - type: marking
   id: HumanHairOmbre
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ombre
 - type: marking
   id: HumanHairOneshoulder
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: oneshoulder
 - type: marking
   id: HumanHairShortovereye
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shortovereye
 - type: marking
   id: HumanHairOxton
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: oxton
 - type: marking
   id: HumanHairParted
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: parted
 - type: marking
   id: HumanHairPart
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: part
 - type: marking
   id: HumanHairKagami
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: kagami
 - type: marking
   id: HumanHairPigtails
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: pigtails
 - type: marking
   id: HumanHairPigtails2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: pigtails2
 - type: marking
   id: HumanHairPixie
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: pixie
 - type: marking
   id: HumanHairPompadour
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: pompadour
 - type: marking
   id: HumanHairBigpompadour
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: bigpompadour
 - type: marking
   id: HumanHairPonytail
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail
 - type: marking
   id: HumanHairPonytail2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail2
 - type: marking
   id: HumanHairPonytail3
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail3
 - type: marking
   id: HumanHairPonytail4
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail4
 - type: marking
   id: HumanHairPonytail5
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail5
 - type: marking
   id: HumanHairPonytail6
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail6
 - type: marking
   id: HumanHairPonytail7
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ponytail7
 - type: marking
   id: HumanHairHighponytail
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: highponytail
 - type: marking
   id: HumanHairStail
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: stail
 - type: marking
   id: HumanHairLongstraightponytail
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longstraightponytail
 - type: marking
   id: HumanHairCountry
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: country
 - type: marking
   id: HumanHairFringetail
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: fringetail
 - type: marking
   id: HumanHairSidetail
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: sidetail
 - type: marking
   id: HumanHairSidetail2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: sidetail2
 - type: marking
   id: HumanHairSidetail3
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: sidetail3
 - type: marking
   id: HumanHairSidetail4
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: sidetail4
 - type: marking
   id: HumanHairSpikyponytail
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: spikyponytail
 - type: marking
   id: HumanHairPoofy
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: poofy
 - type: marking
   id: HumanHairQuiff
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: quiff
 - type: marking
   id: HumanHairRonin
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: ronin
 - type: marking
   id: HumanHairShaved
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shaved
 - type: marking
   id: HumanHairShavedpart
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shavedpart
 - type: marking
   id: HumanHairShortbangs
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shortbangs
 - type: marking
   id: HumanHairA
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: a
 - type: marking
   id: HumanHairShorthair2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shorthair2
 - type: marking
   id: HumanHairShorthair3
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shorthair3
 - type: marking
   id: HumanHairD
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: d
 - type: marking
   id: HumanHairE
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: e
 - type: marking
   id: HumanHairF
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: f
 - type: marking
   id: HumanHairShorthairg
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shorthairg
 - type: marking
   id: HumanHair80s
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: 80s
 - type: marking
   id: HumanHairRosa
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: rosa
 - type: marking
   id: HumanHairB
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: b
 - type: marking
   id: HumanHairSidecut
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: sidecut
 - type: marking
   id: HumanHairSkinhead
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: skinhead
 - type: marking
   id: HumanHairProtagonist
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: protagonist
 - type: marking
   id: HumanHairSpikey
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: spikey
 - type: marking
   id: HumanHairSpiky
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: spiky
 - type: marking
   id: HumanHairSpiky2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: spiky2
 - type: marking
   id: HumanHairSpookyLong
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: spookylong
 - type: marking
   id: HumanHairSwept
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: swept
 - type: marking
   id: HumanHairSwept2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: swept2
 - type: marking
   id: HumanHairBAlt
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: b_alt
 - type: marking
   id: HumanHairThinning
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: thinning
 - type: marking
   id: HumanHairThinningfront
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: thinningfront
 - type: marking
   id: HumanHairThinningrear
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: thinningrear
 - type: marking
   id: HumanHairTopknot
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: topknot
 - type: marking
   id: HumanHairTressshoulder
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: tressshoulder
 - type: marking
   id: HumanHairTrimmed
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: trimmed
 - type: marking
   id: HumanHairTrimflat
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: trimflat
 - type: marking
   id: HumanHairTwintail
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: twintail
 - type: marking
   id: HumanHairTwoStrands
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: twostrands
 - type: marking
   id: HumanHairUndercut
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: undercut
 - type: marking
   id: HumanHairUndercutleft
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: undercutleft
 - type: marking
   id: HumanHairUndercutright
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: undercutright
 - type: marking
   id: HumanHairUnkept
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: unkept
 - type: marking
   id: HumanHairUpdo
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: updo
 - type: marking
   id: HumanHairVlong
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: vlong
 - type: marking
   id: HumanHairLongest
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longest
 - type: marking
   id: HumanHairLongest2
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longest2
 - type: marking
   id: HumanHairVeryshortovereyealternate
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: veryshortovereyealternate
 - type: marking
   id: HumanHairVlongfringe
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: vlongfringe
 - type: marking
   id: HumanHairVolaju
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: volaju
 - type: marking
   id: HumanHairWisp
   bodyPart: Hair
-  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk] # CD: add Foxfolks, Reptilians, and Moths
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] # CD: add Foxfolks, Reptilians, Moths, and Rodentia
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: wisp
 - type: marking
   id: HumanHairUneven
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: uneven
 - type: marking
   id: HumanHairTailed
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: tailed
 - type: marking
   id: HumanHairClassicLong2
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classiclong2
 - type: marking
   id: HumanHairClassicLong3
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: classiclong3
 - type: marking
   id: HumanHairShaped
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: shaped
 - type: marking
   id: HumanHairLongBow
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
     - sprite: Mobs/Customization/human_hair.rsi
       state: longbow
 - type: marking
   id: HumanHairLongWithBangs
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
   - sprite: Mobs/Customization/human_hair.rsi
     state: longwithbangs
 - type: marking
   id: HumanHairOverEyePigtail
   bodyPart: Hair
+  groupWhitelist: [Human, Dwarf, Slime, Reptilian, Moth, Foxfolk, Rodentia] #CD: groupwhitelist
   sprites:
   - sprite: Mobs/Customization/human_hair.rsi
     state: overeyepigtail


### PR DESCRIPTION
## About the PR
Fixes Rodentia not having access to hair markings.

Also fixes some of the newer hairstyles not being accessible by lizards, moths, foxfolk, etc. _(There's got to be a better way to do this.)_

## Media
<img width="1516" height="721" alt="image" src="https://github.com/user-attachments/assets/729b6879-a7aa-4fd7-960a-15cdb65f511e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
Rodentia now have access to hair markings again(?), and several of the newer human hair markings are now available to Reptiles, Moths, Foxfolk, and Rodentia as well of course.