### PR TITLE
Remove Shuttle Call Ion Law

### DIFF
--- a/Resources/Locale/en-US/station-events/events/ion-storm.ftl
+++ b/Resources/Locale/en-US/station-events/events/ion-storm.ftl
@@ -17,7 +17,7 @@ ion-storm-x-and-y = {$x} AND {$y}
 # subjects can generally be threats or jobs or objects
 # thing is specified above it
 ion-storm-law-on-station = THERE ARE {ION-NUMBER-BASE($ion)} {ION-NUMBER-MOD($ion)} {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)} ON THE STATION
-ion-storm-law-call-shuttle = THE SHUTTLE MUST BE CALLED BECAUSE OF {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)} ON THE STATION
+# ion-storm-law-call-shuttle = THE SHUTTLE MUST BE CALLED BECAUSE OF {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)} ON THE STATION #CD: Disable
 ion-storm-law-crew-are = THE {ION-WHO($ion)} ARE NOW {ION-NUMBER-BASE($ion)} {ION-NUMBER-MOD($ion)} {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)}
 
 ion-storm-law-subjects-harmful = {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)} ARE HARMFUL TO THE CREW
@@ -99,3 +99,6 @@ ion-law-error-dataset-empty-or-not-found = THE FILE YOU ARE LOOKING FOR COULD NO
 ion-law-error-fallback-dataset-empty-or-not-found = SYSTEM RESTORE POINT FAILED
 ion-law-error-no-selector-selected = THE SELECTED RESOURCE WAS MOVED OR DELETED
 ion-law-error-no-bool-value = THIS SENTENCE IS FALSE
+
+#CD additions:
+ion-storm-law-dangerous-space = LEAVING THE STATION IS DANGEROUS BECAUSE OF {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)} IN NEARBY SPACE

--- a/Resources/Locale/en-US/station-events/events/ion-storm.ftl
+++ b/Resources/Locale/en-US/station-events/events/ion-storm.ftl
@@ -100,5 +100,5 @@ ion-law-error-fallback-dataset-empty-or-not-found = SYSTEM RESTORE POINT FAILED
 ion-law-error-no-selector-selected = THE SELECTED RESOURCE WAS MOVED OR DELETED
 ion-law-error-no-bool-value = THIS SENTENCE IS FALSE
 
-#CD additions:
+# CD additions:
 ion-storm-law-dangerous-space = LEAVING THE STATION IS DANGEROUS BECAUSE OF {ION-ADJECTIVE($ion)} {ION-SUBJECT($ion)} IN NEARBY SPACE

--- a/Resources/Prototypes/IonLaws/IonLaw.yml
+++ b/Resources/Prototypes/IonLaws/IonLaw.yml
@@ -5,11 +5,12 @@
     food: 0.5
     RandomManifestFill: 0.15
 
-- type: ionLaw
-  id: CallShuttle
-  lawString: ion-storm-law-call-shuttle
-  selectorWeightAdjust:
-    RandomManifestFill: 0.15
+#CD: Disable
+# - type: ionLaw
+#   id: CallShuttle
+#   lawString: ion-storm-law-call-shuttle
+#   selectorWeightAdjust:
+#     RandomManifestFill: 0.15
 
 - type: ionLaw
   id: CrewAre

--- a/Resources/Prototypes/_CD/IonLaws/IonLaw.yml
+++ b/Resources/Prototypes/_CD/IonLaws/IonLaw.yml
@@ -1,0 +1,5 @@
+﻿- type: ionLaw
+  id: DangerousSpace
+  lawString: ion-storm-law-dangerous-space
+  selectorWeightAdjust:
+    RandomManifestFill: 0.15


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

<!-- PRs may be closed by maintainers if we think they are not a good fit for Cosmatic Drift. If you are unsure if a feature
is a good fit please ask a @Maintainer on discord before starting work -->

## About the PR
Removes the, "THE SHUTTLE MUST BE CALLED BECAUSE OF [X] ON THE STATION" ion storm law, because it wasn't very interesting. It forces a confrontation with the AI or else the round literally ends. 90% of the time the confrontation isn't even interesting since the AI is unlikely to have a law that allows it to defend itself- and if it did, the round ending because of this would be lame.

Replaces it with a, "LEAVING THE STATION IS DANGEROUS BECAUSE OF [X] IN NEARBY SPACE" ion storm law, because I didn't want to just simply remove something and not add a replacement. This just came to mind and doesn't have much thought behind it other than it maybe being interesting while not being overly problematic. (Unless the AI blocks people from evacing. That would be a problem- a fixable one, admittedly.)

## Media
<img width="567" height="535" alt="image" src="https://github.com/user-attachments/assets/605c2d65-a367-4337-8e78-8b86fa4cdff7" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Wizard's den Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I understand this PR may be closed if I did not seek prior approval for content additions.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
Ion storms can no longer force silicons to call evac, instead they may result in the silicon considering leaving the station a dangerous activity.